### PR TITLE
add onSubmit to password stretching form

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/index.js
@@ -13,7 +13,7 @@ import Settings from './template.js'
 class SettingsContainer extends React.PureComponent {
   constructor (props) {
     super(props)
-    this.handleSubmit = this.handleSubmit.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
   }
 
@@ -29,7 +29,7 @@ class SettingsContainer extends React.PureComponent {
     }
   }
 
-  handleSubmit () {
+  onSubmit () {
     this.props.settingsActions.updateIpLock(this.props.IPWhitelist)
     this.handleToggle()
   }
@@ -42,9 +42,9 @@ class SettingsContainer extends React.PureComponent {
     const { ui, ...rest } = this.props
     return <Settings
       {...rest}
+      onSubmit={this.onSubmit}
       updateToggled={ui.updateToggled}
       handleToggle={this.handleToggle}
-      handleSubmit={this.handleSubmit}
       handleCancel={() => { this.props.formActions.reset('settingIPWhitelist'); this.handleToggle() }}
     />
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/index.js
@@ -13,7 +13,7 @@ import Settings from './template.js'
 class SettingsContainer extends React.PureComponent {
   constructor (props) {
     super(props)
-    this.handleClick = this.handleClick.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
   }
 
@@ -29,7 +29,7 @@ class SettingsContainer extends React.PureComponent {
     }
   }
 
-  handleClick () {
+  handleSubmit () {
     this.props.settingsActions.updateIpLock(this.props.IPWhitelist)
     this.handleToggle()
   }
@@ -44,7 +44,7 @@ class SettingsContainer extends React.PureComponent {
       {...rest}
       updateToggled={ui.updateToggled}
       handleToggle={this.handleToggle}
-      handleClick={this.handleClick}
+      handleSubmit={this.handleSubmit}
       handleCancel={() => { this.props.formActions.reset('settingIPWhitelist'); this.handleToggle() }}
     />
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/template.js
@@ -30,7 +30,7 @@ const Settings = (props) => {
         </Button>
       }
       { updateToggled &&
-        <SettingForm>
+        <SettingForm onSubmit={handleClick}>
           <Input name='IPWhitelist' validate={[validIpList]} component={TextBox} />
           <ButtonWrapper>
             <Button nature='empty' capitalize onClick={handleCancel}>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/template.js
@@ -19,7 +19,7 @@ const Input = styled(Field)`
   margin-top: 20px;
 `
 const Settings = (props) => {
-  const { updateToggled, handleToggle, handleClick, currentWhitelist, submitting, invalid, handleCancel } = props
+  const { updateToggled, handleToggle, handleSubmit, currentWhitelist, submitting, invalid, handleCancel } = props
 
   return (
     <SettingWrapper>
@@ -30,13 +30,13 @@ const Settings = (props) => {
         </Button>
       }
       { updateToggled &&
-        <SettingForm onSubmit={handleClick}>
+        <SettingForm onSubmit={handleSubmit}>
           <Input name='IPWhitelist' validate={[validIpList]} component={TextBox} />
           <ButtonWrapper>
             <Button nature='empty' capitalize onClick={handleCancel}>
               <FormattedMessage id='scenes.securitysettings.advancedsettings.ipwhitelist.settings.cancel' defaultMessage='Cancel' />
             </Button>
-            <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleClick}>
+            <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleSubmit}>
               <FormattedMessage id='scenes.securitysettings.advancedsettings.ipwhitelist.settings.save' defaultMessage='Save' />
             </Button>
           </ButtonWrapper>
@@ -50,7 +50,7 @@ Settings.propTypes = {
   currentWhitelist: PropTypes.string.isRequired,
   updateToggled: PropTypes.bool.isRequired,
   handleToggle: PropTypes.func.isRequired,
-  handleClick: PropTypes.func.isRequired
+  handleSubmit: PropTypes.func.isRequired
 }
 
 export default reduxForm({ form: 'settingIPWhitelist' })(Settings)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordHint/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordHint/Settings/index.js
@@ -12,11 +12,11 @@ import Settings from './template.js'
 class SettingsContainer extends React.PureComponent {
   constructor (props) {
     super(props)
-    this.handleClick = this.handleClick.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
   }
 
-  handleClick () {
+  handleSubmit () {
     this.props.settingsActions.updateHint(this.props.passwordHintValue)
     this.handleToggle()
   }
@@ -31,7 +31,7 @@ class SettingsContainer extends React.PureComponent {
     return <Settings {...rest}
       updateToggled={ui.updateToggled}
       handleToggle={this.handleToggle}
-      handleClick={this.handleClick}
+      handleSubmit={this.handleSubmit}
       handleCancel={() => { this.props.formActions.reset('settingPasswordHint'); this.handleToggle() }}
     />
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordHint/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordHint/Settings/index.js
@@ -12,11 +12,11 @@ import Settings from './template.js'
 class SettingsContainer extends React.PureComponent {
   constructor (props) {
     super(props)
-    this.handleSubmit = this.handleSubmit.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
   }
 
-  handleSubmit () {
+  onSubmit () {
     this.props.settingsActions.updateHint(this.props.passwordHintValue)
     this.handleToggle()
   }
@@ -29,9 +29,9 @@ class SettingsContainer extends React.PureComponent {
     const { ui, ...rest } = this.props
 
     return <Settings {...rest}
+      onSubmit={this.onSubmit}
       updateToggled={ui.updateToggled}
       handleToggle={this.handleToggle}
-      handleSubmit={this.handleSubmit}
       handleCancel={() => { this.props.formActions.reset('settingPasswordHint'); this.handleToggle() }}
     />
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordHint/Settings/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordHint/Settings/template.js
@@ -27,7 +27,7 @@ const Settings = (props) => {
         </Button>
       }
       { updateToggled &&
-        <SettingForm>
+        <SettingForm onSubmit={handleClick}>
           <Field name='passwordHint' component={TextBox} />
           <ButtonWrapper>
             <Button nature='empty' capitalize onClick={handleCancel}>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordHint/Settings/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordHint/Settings/template.js
@@ -17,7 +17,7 @@ const ButtonWrapper = styled(ButtonGroup)`
 `
 
 const Settings = (props) => {
-  const { updateToggled, handleToggle, handleClick, submitting, invalid, handleCancel } = props
+  const { updateToggled, handleToggle, handleSubmit, submitting, invalid, handleCancel } = props
   return (
     <SettingWrapper>
       <Hint />
@@ -27,13 +27,13 @@ const Settings = (props) => {
         </Button>
       }
       { updateToggled &&
-        <SettingForm onSubmit={handleClick}>
+        <SettingForm onSubmit={handleSubmit}>
           <Field name='passwordHint' component={TextBox} />
           <ButtonWrapper>
             <Button nature='empty' capitalize onClick={handleCancel}>
               <FormattedMessage id='scenes.securitysettings.basicsecurity.passwordhint.settings.cancel' defaultMessage='Cancel' />
             </Button>
-            <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleClick}>
+            <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleSubmit}>
               <FormattedMessage id='scenes.securitysettings.basicsecurity.passwordhint.settings.save' defaultMessage='Change' />
             </Button>
           </ButtonWrapper>
@@ -46,7 +46,7 @@ const Settings = (props) => {
 Settings.propTypes = {
   updateToggled: PropTypes.bool.isRequired,
   handleToggle: PropTypes.func.isRequired,
-  handleClick: PropTypes.func.isRequired
+  handleSubmit: PropTypes.func.isRequired
 }
 
 export default reduxForm({ form: 'settingPasswordHint' })(Settings)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordStretching/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordStretching/Settings/index.js
@@ -11,11 +11,11 @@ import Settings from './template.js'
 class SettingsContainer extends React.PureComponent {
   constructor (props) {
     super(props)
-    this.handleSubmit = this.handleSubmit.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
   }
 
-  handleSubmit () {
+  onSubmit () {
     const { passwordStretchingValue } = this.props
     this.props.walletActions.updatePbkdf2Iterations(Number(passwordStretchingValue))
     this.handleToggle()
@@ -30,9 +30,9 @@ class SettingsContainer extends React.PureComponent {
 
     return <Settings
       {...rest}
+      onSubmit={this.onSubmit}
       updateToggled={ui.updateToggled}
       handleToggle={this.handleToggle}
-      handleSubmit={this.handleSubmit}
     />
   }
 }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordStretching/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordStretching/Settings/index.js
@@ -11,11 +11,11 @@ import Settings from './template.js'
 class SettingsContainer extends React.PureComponent {
   constructor (props) {
     super(props)
-    this.handleClick = this.handleClick.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
   }
 
-  handleClick () {
+  handleSubmit () {
     const { passwordStretchingValue } = this.props
     this.props.walletActions.updatePbkdf2Iterations(Number(passwordStretchingValue))
     this.handleToggle()
@@ -32,7 +32,7 @@ class SettingsContainer extends React.PureComponent {
       {...rest}
       updateToggled={ui.updateToggled}
       handleToggle={this.handleToggle}
-      handleClick={this.handleClick}
+      handleSubmit={this.handleSubmit}
     />
   }
 }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordStretching/Settings/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordStretching/Settings/template.js
@@ -29,7 +29,7 @@ const Settings = (props) => {
         </Button>
       }
       { updateToggled &&
-        <SettingForm>
+        <SettingForm onSubmit={handleClick}>
           <Field name='passwordStretching' component={NumberBox} validate={validPasswordStretchingNumber} />
           <ButtonWrapper>
             <Button nature='empty' capitalize onClick={handleToggle}>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordStretching/Settings/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/PasswordStretching/Settings/template.js
@@ -17,7 +17,7 @@ const ButtonWrapper = styled(ButtonGroup)`
 `
 
 const Settings = (props) => {
-  const { updateToggled, handleToggle, handleClick, submitting, invalid, currentStretch } = props
+  const { updateToggled, handleToggle, handleSubmit, submitting, invalid, currentStretch } = props
   return (
     <SettingWrapper>
       { currentStretch &&
@@ -29,13 +29,13 @@ const Settings = (props) => {
         </Button>
       }
       { updateToggled &&
-        <SettingForm onSubmit={handleClick}>
+        <SettingForm onSubmit={handleSubmit}>
           <Field name='passwordStretching' component={NumberBox} validate={validPasswordStretchingNumber} />
           <ButtonWrapper>
             <Button nature='empty' capitalize onClick={handleToggle}>
               <FormattedMessage id='scenes.securitysettings.advancedsettings.passwordstretching.settings.cancel' defaultMessage='Cancel' />
             </Button>
-            <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleClick}>
+            <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleSubmit}>
               <FormattedMessage id='scenes.securitysettings.advancedsettings.passwordstretching.settings.save' defaultMessage='Change' />
             </Button>
           </ButtonWrapper>
@@ -48,7 +48,7 @@ const Settings = (props) => {
 Settings.propTypes = {
   updateToggled: PropTypes.bool.isRequired,
   handleToggle: PropTypes.func.isRequired,
-  handleClick: PropTypes.func.isRequired
+  handleSubmit: PropTypes.func.isRequired
 }
 
 export default reduxForm({ form: 'settingPasswordStretching' })(Settings)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/SecondPasswordWallet/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/SecondPasswordWallet/Settings/index.js
@@ -11,11 +11,11 @@ import Settings from './template.js'
 class SettingsContainer extends React.PureComponent {
   constructor (props) {
     super(props)
-    this.handleClick = this.handleClick.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
   }
 
-  handleClick (e) {
+  handleSubmit (e) {
     e.preventDefault()
     const { secondPasswordValue } = this.props
     this.props.walletActions.toggleSecondPassword(secondPasswordValue)
@@ -33,7 +33,7 @@ class SettingsContainer extends React.PureComponent {
       {...rest}
       updateToggled={ui.updateToggled}
       handleToggle={this.handleToggle}
-      handleClick={this.handleClick}
+      handleSubmit={this.handleSubmit}
       handleCancel={() => { this.props.formActions.reset('settingSecondPassword'); this.handleToggle() }}
     />
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/SecondPasswordWallet/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/SecondPasswordWallet/Settings/index.js
@@ -11,11 +11,11 @@ import Settings from './template.js'
 class SettingsContainer extends React.PureComponent {
   constructor (props) {
     super(props)
-    this.handleSubmit = this.handleSubmit.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
     this.handleToggle = this.handleToggle.bind(this)
   }
 
-  handleSubmit (e) {
+  onSubmit (e) {
     e.preventDefault()
     const { secondPasswordValue } = this.props
     this.props.walletActions.toggleSecondPassword(secondPasswordValue)
@@ -31,9 +31,9 @@ class SettingsContainer extends React.PureComponent {
 
     return <Settings
       {...rest}
+      onSubmit={this.onSubmit}
       updateToggled={ui.updateToggled}
       handleToggle={this.handleToggle}
-      handleSubmit={this.handleSubmit}
       handleCancel={() => { this.props.formActions.reset('settingSecondPassword'); this.handleToggle() }}
     />
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/SecondPasswordWallet/Settings/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/SecondPasswordWallet/Settings/template.js
@@ -19,7 +19,7 @@ const ButtonWrapper = styled(ButtonGroup)`
 `
 
 const Settings = (props) => {
-  const { updateToggled, handleToggle, handleClick, mainPassword, submitting, invalid, secondPasswordEnabled, handleCancel } = props
+  const { updateToggled, handleToggle, handleSubmit, mainPassword, submitting, invalid, secondPasswordEnabled, handleCancel } = props
   const isMainPassword = (props) => mainPassword !== props ? null : "You can't use your main password as your second password."
   if (secondPasswordEnabled) {
     return (
@@ -30,7 +30,7 @@ const Settings = (props) => {
           </Button>
         }
         { updateToggled &&
-          <SettingForm onSubmit={handleClick}>
+          <SettingForm onSubmit={handleSubmit}>
             <Text size='14px' weight={300}>
               <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.label' defaultMessage='Second Password' />
             </Text>
@@ -39,8 +39,8 @@ const Settings = (props) => {
               <Button nature='empty' capitalize onClick={handleCancel}>
                 <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.cancel' defaultMessage='Cancel' />
               </Button>
-              <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleClick}>
-                <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.remove' defaultMessage='Remove Second password' />
+              <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleSubmit}>
+                <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.remove' defaultMessage='Remove Second Password' />
               </Button>
             </ButtonWrapper>
           </SettingForm>
@@ -86,7 +86,7 @@ const Settings = (props) => {
               <Button nature='empty' capitalize onClick={handleCancel}>
                 <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.cancel2' defaultMessage='Cancel' />
               </Button>
-              <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleClick}>
+              <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleSubmit}>
                 <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.save2' defaultMessage='Save' />
               </Button>
             </ButtonWrapper>
@@ -100,7 +100,7 @@ const Settings = (props) => {
 Settings.propTypes = {
   updateToggled: PropTypes.bool.isRequired,
   handleToggle: PropTypes.func.isRequired,
-  handleClick: PropTypes.func.isRequired
+  handleSubmit: PropTypes.func.isRequired
 }
 
 export default reduxForm({ form: 'settingSecondPassword' })(Settings)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/SecondPasswordWallet/Settings/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/SecondPasswordWallet/Settings/template.js
@@ -26,11 +26,11 @@ const Settings = (props) => {
       <SettingWrapper>
         { !updateToggled &&
           <Button nature='primary' onClick={handleToggle}>
-            <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.remove' defaultMessage='Remove Second Password'/>
+            <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.remove' defaultMessage='Remove Second Password' />
           </Button>
         }
         { updateToggled &&
-          <SettingForm>
+          <SettingForm onSubmit={handleClick}>
             <Text size='14px' weight={300}>
               <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.label' defaultMessage='Second Password' />
             </Text>
@@ -40,7 +40,7 @@ const Settings = (props) => {
                 <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.cancel' defaultMessage='Cancel' />
               </Button>
               <Button nature='primary' capitalize disabled={submitting || invalid} onClick={handleClick}>
-                <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.save' defaultMessage='Save' />
+                <FormattedMessage id='scenes.securitysettings.basicsecurity.secondpasswordwallet.settings.remove' defaultMessage='Remove Second password' />
               </Button>
             </ButtonWrapper>
           </SettingForm>


### PR DESCRIPTION
## Description
onSubmit is required and prevents from crashing when we hit enter on the form

## Change Type
Please enter one or more of the following: 
- Bug Fix

## PR Creator Checklist
- [x] Code compiles correctly
- [x] No lint issues exist (verified via `yarn lint`)
- [x] All unit tests pass (verified via `yarn test`)


