### PR TITLE
make sure options is not undefined

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/data/coinify/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/data/coinify/sagas.js
@@ -13,7 +13,8 @@ export default ({ api, options }) => {
     const state = yield select()
     const delegate = new ExchangeDelegate(state, api)
     const value = yield select(buySellSelectors.getMetadata)
-    coinify = yield apply(coinifyService, coinifyService.refresh, [value, delegate, options])
+    const walletOptions = state.walletOptionsPath.data
+    coinify = yield apply(coinifyService, coinifyService.refresh, [value, delegate, walletOptions])
     yield apply(coinify, coinify.profile.fetch)
     yield put(A.coinifyFetchProfileSuccess(coinify))
   }
@@ -123,7 +124,8 @@ export default ({ api, options }) => {
     const state = yield select()
     const delegate = new ExchangeDelegate(state, api)
     const value = yield select(buySellSelectors.getMetadata)
-    let coinify = yield apply(coinifyService, coinifyService.refresh, [value, delegate, options])
+    const walletOptions = state.walletOptionsPath.data
+    let coinify = yield apply(coinifyService, coinifyService.refresh, [value, delegate, walletOptions])
     yield apply(coinify, coinify.profile.fetch)
     yield put(A.fetchProfileSuccess(coinify))
     return coinify

--- a/packages/blockchain-wallet-v4/src/redux/data/sfox/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/data/sfox/sagas.js
@@ -14,7 +14,8 @@ export default ({ api, options }) => {
     const state = yield select()
     const delegate = new ExchangeDelegate(state, api)
     const value = yield select(buySellSelectors.getMetadata)
-    sfox = sfoxService.refresh(value, delegate, options)
+    const walletOptions = state.walletOptionsPath.data
+    sfox = sfoxService.refresh(value, delegate, walletOptions)
   }
 
   const init = function * () {


### PR DESCRIPTION
This should fix the issue of options being `undefined` when it gets passed to the partner services.

Because of the sagas refactor, SFOX and Coinify each have a `refresh` and `get` saga. I don't want to go through now and sort that out, but when the Coinify implementation gets merged that'll be cleaned up.

Let me know if you're still seeing issues. 