### PR TITLE
fix - refresh fixed missing BTC/BCH data in request modal

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/RequestBch/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/RequestBch/index.js
@@ -55,6 +55,9 @@ class RequestBchContainer extends React.PureComponent {
   }
 
   handleRefresh () {
+    const { bchDataActions, initialValues } = this.props
+    if (!Remote.Success.is(initialValues)) return bchDataActions.fetchData()
+
     this.init()
   }
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/RequestBitcoin/FirstStep/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/RequestBitcoin/FirstStep/index.js
@@ -60,6 +60,9 @@ class FirstStepContainer extends React.PureComponent {
   }
 
   handleRefresh () {
+    const { bitcoinDataActions, initialValues } = this.props
+    if (!Remote.Success.is(initialValues)) return bitcoinDataActions.fetchData()
+
     this.init()
   }
 


### PR DESCRIPTION
## Description
Refetching data in BTC/BCH request forms if one is missing.

## Change Type
- Bug Fix

## Testing Steps
1. Grab a state from 1108 issue
2. Load it while logged in or twice
3. Open request dialog - get an error ( loading state while logged out yields no error message)
4. Click on refresh
5. Should show a request window

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

