### PR TITLE
Qr error message

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
@@ -49,7 +49,7 @@ class QRCodeCaptureContainer extends React.PureComponent {
 
   handleScanBchAddress (data) {
     try {
-      if (utils.bitcoin.isValidBitcoinAddress(data)) {
+      if (utils.bch.isCashAddr(data) || utils.bitcoin.isValidBitcoinAddress(data)) {
         this.props.formActions.change('sendBch', 'to', data)
         this.props.updateUI({ bchAddress: { toggled: false } })
         return
@@ -62,11 +62,6 @@ class QRCodeCaptureContainer extends React.PureComponent {
       this.props.updateUI({ bchAddress: { toggled: false } })
     } catch (e) {
       try {
-        if (utils.bch.isCashAddr(data)) {
-          this.props.formActions.change('sendBch', 'to', data)
-          this.props.updateUI({bchAddress: {toggled: false}})
-          return
-        }
         const {address, options} = bip21.decode(data)
         const {amount, message} = options
         this.props.formActions.change('sendBch', 'to', address)

--- a/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
@@ -88,6 +88,7 @@ class QRCodeCaptureContainer extends React.PureComponent {
   handleScanBtcPriv (data) {
     if (utils.bitcoin.isValidBitcoinPrivateKey(data)) {
       this.props.formActions.change('sendBtc', 'priv', data)
+      this.props.formActions.touch('sendBtc', 'priv')
       this.props.updateUI({ btcPriv: { toggled: false } })
     } else {
       this.props.alertActions.displayError(C.PRIVATE_KEY_INVALID)

--- a/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
@@ -62,6 +62,11 @@ class QRCodeCaptureContainer extends React.PureComponent {
       this.props.updateUI({ bchAddress: { toggled: false } })
     } catch (e) {
       try {
+        if (utils.bch.isCashAddr(data)) {
+          this.props.formActions.change('sendBch', 'to', data)
+          this.props.updateUI({bchAddress: {toggled: false}})
+          return
+        }
         const {address, options} = bip21.decode(data)
         const {amount, message} = options
         this.props.formActions.change('sendBch', 'to', address)

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SendBitcoin/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SendBitcoin/FirstStep/template.success.js
@@ -92,7 +92,7 @@ const FirstStep = props => {
           <Field name='from' component={SelectBoxBitcoinAddresses} validate={[required]} includeAll={false} />
           {watchOnly &&
             <Row>
-              <Field name='priv' placeholder='Please enter your private key...' component={TextBox} validate={[required, validBitcoinPrivateKey, isAddressDerivedFromPriv]} autoFocus />
+              <Field name='priv' placeholder='Pleas enter your private key...' component={TextBox} validate={[required, validBitcoinPrivateKey, isAddressDerivedFromPriv]} autoFocus errorBottom />
               <QRCodeCapture scanType='btcPriv' border={['top', 'bottom']} />
             </Row>
           }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SendBitcoin/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SendBitcoin/FirstStep/template.success.js
@@ -92,7 +92,7 @@ const FirstStep = props => {
           <Field name='from' component={SelectBoxBitcoinAddresses} validate={[required]} includeAll={false} />
           {watchOnly &&
             <Row>
-              <Field name='priv' placeholder='Pleas enter your private key...' component={TextBox} validate={[required, validBitcoinPrivateKey, isAddressDerivedFromPriv]} autoFocus errorBottom />
+              <Field name='priv' placeholder='Please enter your private key...' component={TextBox} validate={[required, validBitcoinPrivateKey, isAddressDerivedFromPriv]} autoFocus errorBottom />
               <QRCodeCapture scanType='btcPriv' border={['top', 'bottom']} />
             </Row>
           }


### PR DESCRIPTION
## Description
Display private key doesn't match on the bottom, and also force validate by calling touch. right now if you enter a valid bitcoin private key  that doesn't match the watch only public key, the error isn't displayed unless you click on the text box, that causes some other problems.

isCashAddr is necessary after all, you were right. but it has to run after ```bip21.decode(data, 'bitcoincash')```

## Change Type
- Bug Fix
- CI/CD


## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

