### PR TITLE
fix - fixed Remote.Failure used without being called

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/manageAddresses/reducers.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/manageAddresses/reducers.js
@@ -10,7 +10,7 @@ export default (state = {}, action) => {
       return assocPath([payload.walletIndex, 'usedAddressesVisible'], payload.visible, state)
     }
     case AT.FETCH_UNUSED_ADDRESSES_ERROR: {
-      return assocPath([payload.walletIndex, 'unusedAddresses'], Remote.Failure, state)
+      return assocPath([payload.walletIndex, 'unusedAddresses'], Remote.Failure(payload.message), state)
     }
     case AT.FETCH_UNUSED_ADDRESSES_LOADING: {
       return assocPath([payload.walletIndex, 'unusedAddresses'], Remote.Loading, state)
@@ -19,7 +19,7 @@ export default (state = {}, action) => {
       return assocPath([payload.walletIndex, 'unusedAddresses'], Remote.Success(payload.unusedAddresses), state)
     }
     case AT.FETCH_USED_ADDRESSES_ERROR: {
-      return assocPath([payload.walletIndex, 'usedAddresses'], Remote.Failure, state)
+      return assocPath([payload.walletIndex, 'usedAddresses'], Remote.Failure(payload.message), state)
     }
     case AT.FETCH_USED_ADDRESSES_LOADING: {
       return assocPath([payload.walletIndex, 'usedAddresses'], Remote.Loading, state)

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/sendBtc/reducers.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/sendBtc/reducers.js
@@ -30,7 +30,7 @@ export default (state = INITIAL_STATE, action) => {
       return assoc('payment', Remote.Loading, state)
     }
     case AT.SEND_BTC_PAYMENT_UPDATED_FAILURE: {
-      return assoc('payment', Remote.Failure, state)
+      return assoc('payment', Remote.Failure(payload), state)
     }
     case AT.SEND_BTC_FIRST_STEP_SUBMIT_CLICKED: {
       return assoc('step', 2, state)


### PR DESCRIPTION
## Description
Remote.Failure can not be used without being called, like Remote.NotAsked or Remote.Loading
That's the [library](https://github.com/fantasyland/daggy) limitation

Fixes send form crashing after send btc form initialization error

## Change Type
- Bug Fix

## Testing Steps
1. Force a crash on send btc form saga with a throw
2. Open buy/sell
3. Page should not break

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

