### PR TITLE
Clean up React warnings from test runs

### DIFF
--- a/packages/blockchain-info-components/package.json
+++ b/packages/blockchain-info-components/package.json
@@ -27,10 +27,10 @@
       "\\.(pdf|jpg|jpeg|png|gif|eot|otf|svg|ttf|woff|woff2)$": "<rootDir>/src/__mocks__/fileMock.js",
       "\\.(css|scss)$": "<rootDir>/../../node_modules/identity-obj-proxy"
     },
-    "modulePathIgnorePatterns": ["<rootDir>/lib"],
+    "modulePathIgnorePatterns": ["./lib"],
     "setupFiles": ["<rootDir>/../../config/jest/jest.shim.js", "<rootDir>/../../config/jest/jest.config.js"],
     "snapshotSerializers": ["<rootDir>/../../node_modules/enzyme-to-json/serializer"],
-    "testPathIgnorePatterns": ["<rootDir>/lib"],
+    "testPathIgnorePatterns": ["./lib"],
     "transform": {
       "^.+\\.jsx$": "<rootDir>/../../node_modules/babel-jest",
       "^.+\\.js$": "<rootDir>/../../node_modules/babel-jest"

--- a/packages/blockchain-info-components/src/Dropdowns/SimpleDropdown/index.js
+++ b/packages/blockchain-info-components/src/Dropdowns/SimpleDropdown/index.js
@@ -52,7 +52,7 @@ SimpleDropdown.defaultProps = {
 }
 
 SimpleDropdown.propTypes = {
-  selectedValue: PropTypes.number,
+  selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   items: PropTypes.arrayOf(PropTypes.shape({
     text: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired

--- a/packages/blockchain-info-components/src/Form/SelectInput/SelectInput.spec.js
+++ b/packages/blockchain-info-components/src/Form/SelectInput/SelectInput.spec.js
@@ -9,7 +9,7 @@ describe('SelectInput component', () => {
     const items = [
       { text: 'test', value: 'value' }
     ]
-    const component = shallow(<SelectInput items={items} display='inherit' />)
+    const component = shallow(<SelectInput selected={{text: 'hello', value: 1}} items={items} display='inherit' />)
     const tree = toJson(component)
     expect(tree).toMatchSnapshot()
   })

--- a/packages/blockchain-info-components/src/Form/SelectInput/__snapshots__/SelectInput.spec.js.snap
+++ b/packages/blockchain-info-components/src/Form/SelectInput/__snapshots__/SelectInput.spec.js.snap
@@ -3,7 +3,9 @@
 exports[`SelectInput component default renders correctly 1`] = `
 <styled.div>
   <styled.button>
-    <styled.div />
+    <styled.div>
+      hello
+    </styled.div>
   </styled.button>
   <Styled(Icon)
     name="down-arrow"

--- a/packages/blockchain-info-components/src/Tooltip/Tooltip.spec.js
+++ b/packages/blockchain-info-components/src/Tooltip/Tooltip.spec.js
@@ -5,7 +5,7 @@ import 'jest-styled-components'
 
 describe('Tooltip component', () => {
   it('renders correctly', () => {
-    const component = renderer.create(<Tooltip colors={{'backgroundColor': '#12345'}}><span>Default</span></Tooltip>)
+    const component = renderer.create(<Tooltip colors={'primary'}><span>Default</span></Tooltip>)
     const tree = component.toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/NumberBox/__snapshots__/index.spec.js.snap
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/NumberBox/__snapshots__/index.spec.js.snap
@@ -1,3 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NumberBox renders correctly 1`] = `<NumberBox__Container />`;
+exports[`NumberBox renders correctly 1`] = `
+<NumberBox__Container>
+  <mockConstructor
+    errorState="initial"
+  />
+</NumberBox__Container>
+`;

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/NumberBox/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/NumberBox/index.spec.js
@@ -2,7 +2,13 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 import NumberBox from './index.js'
-jest.mock('blockchain-info-components', () => ({ Text: 'text' }))
+
+jest.mock('blockchain-info-components', () => {
+  return {
+    Text: jest.fn(),
+    NumberInput: jest.fn()
+  }
+})
 
 describe('NumberBox', () => {
   it('renders correctly', () => {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/PasswordBox/__snapshots__/index.spec.js.snap
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/PasswordBox/__snapshots__/index.spec.js.snap
@@ -2,6 +2,9 @@
 
 exports[`PasswordBox renders correctly 1`] = `
 <PasswordBox__Container>
+  <mockConstructor
+    errorState="initial"
+  />
   <div />
 </PasswordBox__Container>
 `;

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/PasswordBox/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/PasswordBox/index.spec.js
@@ -2,7 +2,13 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 import PasswordBox from './index.js'
-jest.mock('blockchain-info-components', () => ({ Text: 'text' }))
+
+jest.mock('blockchain-info-components', () => {
+  return {
+    Text: jest.fn(),
+    PasswordInput: jest.fn()
+  }
+})
 
 describe('PasswordBox', () => {
   it('renders correctly', () => {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/PhoneNumberBox/__snapshots__/index.spec.js.snap
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/PhoneNumberBox/__snapshots__/index.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`PhoneNumberBox renders correctly 1`] = `
 <PhoneNumberBox__Container>
-  <[object Object]
+  <mockConstructor
     css={
       Array [
         "intl-tel-input",

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/PhoneNumberBox/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/PhoneNumberBox/index.spec.js
@@ -3,10 +3,10 @@ import PhoneNumberBox from './index.js'
 import { shallow } from 'enzyme'
 import 'jest-styled-components'
 import toJson from 'enzyme-to-json'
-jest.mock('blockchain-info-components', () => ({ Text: 'text' }))
-jest.mock('react-intl-tel-input/dist/main.css', () => ({}))
-jest.mock('react-intl-tel-input/dist/libphonenumber.js', () => ({}))
-jest.mock('react-intl-tel-input', () => ({}))
+
+jest.mock('react-intl-tel-input/dist/main.css', () => jest.fn())
+jest.mock('react-intl-tel-input/dist/libphonenumber.js', () => jest.fn())
+jest.mock('react-intl-tel-input', () => jest.fn())
 
 describe('PhoneNumberBox', () => {
   it('renders correctly', () => {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/RadioButton/__snapshots__/index.spec.js.snap
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/RadioButton/__snapshots__/index.spec.js.snap
@@ -2,6 +2,15 @@
 
 exports[`RadioButton renders correctly 1`] = `
 <RadioButton__Wrapper>
-  <RadioButton__Container />
+  <RadioButton__Container>
+    <mockConstructor
+      errorState="initial"
+      props={
+        Object {
+          "id": undefined,
+        }
+      }
+    />
+  </RadioButton__Container>
 </RadioButton__Wrapper>
 `;

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/RadioButton/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/RadioButton/index.spec.js
@@ -2,7 +2,13 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 import RadioButton from './index.js'
-jest.mock('blockchain-info-components', () => ({ Text: 'text' }))
+
+jest.mock('blockchain-info-components', () => {
+  return {
+    Text: jest.fn(),
+    RadioButtonInput: jest.fn()
+  }
+})
 
 describe('RadioButton', () => {
   it('renders correctly', () => {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBox/__snapshots__/index.spec.js.snap
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBox/__snapshots__/index.spec.js.snap
@@ -11,7 +11,23 @@ exports[`SelectBox renders correctly 1`] = `
   className="c0"
 >
   <select-input
+    elements={
+      Array [
+        Object {
+          "group": "fakeG",
+          "items": Array [
+            1,
+            2,
+            3,
+          ],
+        },
+      ]
+    }
     errorState="initial"
+    onBlur={[MockFunction]}
+    onChange={[MockFunction]}
+    onFocus={[MockFunction]}
+    value=""
   />
 </div>
 `;

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBox/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBox/index.spec.js
@@ -12,7 +12,7 @@ const fakeInput = {
 }
 
 const fakeElements = [{
-  group: 'fakeG', items:[1,2,3]
+  group: 'fakeG', items: [1, 2, 3]
 }]
 
 describe('SelectBox', () => {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBox/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBox/index.spec.js
@@ -4,10 +4,21 @@ import 'jest-styled-components'
 import SelectBox from './index.js'
 jest.mock('blockchain-info-components', () => ({ SelectInput: 'select-input' }))
 
+const fakeInput = {
+  onBlur: jest.fn(),
+  onChange: jest.fn(),
+  onFocus: jest.fn(),
+  value: ''
+}
+
+const fakeElements = [{
+  group: 'fakeG', items:[1,2,3]
+}]
+
 describe('SelectBox', () => {
   it('renders correctly', () => {
     const props = { meta: {} }
-    const component = renderer.create(<SelectBox {...props} />)
+    const component = renderer.create(<SelectBox {...props} input={fakeInput} elements={fakeElements}/>)
     const tree = component.toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/packages/blockchain-wallet-v4-frontend/src/components/TransactionListItem/Confirmations/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/TransactionListItem/Confirmations/index.js
@@ -23,7 +23,7 @@ const IconWrapper = styled.div`
   display: flex;
   justify-items: center;
   margin-left: 4px;
-  & > :last-child { display; inline; }
+  & > :last-child { display: inline; }
 `
 
 const explorers = {
@@ -46,8 +46,9 @@ const Confirmations = (props) => {
       )}
       <IconWrapper>
         {
-          props.confirmations < props.minConfirmations && <TransactionTooltip>
-            <Tooltip>
+          props.confirmations < props.minConfirmations &&
+          <TransactionTooltip>
+            <Tooltip colors={'red'}>
               <FormattedMessage id='scenes.transactions.content.list.listitem.transaction_unconfirmed' defaultMessage='Your transaction will be complete after it has {minConfirmations} confirmations.' values={{minConfirmations: props.minConfirmations}} />
               <Link href='https://support.blockchain.com/hc/en-us/articles/217116406-Why-hasn-t-my-transaction-confirmed-yet-' target='_blank' size='12px' weight={300} altFont>Learn more.</Link>
             </Tooltip>

--- a/packages/blockchain-wallet-v4-frontend/src/components/TransactionListItem/__snapshots__/index.spec.js.snap
+++ b/packages/blockchain-wallet-v4-frontend/src/components/TransactionListItem/__snapshots__/index.spec.js.snap
@@ -70,11 +70,13 @@ exports[`ListItemContainer renders correctly 1`] = `
       }
     }
   >
-    <template
+    <Component
       handleCoinToggle={[Function]}
       handleEditDescription={[Function]}
       minConfirmations={3}
-    />
+    >
+      <div />
+    </Component>
   </ListItemContainer>
 </Connect(ListItemContainer)>
 `;

--- a/packages/blockchain-wallet-v4-frontend/src/components/TransactionListItem/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/TransactionListItem/index.spec.js
@@ -3,9 +3,10 @@ import { shallow, mount } from 'enzyme'
 import toJson from 'enzyme-to-json'
 import ListItemContainer from './index'
 import configureStore from 'redux-mock-store'
-jest.mock('./template', () => 'template')
-const store = configureStore([])({})
 
+jest.mock('./template', () => () => { return (<div/>) })
+
+const store = configureStore([])({})
 const tx = { hash: '123abc' }
 
 describe('ListItemContainer', () => {

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Addresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Addresses/index.js
@@ -13,7 +13,6 @@ const Wrapper = styled.div`
 
 const AddressesLayout = props => {
   const { location, children } = props
-  debugger
 
   return (
     <Wrapper location={location}>

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Addresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Addresses/index.js
@@ -13,6 +13,7 @@ const Wrapper = styled.div`
 
 const AddressesLayout = props => {
   const { location, children } = props
+  debugger
 
   return (
     <Wrapper location={location}>


### PR DESCRIPTION
## Description
There were about 15 annoying warnings that were being logged when running the unit tests.  I cleaned up test code and added proper mocks to fix all of them.

## Change Type
Cleanup

## Testing Steps
Run unit tests and observe no more red warning messages

## PR Creator Checklist
- [x] Code compiles correctly
- [x] No lint issues exist (verified via `yarn lint`)
- [x] All unit tests pass (verified via `yarn test`)
- [x] Updated `README.md` and other documentation (if necessary)

## PR Reviewer Checklist
- [ ] Change validated and application spot checked
- [ ] Code styles and best practices met
- [ ] Code is readable and commented when necessary

