### PR TITLE
fix(trigger coinify loading after second password prompt)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/coinify/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/coinify/sagas.js
@@ -78,8 +78,8 @@ export default ({ coreSagas }) => {
 
   const sell = function * () {
     try {
-      yield put(A.coinifyLoading())
       const password = yield call(promptForSecondPassword)
+      yield put(A.coinifyLoading())
       const trade = yield call(coreSagas.data.coinify.sell)
 
       if (!trade) {

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/sfox/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/sfox/sagas.js
@@ -150,8 +150,8 @@ export default ({ coreSagas }) => {
   const submitSellQuote = function * (action) {
     const q = action.payload
     try {
-      yield put(A.sfoxLoading())
       const password = yield call(promptForSecondPassword)
+      yield put(A.sfoxLoading())
       const trade = yield call(coreSagas.data.sfox.handleSellTrade, q)
 
       let p = yield select(sendBtcSelectors.getPayment)


### PR DESCRIPTION
## Description
Wait for second password prompt to succeed before placing sell trade.

## Change Type
- Bug Fix


## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

