### PR TITLE
Top Balance: hide separator when no watch only balances; other fixes

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Actions/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Actions/template.js
@@ -21,8 +21,9 @@ const Wrapper = styled.div`
   }
 `
 const ActionButton = styled(IconButton)`
-  ${media.mobile`
-    padding: 10px 10px;
+  ${media.tablet`
+    height: 30px;
+    padding: 5px 10px;
     div:last-of-type {
       font-size: 13px;
     }

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BchBalance/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BchBalance/template.success.js
@@ -24,8 +24,8 @@ const Success = props => {
   return (
     <LinkContainer to='/bch/transactions'>
       <Wrapper large={large}>
-        <CoinDisplay coin='BCH' cursor='pointer' size='20px' mobileSize='14px' weight={large ? 200 : 300}>{balance}</CoinDisplay>
-        <FiatDisplay coin='BCH' cursor='pointer' size='20px' mobileSize='14px' weight={large ? 200 : 300}>{balance}</FiatDisplay>
+        <CoinDisplay coin='BCH' cursor='pointer' size={large ? '20px' : '12px'} weight={large ? 200 : 300}>{balance}</CoinDisplay>
+        <FiatDisplay coin='BCH' cursor='pointer' size={large ? '20px' : '12px'} weight={large ? 200 : 300}>{balance}</FiatDisplay>
       </Wrapper>
     </LinkContainer>
   )

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BchWatchOnlyBalance/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BchWatchOnlyBalance/index.js
@@ -18,6 +18,10 @@ class BchWatchOnlyBalance extends React.PureComponent {
     this.props.actions.fetchData()
   }
 
+  componentDidUpdate () {
+    this.props.data.getOrElse() && this.props.hasBchSubBalance()
+  }
+
   handleRefresh () {
     this.props.actions.fetchData()
   }

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BchWatchOnlyBalance/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BchWatchOnlyBalance/template.success.js
@@ -22,7 +22,7 @@ const Wrapper = styled.div`
 `
 
 const Success = props => {
-  return props.balance === 0 ? < div /> : (
+  return props.balance === 0 ? <div /> : (
     <LinkContainer to='/bch/transactions'>
       <Wrapper>
         <Text size='10px' weight={300}>BCH</Text>

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BtcBalance/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BtcBalance/template.success.js
@@ -24,8 +24,8 @@ const Success = props => {
   return (
     <LinkContainer to='/btc/transactions'>
       <Wrapper large={large}>
-        <CoinDisplay coin='BTC' cursor='pointer' size='20px' mobileSize='14px' weight={large ? 200 : 300}>{balance}</CoinDisplay>
-        <FiatDisplay coin='BTC' cursor='pointer' size='20px' mobileSize='14px' weight={large ? 200 : 300}>{balance}</FiatDisplay>
+        <CoinDisplay coin='BTC' cursor='pointer' size={large ? '20px' : '12px'} weight={large ? 200 : 300}>{balance}</CoinDisplay>
+        <FiatDisplay coin='BTC' cursor='pointer' size={large ? '20px' : '12px'} weight={large ? 200 : 300}>{balance}</FiatDisplay>
       </Wrapper>
     </LinkContainer>
   )

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BtcWatchOnlyBalance/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BtcWatchOnlyBalance/index.js
@@ -18,6 +18,10 @@ class BtcWatchOnlyBalance extends React.PureComponent {
     this.props.actions.fetchData()
   }
 
+  componentDidUpdate () {
+    this.props.data.getOrElse() && this.props.hasBtcSubBalance()
+  }
+
   handleRefresh () {
     this.props.actions.fetchData()
   }

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BtcWatchOnlyBalance/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/BtcWatchOnlyBalance/template.success.js
@@ -22,7 +22,7 @@ const Wrapper = styled.div`
 `
 
 const Success = props => {
-  return props.balance === 0 ? < div /> : (
+  return props.balance === 0 ? <div /> : (
     <LinkContainer to='/btc/transactions'>
       <Wrapper>
         <Text size='10px' weight={300}>BTC</Text>

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/EthBalance/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/EthBalance/template.success.js
@@ -24,8 +24,8 @@ const Success = props => {
   return (
     <LinkContainer to='/eth/transactions'>
       <Wrapper large={large}>
-        <CoinDisplay coin='ETH' cursor='pointer' size='20px' mobileSize='14px' weight={large ? 200 : 300}>{balance}</CoinDisplay>
-        <FiatDisplay coin='ETH' cursor='pointer' size='20px' mobileSize='14px' weight={large ? 200 : 300}>{balance}</FiatDisplay>
+        <CoinDisplay coin='ETH' cursor='pointer' size={large ? '20px' : '12px'} weight={large ? 200 : 300}>{balance}</CoinDisplay>
+        <FiatDisplay coin='ETH' cursor='pointer' size={large ? '20px' : '12px'} weight={large ? 200 : 300}>{balance}</FiatDisplay>
       </Wrapper>
     </LinkContainer>
   )

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/index.js
@@ -5,8 +5,16 @@ import { selectors } from 'data'
 import Template from './template'
 
 class Balance extends React.PureComponent {
+  state = { btcSubBalance: false, bchSubBalance: false }
+
   render () {
-    return <Template path={this.props.path} />
+    return <Template
+      path={this.props.path}
+      hasBchSubBalance={() => this.setState({ bchSubBalance: true })}
+      hasBtcSubBalance={() => this.setState({ btcSubBalance: true })}
+      btcSubBalance={this.state.btcSubBalance}
+      bchSubBalance={this.state.bchSubBalance}
+    />
   }
 }
 

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/template.js
@@ -87,13 +87,20 @@ const getBalanceMessage = path => {
   }
 }
 
-const getSubBalances = props => (
-  <SubItems>
-    <Separator margin='0' />
-    <BtcWatchOnlyBalance />
-    <BchWatchOnlyBalance />
-  </SubItems>
-)
+const getSubBalances = (props) => {
+  const { hasBchSubBalance, hasBtcSubBalance, btcSubBalance, bchSubBalance } = props
+  return (
+    <SubItems>
+      {
+        !btcSubBalance && !bchSubBalance
+          ? null
+          : <Separator margin='0' />
+      }
+      <BtcWatchOnlyBalance hasBtcSubBalance={hasBtcSubBalance} />
+      <BchWatchOnlyBalance hasBchSubBalance={hasBchSubBalance} />
+    </SubItems>
+  )
+}
 
 const Success = props => (
   <Wrapper>
@@ -106,7 +113,7 @@ const Success = props => (
         forceSelected
         color={'gray-5'}
         selectedComponent={getComponentOrder(props.path)[0]}
-        components={getComponentOrder(props.path).concat(getSubBalances())}
+        components={getComponentOrder(props.path).concat(getSubBalances(props))}
         callback={() => {}} />
     </BalanceDropdown>
   </Wrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/template.js
@@ -47,7 +47,7 @@ const Top = styled.div`
   display: flex;
   height: 115px;
   width: 100%;
-  ${media.mobile`
+  ${media.laptop`
     height: 150px;
   `}
 `

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/template.success.js
@@ -16,7 +16,7 @@ const Row = styled.div`
   align-items: center;
   flex-direction: row;
   width: 100%;
-  ${media.laptop`
+  ${media.tablet`
     align-items: flex-start;
   `}
 `
@@ -24,14 +24,14 @@ const ColLeft = styled.div`
   width: 50%;
   margin-right: 5%;
   margin-top: -28px;
-  ${media.laptop`
+  ${media.tablet`
     display: none;
   `}
 `
 const ColRight = styled.div`
   width: 40%;
   margin-top: -56px;
-  ${media.laptop`
+  ${media.tablet`
     width: 100%;
     margin-top: 30px;
   `}

--- a/packages/blockchain-wallet-v4-frontend/src/services/ResponsiveService/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/services/ResponsiveService/index.js
@@ -3,7 +3,7 @@ import { css } from 'styled-components'
 const sizes = {
   mobile: 479,
   tablet: 767,
-  laptop: 1023,
+  laptop: 1200,
   laptopL: 1440,
   desktop: 2560
 }


### PR DESCRIPTION
Because of the way these components are organized, there wasn't a straight forward way to do this since you need to have all watch only balance data in the same place to determine showing/hiding the separator. The other option probably means reshuffling components and selectors around, and I'd rather not at this point. Open to suggestions if there's a better way.

## Description
Hide the `separator` component when there's no btc and bch watch only balances.

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

