### PR TITLE
Improve Webpack config to minimise build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "redux-mock-store": "^1.3.0",
     "standard": "^11.0.1",
     "style-loader": "^0.20.3",
+    "thread-loader": "^1.1.5",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "webpack": "^4.3.0",
     "webpack-bundle-analyzer": "^2.11.1",

--- a/packages/blockchain-wallet-v4-frontend/webpack.config.js
+++ b/packages/blockchain-wallet-v4-frontend/webpack.config.js
@@ -71,11 +71,15 @@ module.exports = {
     rules: [
       (isProdBuild ? {
         test: /\.js$/,
-        use: ['babel-loader']
+        use: [
+          'thread-loader',
+          'babel-loader'
+        ]
       } : {
         test: /\.js$/,
         include: /src|blockchain-info-components.src|blockchain-wallet-v4.src/,
         use: [
+          'thread-loader',
           {
             loader: 'babel-loader',
             options: {
@@ -142,7 +146,9 @@ module.exports = {
           nameCache: null,
           toplevel: false,
           ie8: false
-        }
+        },
+        parallel: true,
+        cache: true
       })
     ],
     concatenateModules: isProdBuild,


### PR DESCRIPTION
Improve Webpack performance, result on my machine (depends on the # of cores)

Command "`npm run build:prod`"

Results:
3m18.341s
3m21.134s
3m16.703s

# thread-loader
2m34.049s
2m28.473s
2m23.440s

~= 25% faster


# parallel uglify
2m49.154s
3m1.668s
2m55.644s

~= 12% faster


# thread-loader + parallel-uglify
1m53.143s
1m50.950s
1m50.899s

__~= 44% faster__


### Notes
- The thread-loader improvement should also impact positively the dev build.
- I did not benchmark the "cache" property on uglify, the impact can be __HUGE__,
however it depends on how many files were changed since the last compilation.


### References
- https://github.com/webpack-contrib/thread-loader
- https://github.com/webpack-contrib/uglifyjs-webpack-plugin
