### PR TITLE
Recover wallet passwords must match

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Recover/FirstStep/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Recover/FirstStep/index.js
@@ -29,10 +29,14 @@ const MnemonicLabel = styled(FormLabel)`
     margin-bottom: 10px;
   }
 `
-const Footer = styled.div`
-  margin-top: 20px;
+const Footer = styled(FormGroup)`
   display: flex;
-  align-items: start;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+`
+const GoBackLink = styled(LinkContainer)`
+  margin-right: 15px;
 `
 
 const FirstStep = (props) => {
@@ -69,17 +73,17 @@ const FirstStep = (props) => {
             <Field name='mnemonic' autoFocus validate={[required, validMnemonic]} component={TextBox} />
           </FormItem>
         </FormGroup>
-        <Button type='submit' nature='primary' fullwidth uppercase disabled={submitting || invalid}>
-          <FormattedMessage id='scenes.recover.firststep.continue' defaultMessage='Continue' />
-        </Button>
+        <Footer>
+          <GoBackLink to='/help'>
+            <Link size='13px' weight={300}>
+              <FormattedMessage id='scenes.recover.firststep.back' defaultMessage='Go Back' />
+            </Link>
+          </GoBackLink>
+          <Button type='submit' nature='primary' uppercase disabled={submitting || invalid}>
+            <FormattedMessage id='scenes.recover.firststep.continue' defaultMessage='Continue' />
+          </Button>
+        </Footer>
       </Form>
-      <Footer>
-        <LinkContainer to='/help'>
-          <Link size='13px' weight={300}>
-            <FormattedMessage id='scenes.recover.firststep.back' defaultMessage='Go Back' />
-          </Link>
-        </LinkContainer>
-      </Footer>
     </Wrapper>
 
   )

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Recover/SecondStep/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Recover/SecondStep/template.js
@@ -5,7 +5,7 @@ import { Field, reduxForm } from 'redux-form'
 
 import { required, validEmail } from 'services/FormHelper'
 import { Button, Link, HeartbeatLoader, Separator, Text } from 'blockchain-info-components'
-import { CheckBox, Form, PasswordBox, TextBox } from 'components/Form'
+import { CheckBox, Form, FormGroup, PasswordBox, TextBox } from 'components/Form'
 import Terms from 'components/Terms'
 
 const Wrapper = styled.div`
@@ -21,8 +21,14 @@ const Header = styled.div`
   justify-content: space-between;
   align-items: center;
 `
