### PR TITLE
Fix - added minimal npm version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repo contains the three codebases/packages listed below that are combined i
 
 
 ## Local Development
-1. Ensure Node version >= 8.0 is installed
+1. Ensure Node version >= 8.0 and npm version >= 6 are installed
 2. Run the following command to install necessary global packages: `npm install -g lerna yarn babel-cli rimraf cross-env`
 3. Install, link and hoist packages: `yarn bootstrap`
 4. Start the application in development mode: `yarn start`


### PR DESCRIPTION
## Description
Added npm version dependency to README:
`npm ci` requires npm>=6

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [+] Code compiles successfully (verified via `yarn start`)
- [+] No lint issues exist (verified via `yarn lint`)
- [+] New and existing unit tests pass (verified via `yarn test`)
- [+] `README.md` and other documentation is updated as needed

