### PR TITLE
fix(KV): create ss entry with USAState null for android parsing

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/kvStore/shapeShift/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/shapeShift/sagas.js
@@ -32,7 +32,7 @@ export default ({ api }) => {
   const createShapeshift = function * (kv) {
     const newShapeshiftEntry = {
       trades: [],
-      USAState: ''
+      USAState: null
     }
     const newkv = set(KVStoreEntry.value, newShapeshiftEntry, kv)
     yield put(A.createMetadataShapeshift(newkv))


### PR DESCRIPTION
## Description
Android could not correctly parse an empty ss metadata entry. This changes the initial entry for USAState to null instead of empty string

## Change Type
Please enter one or more of the following: 
- Feature
- Bug Fix
- CI/CD
- Upgrades
- Other (add explanation)

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## PR Creator Checklist
- [x] Code compiles correctly
- [x] No lint issues exist (verified via `yarn lint`)
- [x] All unit tests pass (verified via `yarn test`)
- [x] Updated `README.md` and other documentation (if necessary)

## PR Reviewer Checklist
- [ ] Change validated and application spot checked
- [ ] Code styles and best practices met
- [ ] Code is readable and commented when necessary

