### PR TITLE
fix(BCH QR): add notes and fix issues around bch scan

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
@@ -48,12 +48,8 @@ class QRCodeCaptureContainer extends React.PureComponent {
   }
 
   handleScanBchAddress (data) {
+    // try bitcoincash:qruaxzyr4wcxyuxg2qnteajhgnq2nsmzccuc6d4r5u
     try {
-      if (utils.bch.isCashAddr(data) || utils.bitcoin.isValidBitcoinAddress(data)) {
-        this.props.formActions.change('sendBch', 'to', data)
-        this.props.updateUI({ bchAddress: { toggled: false } })
-        return
-      }
       const {address, options} = bip21.decode(data, 'bitcoincash')
       const {amount, message} = options
       this.props.formActions.change('sendBch', 'to', address)
@@ -62,12 +58,20 @@ class QRCodeCaptureContainer extends React.PureComponent {
       this.props.updateUI({ bchAddress: { toggled: false } })
     } catch (e) {
       try {
-        const {address, options} = bip21.decode(data)
-        const {amount, message} = options
-        this.props.formActions.change('sendBch', 'to', address)
-        this.props.formActions.change('sendBch', 'amount', amount)
-        this.props.formActions.change('sendBch', 'message', message)
-        this.props.updateUI({ bchAddress: { toggled: false } })
+        // try qruaxzyr4wcxyuxg2qnteajhgnq2nsmzccuc6d4r5u
+        if (utils.bch.isCashAddr(data)) {
+          this.props.formActions.change('sendBch', 'to', data)
+          this.props.updateUI({ bchAddress: { toggled: false } })
+          return
+        }
+        // try legacy addr
+        if (utils.bitcoin.isValidBitcoinAddress(data)) {
+          this.props.formActions.change('sendBch', 'to', data)
+          this.props.updateUI({ bchAddress: { toggled: false } })
+          return
+        }
+        // throw error
+        throw Error('invalid_bch_addr')
       } catch (e) {
         this.props.alertActions.displayError(C.BCH_ADDRESS_INVALID)
         this.props.updateUI({bchAddress: {toggled: false}})


### PR DESCRIPTION
## Description
973

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
1. scan bitcoin address from mobile wallet (will fail because `bitcoin:` prefix)
2. scan bch addr from mobile wallet (will pass)
3. scan bch addr without `bitcoincash:` prefix (will pass)
4. scan btc addr without `bitcoin:` prefix (will pass because it is a legacy addr)

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