-const Footer = styled.div`
-  padding: 5px 0;
+const Footer = styled(FormGroup)`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+`
+const GoBackLink = styled(Link)`
+  margin-right: 10px;
 `
 
 const validatePasswordsMatch = values => {
@@ -48,34 +54,41 @@ const SecondStep = (props) => {
       </Text>
       <Separator />
       <Form onSubmit={onSubmit}>
-        <Text size='14px' weight={500}>
-          <FormattedMessage id='scenes.recover.secondstep.email' defaultMessage='Email' />
-        </Text>
-        <Field name='email' validate={[required, validEmail]} component={TextBox} />
-        <Text size='14px' weight={500}>
-          <FormattedMessage id='scenes.recover.secondstep.password' defaultMessage='Password' />
-        </Text>
-        <Field name='password' validate={[required]} component={PasswordBox} score />
-        <Text size='14px' weight={500}>
-          <FormattedMessage id='scenes.recover.secondstep.confirmationPassword' defaultMessage='Confirm Password' />
-        </Text>
-        <Field name='confirmationPassword' validate={[required]} component={PasswordBox} />
-        <Field name='terms' validate={[checkboxShouldBeChecked]} component={CheckBox}>
-          <Terms />
-        </Field>
-        <Button type='submit' nature='primary' fullwidth uppercase disabled={busy || invalid}>
-          {
-            busy
+        <FormGroup>
+          <Text size='14px' weight={500}>
+            <FormattedMessage id='scenes.recover.secondstep.email' defaultMessage='Email' />
+          </Text>
+          <Field name='email' validate={[required, validEmail]} component={TextBox} />
+        </FormGroup>
+        <FormGroup>
+          <Text size='14px' weight={500}>
+            <FormattedMessage id='scenes.recover.secondstep.password' defaultMessage='Password' />
+          </Text>
+          <Field name='password' validate={[required]} component={PasswordBox} score />
+        </FormGroup>
+        <FormGroup>
+          <Text size='14px' weight={500}>
+            <FormattedMessage id='scenes.recover.secondstep.confirmationPassword' defaultMessage='Confirm Password' />
+          </Text>
+          <Field name='confirmationPassword' validate={[required]} component={PasswordBox} />
+        </FormGroup>
+        <FormGroup>
+          <Field name='terms' validate={[checkboxShouldBeChecked]} component={CheckBox}>
+            <Terms />
+          </Field>
+        </FormGroup>
+        <Footer>
+          <GoBackLink onClick={previousStep} size='13px' weight={300}>
+            <FormattedMessage id='scenes.recover.secondstep.back' defaultMessage='Go Back' />
+          </GoBackLink>
+          <Button type='submit' nature='primary' uppercase disabled={busy || invalid}>
+            { busy
               ? <HeartbeatLoader height='20px' width='20px' color='white' />
               : <FormattedMessage id='scenes.recover.secondstep.recover' defaultMessage='Recover Funds' />
-          }
-        </Button>
+            }
+          </Button>
+        </Footer>
       </Form>
-      <Footer>
-        <Link onClick={previousStep} size='13px' weight={300}>
-          <FormattedMessage id='scenes.recover.secondstep.back' defaultMessage='Go Back' />
-        </Link>
-      </Footer>
     </Wrapper>
   )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Recover/SecondStep/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Recover/SecondStep/template.js
@@ -25,6 +25,10 @@ const Footer = styled.div`
   padding: 5px 0;
 `
 
+const validatePasswordsMatch = values => {
+  return values.password === values.confirmationPassword ? {} : { confirmationPassword: 'Passwords must match' }
+}
+
 const SecondStep = (props) => {
   const { busy, onSubmit, previousStep, invalid } = props
   const checkboxShouldBeChecked = value => value ? undefined : 'You must agree with the terms and conditions'
@@ -76,4 +80,8 @@ const SecondStep = (props) => {
   )
 }
 
-export default reduxForm({ form: 'recover', destroyOnUnmount: false })(SecondStep)
+export default reduxForm({
+  form: 'recover',
+  destroyOnUnmount: false,
+  validate: validatePasswordsMatch
+})(SecondStep)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Recover/SecondStep/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Recover/SecondStep/template.js
@@ -28,7 +28,7 @@ const Footer = styled(FormGroup)`
   align-items: center;
 `
 const GoBackLink = styled(Link)`
-  margin-right: 10px;
+  margin-right: 15px;
 `
 
 const validatePasswordsMatch = values => {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Reminder/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Reminder/template.js
@@ -17,9 +17,13 @@ const Wrapper = styled.div`
   @media(min-width: 768px) { width: 550px; }
 `
 const Footer = styled.div`
-  margin-top: 20px;
   display: flex;
