### PR TITLE
fiat conversion

### DIFF
--- a/packages/blockchain-wallet-v4/src/exchange/convertFiatToBitcoin.spec.js
+++ b/packages/blockchain-wallet-v4/src/exchange/convertFiatToBitcoin.spec.js
@@ -10,7 +10,7 @@ describe('convertFiatToBitcoin', () => {
       rates: bitcoinRates
     }
     const expectedOutput = {
-      value: '0.00015174',
+      value: '0.00015175',
       unit: { rate: '100000000', symbol: 'BTC', decimal_digits: 8, currency: 'BTC' }
     }
     const result = Conversion.convertFiatToBitcoin(input)
@@ -24,7 +24,7 @@ describe('convertFiatToBitcoin', () => {
       rates: bitcoinRates
     }
     const expectedOutput = {
-      value: '0',
+      value: '0.00000000',
       unit: { rate: '100000000', symbol: 'BTC', decimal_digits: 8, currency: 'BTC' }
     }
     const result = Conversion.convertFiatToBitcoin(input)

--- a/packages/blockchain-wallet-v4/src/exchange/currency/index.js
+++ b/packages/blockchain-wallet-v4/src/exchange/currency/index.js
@@ -13,7 +13,7 @@ export class Currency extends Type {
   toUnit (unit) {
     if (unit && unit.currency === this.currency.code) {
       return Maybe.Just({
-        value: this.value.multiply(BigRational(unit.rate).reciprocate()).toDecimal(unit.decimal_digits),
+        value: Number(this.value.multiply(BigRational(unit.rate).reciprocate())).toFixed(unit.decimal_digits),
         unit: unit
       })
     } else { return Maybe.Nothing() }

--- a/packages/blockchain-wallet-v4/src/exchange/displayFiatToBitcoin.spec.js
+++ b/packages/blockchain-wallet-v4/src/exchange/displayFiatToBitcoin.spec.js
@@ -9,7 +9,7 @@ describe('displayFiatToBitcoin', () => {
       toUnit: 'BTC',
       rates: bitcoinRates
     }
-    const expectedOutput = '0.00015174 BTC'
+    const expectedOutput = '0.00015175 BTC'
     const result = Conversion.displayFiatToBitcoin(input)
     expect(result).toEqual(expectedOutput)
   })
@@ -20,7 +20,7 @@ describe('displayFiatToBitcoin', () => {
       toUnit: 'BTC',
       rates: bitcoinRates
     }
-    const expectedOutput = '0 BTC'
+    const expectedOutput = '0.00000000 BTC'
     const result = Conversion.displayFiatToBitcoin(input)
     expect(result).toEqual(expectedOutput)
   })


### PR DESCRIPTION
## Description
use Number.toFixed instead of BigRational.toDecimal, because toDecimal always rounds it down
819


## Change Type
- Bug Fix


## PR Creator Checklist
- [ ] Code compiles correctly
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] All unit tests pass (verified via `yarn test`)

## PR Reviewer Checklist
- [ ] Change validated and application spot checked
- [ ] Code styles and best practices met
- [ ] Code is readable and commented when necessary

