### PR TITLE
add support for mini key format

### DIFF
--- a/packages/blockchain-wallet-v4/src/utils/bitcoin.js
+++ b/packages/blockchain-wallet-v4/src/utils/bitcoin.js
@@ -71,25 +71,25 @@ export const scriptToAddress = (script, network) => {
 export const detectPrivateKeyFormat = key => {
   let isTestnet = false
   // 51 characters base58, always starts with 5 (or 9, for testnet)
-  var sipaRegex = isTestnet
-    ? (/^[9][123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}$/)
-    : (/^[5][123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}$/)
+  const sipaRegex = isTestnet
+    ? (/^[9][1-9A-HJ-Za-km-z]{50}$/)
+    : (/^[5][1-9A-HJ-Za-km-z]{50}$/)
 
   if (sipaRegex.test(key)) {
     return 'sipa'
   }
 
   // 52 character compressed starts with L or K (or c, for testnet)
-  var compsipaRegex = isTestnet
-    ? (/^[c][123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{51}$/)
-    : (/^[LK][123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{51}$/)
+  const compsipaRegex = isTestnet
+    ? (/^[c][1-9A-HJ-Za-km-z]{51}$/)
+    : (/^[LK][1-9A-HJ-Za-km-z]{51}$/)
 
   if (compsipaRegex.test(key)) {
     return 'compsipa'
   }
 
   // 40-44 characters base58
-  if (/^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{40,44}$/.test(key)) {
+  if (/^[1-9A-HJ-Za-km-z]{40,44}$/.test(key)) {
     return 'base58'
   }
 
@@ -101,15 +101,15 @@ export const detectPrivateKeyFormat = key => {
     return 'base64'
   }
 
-  if (/^6P[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{56}$/.test(key)) {
+  if (/^6P[1-9A-HJ-Za-km-z]{56}$/.test(key)) {
     return 'bip38'
   }
 
-  if (/^S[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21}$/.test(key) ||
-    /^S[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{25}$/.test(key) ||
-    /^S[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{29}$/.test(key) ||
-    /^S[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{30}$/.test(key)) {
-    var testBytes = crypto.sha256(key + '?')
+  if (/^S[1-9A-HJ-Za-km-z]{21}$/.test(key) ||
+    /^S[1-9A-HJ-Za-km-z]{25}$/.test(key) ||
+    /^S[1-9A-HJ-Za-km-z]{29}$/.test(key) ||
+    /^S[1-9A-HJ-Za-km-z]{30}$/.test(key)) {
+    const testBytes = crypto.sha256(key + '?')
 
     if (testBytes[0] === 0x00 || testBytes[0] === 0x01) {
       return 'mini'
@@ -119,7 +119,7 @@ export const detectPrivateKeyFormat = key => {
 }
 
 const parseMiniKey = function (miniKey) {
-  var check = crypto.sha256(miniKey + '?')
+  const check = crypto.sha256(miniKey + '?')
   if (check[0] !== 0x00) {
     throw new Error('Invalid mini key')
   }
@@ -130,7 +130,7 @@ export const privateKeyStringToKey = function (value, format, network = networks
   if (format === 'sipa' || format === 'compsipa') {
     return ECPair.fromWIF(value, networks.bitcoin)
   } else {
-    var keyBuffer = null
+    let keyBuffer = null
 
     switch (format) {
       case 'base58':
@@ -149,8 +149,8 @@ export const privateKeyStringToKey = function (value, format, network = networks
         throw new Error('Unsupported Key Format')
     }
 
-    var d = BigInteger.fromBuffer(keyBuffer)
-    var keyPair = new ECPair(d, null, { network: network })
+    const d = BigInteger.fromBuffer(keyBuffer)
+    let keyPair = new ECPair(d, null, { network: network })
 
     if (addr && keyPair.getAddress() !== addr) {
       keyPair.compressed = false


### PR DESCRIPTION
## Description
fixed 804. i'm a little concerned because it seems like this was intentionally omitted originally.

## Change Type
Please enter one or more of the following: 
- Feature

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

