### PR TITLE
fix - refetching all transactions for activity stream while on the home page

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/refresh/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/refresh/sagas.js
@@ -17,6 +17,11 @@ export default () => {
         case '/bch/transactions': yield call(refreshBchTransactions); break
         case '/btc/transactions': yield call(refreshBtcTransactions); break
         case '/eth/transactions': yield call(refreshEthTransactions); break
+        case '/home': {
+          yield put(actions.core.data.bitcoin.fetchTransactions('', true))
+          yield put(actions.core.data.ethereum.fetchTransactions(true))
+          yield put(actions.core.data.bch.fetchTransactions('', true))
+        }
       }
     } catch (e) {
       yield put(actions.logs.logErrorMessage('components/refresh/sagas', 'refresh', 'Refresh failed.'))

--- a/packages/blockchain-wallet-v4/src/network/api/wallet/index.js
+++ b/packages/blockchain-wallet-v4/src/network/api/wallet/index.js
@@ -40,6 +40,7 @@ export default ({ rootUrl, apiUrl, get, post }) => {
     data: merge({ method: 'insert', format: 'plain', email }, data)
   }).then(() => data.checksum)
 
+  // onlyShow is xpub or address to filter data with
   const fetchBlockchainData = (context, { n = 50, offset = 0, onlyShow } = {}) => {
     const data = {
       active: (Array.isArray(context) ? context : [context]).join('|'),


### PR DESCRIPTION
## Description
Home page activity stream is not refreshed without transaction refetch

## Change Type
- Bug Fix

## Testing Steps
1. Make a transaction that won't show up in the activity stream, btc state from 1108 is valid
2. Click refresh while on the main page
3. See activity stream refreshed

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

