### PR TITLE
fix(Login): when 2fa is required after incorrect pw

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -273,7 +273,7 @@ export default ({ api, coreSagas }) => {
       const { guid } = action.payload
       const sessionToken = yield select(selectors.session.getSession, guid)
       const response = yield call(coreSagas.wallet.resendSmsLoginCode, { guid, sessionToken })
-      if (response.initial_error) {
+      if (response.initial_error && !response.initial_error.includes('login attempts left')) {
         throw new Error(response)
       } else {
         yield put(actions.alerts.displaySuccess(C.SMS_RESEND_SUCCESS))

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/index.js
@@ -11,19 +11,13 @@ class LoginContainer extends React.PureComponent {
     super(props)
     this.state = { useCode: true }
     this.onSubmit = this.onSubmit.bind(this)
-    this.handleCode = this.handleCode.bind(this)
     this.handleMobile = this.handleMobile.bind(this)
     this.handleSmsResend = this.handleSmsResend.bind(this)
   }
 
-  handleCode (val) {
-    this.setState({ useCode: val })
-  }
-
   onSubmit () {
-    const { useCode } = this.state
     const { guid, password, code } = this.props
-    let auth = useCode ? code : undefined
+    let auth = code
     // only uppercase if authType is not Yubikey
     if (auth && this.props.authType !== 1) {
       auth = auth.toUpperCase()
@@ -54,7 +48,6 @@ class LoginContainer extends React.PureComponent {
       authType,
       loginError: error,
       onSubmit: this.onSubmit,
-      handleCode: this.handleCode,
       handleMobile: this.handleMobile,
       handleSmsResend: this.handleSmsResend
     }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/template.js
@@ -70,8 +70,6 @@ const Login = (props) => {
   const twoFactorError = loginError && loginError.toLowerCase().includes('authentication code')
   const accountLocked = loginError && (loginError.toLowerCase().includes('this account has been locked') || loginError.toLowerCase().includes('account is locked'))
 
-  const handlePasswordChange = () => { passwordError && props.handleCode(false) }
-
   return (
     <Wrapper>
       <Modals>
@@ -143,7 +141,7 @@ const Login = (props) => {
             <FormLabel for='password'>
               <FormattedMessage id='scenes.login.password' defaultMessage='Password' />
             </FormLabel>
-            <Field name='password' validate={[required]} component={PasswordBox} onChange={handlePasswordChange} borderColor={passwordError ? 'invalid' : undefined} disabled={!isSupportedBrowser} />
+            <Field name='password' validate={[required]} component={PasswordBox} borderColor={passwordError ? 'invalid' : undefined} disabled={!isSupportedBrowser} />
             { passwordError && <FormError position={authType > 0 ? 'relative' : 'absolute'}><FormattedMessage id='scenes.login.wrong_password' defaultMessage='Error decrypting wallet. Wrong password' /></FormError> }
             { accountLocked && <FormError position={authType > 0 || passwordError ? 'relative' : 'absolute'}>{loginError}</FormError> }
           </FormItem>


### PR DESCRIPTION
## Description
1041

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
Create wallet with 2fa, logout, enter password incorrectly, enter 2fa. See that your pw is incorrect, correct password, get new 2fa code, login.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

