### PR TITLE
feat(remember guid during login and account creation)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -56,8 +56,6 @@ export default ({ api, coreSagas }) => {
 
   const loginRoutineSaga = function * (mobileLogin, firstLogin) {
     try {
-      // Clear form
-      yield put(actions.form.destroy('login'))
       // If needed, the user should upgrade its wallet before being able to open the wallet
       let isHdWallet = yield select(selectors.core.wallet.isHdWallet)
       if (!isHdWallet) {
@@ -71,9 +69,6 @@ export default ({ api, coreSagas }) => {
       yield call(coreSagas.kvStore.ethereum.fetchMetadataEthereum)
       yield call(coreSagas.kvStore.bch.fetchMetadataBch)
       yield put(actions.router.push('/home'))
-      // reset auth type and clear previous login form state
-      yield put(actions.auth.setAuthType(0))
-      yield put(actions.form.destroy('login'))
       yield put(actions.auth.loginSuccess())
       yield put(actions.auth.startLogoutTimer())
       yield put(actions.goals.runGoals())
@@ -88,6 +83,10 @@ export default ({ api, coreSagas }) => {
       yield put(actions.logs.logErrorMessage(logLocation, 'loginRoutineSaga', e))
       // Redirect to error page instead of notification
       yield put(actions.alerts.displayError(C.WALLET_LOADING_ERROR))
+    } finally {
+      // reset auth type and clear previous login form state
+      yield put(actions.auth.setAuthType(0))
+      yield put(actions.form.destroy('login'))
     }
   }
 

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.spec.js
@@ -22,9 +22,6 @@ describe('authSagas', () => {
     it('should put saveSession', () => {
       expect(gen.next('sessionToken').value).toEqual(put(actions.session.saveSession({'123abc456def': 'sessionToken'})))
     })
-    it('should cache guid', () => {
-      expect(gen.next('123abc456def').value).toEqual(put(actions.cache.guidEntered('123abc456def')))
-    })
     it('should put login loading', () => {
       expect(gen.next().value).toEqual(put(actions.auth.loginLoading()))
     })
@@ -41,7 +38,6 @@ describe('authSagas', () => {
       gen.next()
       gen.next()
       gen.next('sessionToken')
-      gen.next('123abc456def')
       expect(gen.next().value).toEqual(put(actions.auth.loginLoading()))
       expect(gen.throw({ message: 'error' }).value).toEqual(put(actions.auth.loginFailure('error')))
     })


### PR DESCRIPTION
## Description
Stores the current guid in cache for users to be able to easily re-login with.  Also ensure the login form state is not cleared until well into the login saga so user see notice an empty form during login routine.

## Change Type
Feature, Bug Fix

## Testing Steps
Login with existing wallet and login => see the guid is stored.
Create new wallet and logout => see the guid is stored.

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

