### PR TITLE
Feature/active inactive addresses

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/index.js
@@ -12,7 +12,7 @@ class Balance extends React.PureComponent {
   render () {
     const { data } = this.props
     return data.cata({
-      Success: (value) => <Success bitcoinContext={value.bitcoinContext} etherContext={value.etherContext} bchContext={value.bchContext} path={value.path} />,
+      Success: (value) => <Success btcContext={value.btcContext} ethContext={value.ethContext} bchContext={value.bchContext} path={value.path} />,
       Failure: (message) => <Error>{message}</Error>,
       Loading: () => <Loading />,
       NotAsked: () => <Loading />

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/selectors.js
@@ -3,10 +3,10 @@ import { selectors } from 'data'
 import { join, lift } from 'ramda'
 
 export const getData = (state) => {
-  const bitcoinContext = Remote.of(join('|', selectors.core.wallet.getWalletContext(state)))
-  const etherContext = selectors.core.kvStore.ethereum.getContext(state)
+  const ethContext = selectors.core.kvStore.ethereum.getContext(state)
+  const btcContext = Remote.of(join('|', selectors.core.wallet.getWalletContext(state)))
   const bchContext = Remote.of(join('|', selectors.core.wallet.getWalletContext(state)))
   const path = state.router.location.pathname
-  const transform = lift((bitcoinContext, etherContext, bchContext) => ({bitcoinContext, etherContext, bchContext, path}))
-  return transform(bitcoinContext, etherContext, bchContext)
+  const transform = lift((btcContext, ethContext, bchContext) => ({btcContext, ethContext, bchContext, path}))
+  return transform(btcContext, ethContext, bchContext)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/selectors.js
@@ -4,10 +4,10 @@ import { join, lift } from 'ramda'
 
 export const getData = (state) => {
   const btcContext = selectors.core.wallet.getWalletContext(state)
-  const ethContext = selectors.core.kvStore.ethereum.getContext(state)
-  const bchContext = Remote.of(selectors.core.kvStore.bch.getContext(state, btcContext))
+  const ethContextR = selectors.core.kvStore.ethereum.getContext(state)
+  const bchContextR = Remote.of(selectors.core.kvStore.bch.getContext(state, btcContext))
   const btcContextR = Remote.of(join('|', btcContext))
   const path = state.router.location.pathname
-  const transform = lift((btcContextR, ethContext, bchContext) => ({btcContext, ethContext, bchContext, path}))
-  return transform(btcContextR, ethContext, bchContext)
+  const transform = lift((btcContext, ethContext, bchContext) => ({btcContext, ethContext, bchContext, path}))
+  return transform(btcContextR, ethContextR, bchContextR)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/selectors.js
@@ -3,10 +3,11 @@ import { selectors } from 'data'
 import { join, lift } from 'ramda'
 
 export const getData = (state) => {
+  const btcContext = selectors.core.wallet.getWalletContext(state)
   const ethContext = selectors.core.kvStore.ethereum.getContext(state)
-  const btcContext = Remote.of(join('|', selectors.core.wallet.getWalletContext(state)))
-  const bchContext = Remote.of(join('|', selectors.core.wallet.getWalletContext(state)))
+  const bchContext = Remote.of(selectors.core.kvStore.bch.getContext(state, btcContext))
+  const btcContextR = Remote.of(join('|', btcContext))
   const path = state.router.location.pathname
-  const transform = lift((btcContext, ethContext, bchContext) => ({btcContext, ethContext, bchContext, path}))
-  return transform(btcContext, ethContext, bchContext)
+  const transform = lift((btcContextR, ethContext, bchContext) => ({btcContext, ethContext, bchContext, path}))
+  return transform(btcContextR, ethContext, bchContext)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/template.success.js
@@ -59,14 +59,14 @@ const BalanceDropdown = styled.div`
 `
 
 const Success = props => {
-  const { bitcoinContext, etherContext, bchContext, path } = props
+  const { btcContext, ethContext, bchContext, path } = props
 
   const getComponentOrder = () => {
     switch (path) {
-      case '/btc/transactions': return [<BitcoinBalance large context={bitcoinContext} />, <EtherBalance context={etherContext} />, <BchBalance context={bchContext} />, <TotalBalance />]
-      case '/eth/transactions': return [<EtherBalance large context={etherContext} />, <BitcoinBalance context={bitcoinContext} />, <BchBalance context={bchContext} />, <TotalBalance />]
-      case '/bch/transactions': return [<BchBalance large context={bchContext} />, <BitcoinBalance context={bitcoinContext} />, <EtherBalance context={etherContext} />, <TotalBalance />]
-      default: return [<TotalBalance large />, <BitcoinBalance context={bitcoinContext} />, <EtherBalance context={etherContext} />, <BchBalance context={bchContext} />]
+      case '/btc/transactions': return [<BitcoinBalance large context={btcContext} />, <EtherBalance context={ethContext} />, <BchBalance context={bchContext} />, <TotalBalance />]
+      case '/eth/transactions': return [<EtherBalance large context={ethContext} />, <BitcoinBalance context={btcContext} />, <BchBalance context={bchContext} />, <TotalBalance />]
+      case '/bch/transactions': return [<BchBalance large context={bchContext} />, <BitcoinBalance context={btcContext} />, <EtherBalance context={ethContext} />, <TotalBalance />]
+      default: return [<TotalBalance large />, <BitcoinBalance context={btcContext} />, <EtherBalance context={ethContext} />, <BchBalance context={bchContext} />]
     }
   }
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/Wallets/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/Wallets/template.success.js
@@ -53,7 +53,7 @@ const Success = (props) => {
           {isArchived && <Banner label type='informational'><FormattedMessage id='scenes.settings.bch.addresses.archived_label' defaultMessage='Archived' /></Banner>}
         </WalletTableCell>
         <TableCell width='30%'>
-          <SwitchableDisplay size='13px' coin='BCH'>{wallet.value.balance}</SwitchableDisplay>
+          {!isArchived && <SwitchableDisplay size='13px' coin='BCH'>{wallet.value.balance}</SwitchableDisplay>}
         </TableCell>
         <TableCell width='20%' style={{ display: 'flex', justifyContent: 'flex-end' }}>
           <ComponentDropdown

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/Wallets/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/Wallets/template.success.js
@@ -12,9 +12,6 @@ const Wrapper = styled.section`
 const BchWalletsAddressesSettingHeader = SettingHeader.extend`
   justify-content: flex-start;
 `
-const AddressesSettingDescription = SettingDescription.extend`
-  margin-bottom: 10px;
-`
 const WalletTableCell = styled(TableCell)`
   align-items: center;
   min-height: 23px;
@@ -83,9 +80,9 @@ const Success = (props) => {
       <BchWalletsAddressesSettingHeader>
         <FormattedMessage id='scenes.settings.addresses.bch_wallets' defaultMessage='Bitcoin Cash Wallets' />
       </BchWalletsAddressesSettingHeader>
-      <AddressesSettingDescription>
+      <SettingDescription>
         <FormattedMessage id='scenes.settings.addresses.bch_wallets_description' defaultMessage='Wallets allow you to organize your funds into categories, like spending or savings. To see all of the individual addresses that have been generated for each wallet, click on ‘Manage‘.' />
-      </AddressesSettingDescription>
+      </SettingDescription>
       <Table>
         <TableHeader>
           <TableCell width='50%'>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/AddressRow.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/AddressRow.js
@@ -18,7 +18,7 @@ const MoreOptions = () => (
   </Link>
 )
 
-const AddressRow = ({ address, coin, renderOptions }) => {
+const AddressRow = ({ address, archived, coin, renderOptions }) => {
   return (
     <TableRow>
       <AddressTableCell width='50%' style={{ display: 'flex' }}>
@@ -28,7 +28,7 @@ const AddressRow = ({ address, coin, renderOptions }) => {
         )}
       </AddressTableCell>
       <TableCell width='30%'>
-        <SwitchableDisplay size='13px' coin={coin || 'BTC'}>{address.info && address.info.final_balance}</SwitchableDisplay>
+        {!archived && <SwitchableDisplay size='13px' coin={coin || 'BTC'}>{address.info && address.info.final_balance}</SwitchableDisplay>}
       </TableCell>
       <TableCell width='20%' style={{ display: 'flex', justifyContent: 'flex-end' }}>
         { renderOptions && <ComponentDropdown down forceSelected color={'gray-5'} selectedComponent={<MoreOptions />} components={renderOptions()} /> }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ArchivedAddresses/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ArchivedAddresses/template.success.js
@@ -19,7 +19,7 @@ const ArchivedAddressesContainer = SettingHeader.extend`
 const Success = ({ archivedAddresses, onToggleArchived, onDelete, search }) => {
   const isMatch = (address) => !search || address.addr.toLowerCase().indexOf(search) > -1
   const archivedAddressesTableRows = filter(isMatch, archivedAddresses).map((address) => (
-    <AddressRow key={address.addr} address={address} renderOptions={() => [
+    <AddressRow key={address.addr} archived address={address} renderOptions={() => [
       <OptionItem id='scenes.settings.addresses.unarchive' defaultMessage='Unarchive' onClick={() => onToggleArchived(address)} />,
       <OptionItem id='scenes.settings.addresses.delete_address' defaultMessage='Delete' onClick={() => onDelete(address)} />
     ]} />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/template.success.js
@@ -27,12 +27,12 @@ const Success = ({ wallets, handleClick, onUnarchive, search }) => {
   const walletTableRows = filter(isMatch, wallets).map((wallet) => {
     return (
       <TableRow key={wallet.index}>
-        <WalletTableCell width='40%' style={{ display: 'flex' }}>
+        <WalletTableCell width='50%' style={{ display: 'flex' }}>
           <LabelCell size='13px'>{wallet.label}</LabelCell>
           {wallet.default && <Banner label><FormattedMessage id='scenes.settings.addresses.default_label' defaultMessage='Default' /></Banner>}
           {wallet.archived && <Banner label type='informational'><FormattedMessage id='scenes.settings.addresses.archived_label' defaultMessage='Archived' /></Banner>}
         </WalletTableCell>
-        <TableCell width='40%'>
+        <TableCell width='30%'>
           {!wallet.archived && <SwitchableDisplay size='13px' coin='BTC'>{wallet.balance}</SwitchableDisplay>}
         </TableCell>
         <TableCell width='20%' style={{ display: 'flex', justifyContent: 'flex-end' }}>
@@ -62,12 +62,12 @@ const Success = ({ wallets, handleClick, onUnarchive, search }) => {
       </SettingDescription>
       <Table>
         <TableHeader>
-          <TableCell width='40%'>
+          <TableCell width='50%'>
             <Text size='13px' weight={500}>
               <FormattedMessage id='scenes.settings.addresses.wallet_name' defaultMessage='Wallet Name' />
             </Text>
           </TableCell>
-          <TableCell width='40%'>
+          <TableCell width='30%'>
             <Text size='13px' weight={500}>
               <FormattedMessage id='scenes.settings.addresses.wallet_description' defaultMessage='Balance' />
             </Text>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/template.success.js
@@ -33,7 +33,7 @@ const Success = ({ wallets, handleClick, onUnarchive, search }) => {
           {wallet.archived && <Banner label type='informational'><FormattedMessage id='scenes.settings.addresses.archived_label' defaultMessage='Archived' /></Banner>}
         </WalletTableCell>
         <TableCell width='40%'>
-          <SwitchableDisplay size='13px' coin='BTC'>{wallet.balance}</SwitchableDisplay>
+          {!wallet.archived && <SwitchableDisplay size='13px' coin='BTC'>{wallet.balance}</SwitchableDisplay>}
         </TableCell>
         <TableCell width='20%' style={{ display: 'flex', justifyContent: 'flex-end' }}>
           {wallet.archived ? (

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/bch/sagaRegister.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/bch/sagaRegister.js
@@ -8,5 +8,6 @@ export default ({ api }) => {
 
   return function * () {
     yield takeLatest(AT.FETCH_METADATA_BCH, kvStoreBchSagas.fetchMetadataBch)
+    yield takeLatest(AT.SET_BCH_ACCOUNT_ARCHIVED, kvStoreBchSagas.setBchAccountArchived)
   }
 }

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/bch/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/bch/sagas.js
@@ -2,6 +2,7 @@ import { call, put, select } from 'redux-saga/effects'
 import { compose, concat, gt, isNil, length, map, path, prop, range } from 'ramda'
 import { set } from 'ramda-lens'
 import * as A from './actions'
+import * as refreshActions from '../../refresh/actions'
 import { KVStoreEntry } from '../../../types'
 import { getMetadataXpriv } from '../root/selectors'
 import { getHDAccounts } from '../../wallet/selectors'
@@ -47,7 +48,12 @@ export default ({ api }) => {
     }
   }
 
+  const setBchAccountArchived = function * () {
+    yield put(refreshActions.refresh())
+  }
+
   return {
-    fetchMetadataBch
+    fetchMetadataBch,
+    setBchAccountArchived
   }
 }

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/bch/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/bch/sagas.js
@@ -2,11 +2,12 @@ import { call, put, select } from 'redux-saga/effects'
 import { compose, concat, gt, isNil, length, map, path, prop, range } from 'ramda'
 import { set } from 'ramda-lens'
 import * as A from './actions'
-import * as refreshActions from '../../refresh/actions'
+import * as S from './selectors'
+import * as bchActions from '../../data/bch/actions'
 import { KVStoreEntry } from '../../../types'
-import { getMetadataXpriv } from '../root/selectors'
-import { getHDAccounts } from '../../wallet/selectors'
 import { derivationMap, BCH } from '../config'
+import { getMetadataXpriv } from '../root/selectors'
+import { getHDAccounts, getWalletContext } from '../../wallet/selectors'
 
 const taskToPromise = t => new Promise((resolve, reject) => t.fork(reject, resolve))
 
@@ -49,7 +50,9 @@ export default ({ api }) => {
   }
 
   const setBchAccountArchived = function * () {
-    yield put(refreshActions.refresh())
+    const btcContext = yield select(getWalletContext)
+    const bchContext = yield select(S.getContext, btcContext)
+    yield put(bchActions.fetchData(bchContext))
   }
 
   return {

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/bch/selectors.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/bch/selectors.js
@@ -1,4 +1,4 @@
-import { curry, keys, lift, map, path } from 'ramda'
+import { curry, keys, filter, lift, map, path } from 'ramda'
 import { BCH } from '../config'
 import { kvStorePath } from '../../paths'
 
@@ -11,6 +11,12 @@ export const getAccounts = state => getMetadata(state).map(path(['value', 'accou
 export const getAccountsList = state => {
   const accountsObj = getAccounts(state)
   return lift(a => map(key => a[key], keys(a)))(accountsObj)
+}
+
+export const getContext = (state, btcContext) => {
+  const accountsObj = getAccounts(state)
+  const xpubs = filter(x => x.includes('xpub'), btcContext)
+  return xpubs.filter((xpub, i) => !accountsObj.data[i].archived)
 }
 
 export const getDefaultAccountId = state => getMetadata(state).map(path(['value', 'default_account_idx']))

--- a/packages/blockchain-wallet-v4/src/redux/refresh/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/refresh/sagas.js
@@ -3,14 +3,16 @@ import * as btcActions from '../data/bitcoin/actions'
 import * as bchActions from '../data/bch/actions'
 import * as ethActions from '../data/ethereum/actions'
 import * as S from '../wallet/selectors'
+import * as bchSelectors from '../kvStore/bch/selectors'
 import * as ethSelectors from '../kvStore/ethereum/selectors'
 
 export default () => {
   const refresh = function * () {
-    const walletContext = yield select(S.getWalletContext)
-    yield put(btcActions.fetchData(walletContext))
-    yield put(bchActions.fetchData(walletContext))
+    const btcContext = yield select(S.getWalletContext)
+    const bchContext = yield select(bchSelectors.getContext, btcContext)
     const ethContext = yield select(ethSelectors.getContext)
+    yield put(btcActions.fetchData(btcContext))
+    yield put(bchActions.fetchData(bchContext))
     yield put(ethActions.fetchData(ethContext.data))
     yield put(btcActions.fetchRates())
     yield put(bchActions.fetchRates())

--- a/packages/blockchain-wallet-v4/src/redux/rootSaga.js
+++ b/packages/blockchain-wallet-v4/src/redux/rootSaga.js
@@ -4,6 +4,7 @@ import kvStore from './kvStore/sagaRegister'
 import walletOptions from './walletOptions/sagaRegister'
 import settings from './settings/sagaRegister'
 import refresh from './refresh/sagaRegister'
+import wallet from './wallet/sagaRegister'
 
 export default ({ api, options }) => function * () {
   yield all([
@@ -11,6 +12,7 @@ export default ({ api, options }) => function * () {
     fork(kvStore({ api })),
     fork(walletOptions({ api, options })),
     fork(settings({ api })),
+    fork(wallet({ api })),
     fork(refresh())
   ])
 }

--- a/packages/blockchain-wallet-v4/src/redux/wallet/sagaRegister.js
+++ b/packages/blockchain-wallet-v4/src/redux/wallet/sagaRegister.js
@@ -1,0 +1,13 @@
+
+import { takeLatest } from 'redux-saga/effects'
+import * as AT from './actionTypes'
+import sagas from './sagas'
+
+export default ({ api }) => {
+  const walletSagas = sagas({ api })
+
+  return function * () {
+    yield takeLatest(AT.SET_ADDRESS_ARCHIVED, walletSagas.refetchContextData)
+    yield takeLatest(AT.SET_ACCOUNT_ARCHIVED, walletSagas.refetchContextData)
+  }
+}

--- a/packages/blockchain-wallet-v4/src/types/HDAccountList.js
+++ b/packages/blockchain-wallet-v4/src/types/HDAccountList.js
@@ -17,7 +17,7 @@ export const selectAccount = curry((index, as) => pipe(HDAccountList.guard, view
 export const selectByXpub = curry((xpub, as) => pipe(HDAccountList.guard, xs => xs.find(HDAccount.isXpub(xpub)))(as))
 
 export const selectContext = pipe(HDAccountList.guard, (accList) => {
-  return map(HDAccount.selectXpub, accList)
+  return map(HDAccount.selectXpub, filter(HDAccount.isActive, accList))
 })
 
 export const selectActive = pipe(HDAccountList.guard, filter(HDAccount.isActive))


### PR DESCRIPTION
## Description
711. Refetch context when accounts are archived/unarchived. BTC context filters out archived accounts, BCH context filters out archived accounts (based on metadata)

## Change Type
Please enter one or more of the following: 
- Bug Fix
- Upgrades

## Testing Steps
Toggle btc/bch archived/unarchived states

## PR Creator Checklist
- [ ] Code compiles correctly
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] All unit tests pass (verified via `yarn test`)
- [ ] Updated `README.md` and other documentation (if necessary)

## PR Reviewer Checklist
- [ ] Change validated and application spot checked
- [ ] Code styles and best practices met
- [ ] Code is readable and commented when necessary

