### PR TITLE
fix - fixed address derivation for archived wallets

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/walletSync/middleware.js
+++ b/packages/blockchain-wallet-v4/src/redux/walletSync/middleware.js
@@ -1,6 +1,6 @@
 import { futurizeP } from 'futurize'
 import Task from 'data.task'
-import { compose, assoc, join, curry, range, keysIn } from 'ramda'
+import { compose, assoc, join, curry, range, keysIn, isNil } from 'ramda'
 import { networks } from 'bitcoinjs-lib'
 
 import * as A from '../actions'
@@ -37,9 +37,13 @@ export const getHDAccountAddressPromises = curry((state, account) => {
    */
   const asyncDerive = index => toAsync(() =>
     HDAccount.getReceiveAddress(account, index, networks.bitcoin.NETWORK_BITCOIN))
-  return selectors.data.bitcoin.getReceiveIndex(xpub, state)
-    .map((receiveIndex) => range(receiveIndex, receiveIndex + addressLookaheadCount))
-    .getOrElse([])
+
+  const receiveIndex = selectors.data.bitcoin
+    .getReceiveIndex(xpub, state)
+    .getOrElse(null)
+  if (isNil(receiveIndex)) return []
+
+  return range(receiveIndex, receiveIndex + addressLookaheadCount)
     .map(asyncDerive)
 })
 


### PR DESCRIPTION
## Description
Receive index is undefined for archive wallets. So in case of notifications being on sync failed.

## Change Type
- Bug Fix

## Testing Steps
1. Add an archived wallet
2. Turn on any of notifications
3. Add another wallet
4. Sign out
5. Sign in
6. All wallets should remain in place

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