-  align-items: start;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+`
+const GoBackLink = styled(LinkContainer)`
+  margin-right: 15px;
 `
 
 const Reminder = (props) => {
@@ -51,21 +55,17 @@ const Reminder = (props) => {
             <Field name='code' validate={[required]} component={CaptchaBox} props={{ timestamp: timestamp }} />
           </FormItem>
         </FormGroup>
-        <FormGroup>
-          <FormItem>
-            <Button type='submit' nature='primary' fullwidth uppercase disabled={submitting || invalid} onClick={onSubmit}>
-              <FormattedMessage id='scenes.reminder.continue' defaultMessage='Continue' />
-            </Button>
-          </FormItem>
-        </FormGroup>
+        <Footer>
+          <GoBackLink to='/help'>
+            <Link size='13px' weight={300}>
+              <FormattedMessage id='scenes.reminder.back' defaultMessage='Go Back' />
+            </Link>
+          </GoBackLink>
+          <Button type='submit' nature='primary' uppercase disabled={submitting || invalid} onClick={onSubmit}>
+            <FormattedMessage id='scenes.reminder.continue' defaultMessage='Continue' />
+          </Button>
+        </Footer>
       </Form>
-      <Footer>
-        <LinkContainer to='/help'>
-          <Link size='13px' weight={300}>
-            <FormattedMessage id='scenes.reminder.back' defaultMessage='Go Back' />
-          </Link>
-        </LinkContainer>
-      </Footer>
     </Wrapper>
   )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Reset2FA/FirstStep/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Reset2FA/FirstStep/template.js
@@ -21,10 +21,14 @@ const Header = styled.div`
   justify-content: space-between;
   align-items: center;
 `
-const Footer = styled.div`
-  margin-top: 20px;
+const Footer = styled(FormGroup)`
   display: flex;
-  align-items: start;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+`
+const GoBackLink = styled(LinkContainer)`
+  margin-right: 15px;
 `
 
 const FirstStep = (props) => {
@@ -80,17 +84,17 @@ const FirstStep = (props) => {
             </Text>
           </FormItem>
         </FormGroup>
-        <Button type='submit' nature='primary' fullwidth uppercase disabled={submitting || invalid} >
-          <FormattedMessage id='scenes.reset2fa.firststep.firststepform.continue' defaultMessage='Continue' />
-        </Button>
+        <Footer>
+          <GoBackLink to='/help'>
+            <Link size='13px' weight={300}>
+              <FormattedMessage id='scenes.reset2fa.firststep.back' defaultMessage='Go Back' />
+            </Link>
+          </GoBackLink>
+          <Button type='submit' nature='primary' uppercase disabled={submitting || invalid} >
+            <FormattedMessage id='scenes.reset2fa.firststep.firststepform.continue' defaultMessage='Continue' />
+          </Button>
+        </Footer>
       </Form>
-      <Footer>
-        <LinkContainer to='/help'>
-          <Link size='13px' weight={300}>
-            <FormattedMessage id='scenes.reset2fa.firststep.back' defaultMessage='Go Back' />
-          </Link>
-        </LinkContainer>
-      </Footer>
     </Wrapper>
   )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/store/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/store/index.js
@@ -41,7 +41,9 @@ const configureStore = () => {
     .then(res => res.json())
     .then(options => {
       const apiKey = '1770d5d9-bcea-4d28-ad21-6cbd5be018a8'
-      const socket = new Socket({ options })
+      const btcSocket = new Socket({ options, socketType: 'btcSocket' })
+      const ethSocket = new Socket({ options, socketType: 'ethSocket' })
+      const bchSocket = new Socket({ options, socketType: 'bchSocket' })
       const api = createWalletApi({ options, apiKey })
 
       const store = createStore(
@@ -51,7 +53,9 @@ const configureStore = () => {
             sagaMiddleware,
             routerMiddleware(history),
             coreMiddleware.kvStore({ isAuthenticated, api, kvStorePath }),
-            coreMiddleware.socket.bitcoin(socket, walletPath, isAuthenticated),
+            coreMiddleware.socket.bitcoin(btcSocket, walletPath, isAuthenticated),
+            coreMiddleware.socket.ethereum(ethSocket, walletPath, isAuthenticated),
+            coreMiddleware.socket.bch(bchSocket, walletPath, isAuthenticated),
             coreMiddleware.walletSync({ isAuthenticated, api, walletPath }),
             autoDisconnection()
           ),
@@ -59,7 +63,7 @@ const configureStore = () => {
         )
       )
       persistStore(store, { whitelist: ['session', 'preferences', 'cache'] })
-      sagaMiddleware.run(rootSaga, { api, socket, options })
+      sagaMiddleware.run(rootSaga, { api, btcSocket, ethSocket, bchSocket, options })
 
       return {
         store,

--- a/packages/blockchain-wallet-v4-frontend/src/store/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/store/index.spec.js
@@ -41,7 +41,7 @@ jest.mock('config', () => {
 describe('App Store Config', () => {
   let apiKey = '1770d5d9-bcea-4d28-ad21-6cbd5be018a8'
   let fakeWalletOptions = { domains: { webSocket: 'MOCK_SOCKET', root: 'MOCK_ROOT' } }
-  let createStoreSpy, applyMiddlewareSpy, composeSpy, kvStoreSpy, btcSocketSpy, walletSyncSpy, autoDisconnectSpy
+  let createStoreSpy, applyMiddlewareSpy, composeSpy, kvStoreSpy, btcSocketSpy, walletSyncSpy, autoDisconnectSpy, bchSocketSpy, ethSocketSpy
 
   beforeAll(() => {
     // setup fetch mock
@@ -54,6 +54,8 @@ describe('App Store Config', () => {
     composeSpy = jest.spyOn(Redux, 'compose').mockImplementation(jest.fn())
     kvStoreSpy = jest.spyOn(CoreSrc.coreMiddleware, 'kvStore')
     btcSocketSpy = jest.spyOn(CoreSrc.coreMiddleware.socket, 'bitcoin')
+    bchSocketSpy = jest.spyOn(CoreSrc.coreMiddleware.socket, 'bch')
+    ethSocketSpy = jest.spyOn(CoreSrc.coreMiddleware.socket, 'ethereum')
     walletSyncSpy = jest.spyOn(CoreSrc.coreMiddleware, 'walletSync')
     autoDisconnectSpy = jest.spyOn(Middleware, 'autoDisconnection')
   })
@@ -67,8 +69,10 @@ describe('App Store Config', () => {
     expect(fetch.mock.calls.length).toEqual(1)
     expect(fetch.mock.calls[0][0]).toEqual('/Resources/wallet-options-v4.json')
     // socket registration
-    expect(Socket.mock.calls.length).toEqual(1)
-    expect(Socket.mock.calls[0][0]).toEqual({ options: fakeWalletOptions })
+    expect(Socket.mock.calls.length).toEqual(3)
+    expect(Socket.mock.calls[0][0]).toEqual({ options: fakeWalletOptions, socketType: 'btcSocket' })
+    expect(Socket.mock.calls[1][0]).toEqual({ options: fakeWalletOptions, socketType: 'ethSocket' })
+    expect(Socket.mock.calls[2][0]).toEqual({ options: fakeWalletOptions, socketType: 'bchSocket' })
     // build api
     expect(createWalletApi.mock.calls.length).toBe(1)
     expect(createWalletApi.mock.calls[0][0]).toEqual({
@@ -84,6 +88,10 @@ describe('App Store Config', () => {
     })
     expect(btcSocketSpy).toHaveBeenCalledTimes(1)
     expect(btcSocketSpy).toHaveBeenCalledWith(expect.any(Object), 'MOCK_WALLET_PATH', expect.any(Function))
+    expect(bchSocketSpy).toHaveBeenCalledTimes(1)
+    expect(bchSocketSpy).toHaveBeenCalledWith(expect.any(Object), 'MOCK_WALLET_PATH', expect.any(Function))
+    expect(ethSocketSpy).toHaveBeenCalledTimes(1)
+    expect(ethSocketSpy).toHaveBeenCalledWith(expect.any(Object), 'MOCK_WALLET_PATH', expect.any(Function))
     expect(walletSyncSpy).toHaveBeenCalledTimes(1)
     expect(walletSyncSpy).toHaveBeenCalledWith({
       isAuthenticated: expect.any(Function),


### PR DESCRIPTION
## Description
- Fixes issue where socket saga registration was failing in development branch due to merge issue
- Ensure passwords match on wallet recovery page
- Better stying for wallet recover form
- Better stying for other help form footers

## Change Type
Bug Fix

## Testing Steps
Login page => other  => recover wallet => enter mnemonic phrase => enter mismatching passwords => error

## PR Creator Checklist
- [x] Code compiles correctly
- [x] No lint issues exist (verified via `yarn lint`)
- [x] All unit tests pass (verified via `yarn test`)
- [x] Updated `README.md` and other documentation (if necessary)

## PR Reviewer Checklist
- [ ] Change validated and application spot checked
- [ ] Code styles and best practices met
- [ ] Code is readable and commented when necessary

