### PR TITLE
BuySell failure templates

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/BuySell/Failure.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/BuySell/Failure.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import styled from 'styled-components'
+import { FormattedMessage } from 'react-intl'
+import { Text, Link } from 'blockchain-info-components'
+import { path } from 'ramda'
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  div:last-of-type {
+    margin-top: 10px;
+  }
+`
+
+const Loading = (e) => (
+  <Container>
+    <Text weight={300} size='16px'>
+      <FormattedMessage id='buysell.general.failure.message' defaultMessage='Sorry, an error has occurred while connecting to your exchange partner.' />
+    </Text>
+    <Text weight={300} size='16px'>
+      <FormattedMessage id='buysell.general.failure.message2' defaultMessage='If the problem continues, please reach out to our support team {supportLink}' values={{ supportLink: <Link href='https://support.blockchain.com/hc/en-us/requests/new' target='_blank' size='16px' weight={300}><FormattedMessage id='buysell.general.failure.here' defaultMessage='here.' /></Link> }} />
+    </Text>
+    <Text weight={300} size='14px'>
+      <FormattedMessage id='buysell.general.failure.message3' defaultMessage='Error code: {err}' values={{ err: path(['error', 'message'], e) }} />
+    </Text>
+  </Container>
+)
+
+export default Loading

--- a/packages/blockchain-wallet-v4-frontend/src/components/BuySell/Failure.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/BuySell/Failure.js
@@ -18,7 +18,7 @@ const Container = styled.div`
 
 const link = <Link href='https://support.blockchain.com/hc/en-us/requests/new' target='_blank' size='16px' weight={300}><FormattedMessage id='buysell.general.failure.here' defaultMessage='here.' /></Link>
 
-const Loading = (e) => (
+const Failure = (e) => (
   <Container>
     <Text weight={300} size='16px'>
       <FormattedMessage id='buysell.general.failure.message' defaultMessage='Sorry, an error has occurred while connecting to your exchange partner.' />
@@ -32,4 +32,4 @@ const Loading = (e) => (
   </Container>
 )
 
-export default Loading
+export default Failure

--- a/packages/blockchain-wallet-v4-frontend/src/components/BuySell/Failure.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/BuySell/Failure.js
@@ -16,13 +16,15 @@ const Container = styled.div`
   }
 `
 
+const link = <Link href='https://support.blockchain.com/hc/en-us/requests/new' target='_blank' size='16px' weight={300}><FormattedMessage id='buysell.general.failure.here' defaultMessage='here.' /></Link>
+
 const Loading = (e) => (
   <Container>
     <Text weight={300} size='16px'>
       <FormattedMessage id='buysell.general.failure.message' defaultMessage='Sorry, an error has occurred while connecting to your exchange partner.' />
     </Text>
     <Text weight={300} size='16px'>
-      <FormattedMessage id='buysell.general.failure.message2' defaultMessage='If the problem continues, please reach out to our support team {supportLink}' values={{ supportLink: <Link href='https://support.blockchain.com/hc/en-us/requests/new' target='_blank' size='16px' weight={300}><FormattedMessage id='buysell.general.failure.here' defaultMessage='here.' /></Link> }} />
+      <FormattedMessage id='buysell.general.failure.message2' defaultMessage='If the problem continues, please reach out to our support team {supportLink}' values={{ supportLink: link }} />
     </Text>
     <Text weight={300} size='14px'>
       <FormattedMessage id='buysell.general.failure.message3' defaultMessage='Error code: {err}' values={{ err: path(['error', 'message'], e) }} />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/CoinifyExchangeData/Confirm/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/CoinifyExchangeData/Confirm/index.js
@@ -7,6 +7,7 @@ import ui from 'redux-ui'
 import { path } from 'ramda'
 import Template from './template'
 import { getData } from './selectors'
+import Failure from 'components/BuySell/Failure'
 
 class ConfirmContainer extends Component {
   constructor (props) {
@@ -46,7 +47,7 @@ class ConfirmContainer extends Component {
           editingAmount={editingAmount}
           toggleEdit={() => this.props.updateUI({ editing: !this.props.ui.editing })}
         />,
-      Failure: (msg) => <div>ERROR: {msg}</div>,
+      Failure: (msg) => <Failure error={msg} />,
       Loading: () => <div>Loading...</div>,
       NotAsked: () => <div>Not asked...</div>
     })

--- a/packages/blockchain-wallet-v4-frontend/src/modals/CoinifyExchangeData/Payment/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/CoinifyExchangeData/Payment/index.js
@@ -8,6 +8,7 @@ import Success from './template.success'
 import { path } from 'ramda'
 import Loading from 'components/BuySell/Loading'
 import { Remote } from 'blockchain-wallet-v4/src'
+import Failure from 'components/BuySell/Failure'
 
 class PaymentContainer extends Component {
   constructor (props) {
@@ -61,7 +62,7 @@ class PaymentContainer extends Component {
           openPendingKyc={openKYC}
           handlePrefillCardMax={(limits) => checkoutCardMax(limits)}
         />,
-      Failure: (msg) => <div>ERROR: {msg}</div>,
+      Failure: (msg) => <Failure error={msg} />,
       Loading: () => <Loading />,
       NotAsked: () => <Loading />
     })

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SfoxExchangeData/Upload/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SfoxExchangeData/Upload/index.js
@@ -5,6 +5,7 @@ import Upload from './template'
 import { actions } from 'data'
 import { getData } from './selectors'
 import ui from 'redux-ui'
+import Failure from 'components/BuySell/Failure'
 
 class UploadContainer extends Component {
   constructor (props) {
@@ -78,7 +79,7 @@ class UploadContainer extends Component {
         submitForUpload={this.submitForUpload}
         handleStartClick={this.handleStartClick}
       />,
-      Failure: (msg) => <div>{msg.error}</div>,
+      Failure: (msg) => <Failure error={msg} />,
       Loading: () => <div>Loading...</div>,
       NotAsked: () => <div />
     })

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/CoinifyCheckout/Content/Buy/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/CoinifyCheckout/Content/Buy/index.js
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux'
 import { getData } from './selectors'
 import Success from './template.success'
 import Loading from 'components/BuySell/Loading'
+import Failure from 'components/BuySell/Failure'
 
 class CoinifyBuyContainer extends React.Component {
   constructor (props) {
@@ -66,7 +67,7 @@ class CoinifyBuyContainer extends React.Component {
         subscriptions={subscriptions}
         trades={trades}
       />,
-      Failure: (msg) => <div>Failure: {msg.error}</div>,
+      Failure: (e) => <Failure error={e} />,
       Loading: () => <Loading />,
       NotAsked: () => <div>Not Asked</div>
     })

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/CoinifyCheckout/Content/OrderHistory/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/CoinifyCheckout/Content/OrderHistory/index.js
@@ -6,6 +6,7 @@ import { getData, getTrade } from './selectors'
 import Success from './template.success.js'
 import Loading from 'components/BuySell/Loading'
 import { path } from 'ramda'
+import Failure from 'components/BuySell/Failure'
 
 class OrderHistoryContainer extends React.Component {
   componentDidMount () {
@@ -43,7 +44,7 @@ class OrderHistoryContainer extends React.Component {
         onCancelSubscription={cancelSubscription}
         changeTab={tab => change('buySellTabStatus', 'status', tab)}
       />,
-      Failure: (msg) => <div>Failure: {msg.error}</div>,
+      Failure: (msg) => <Failure error={msg} />,
       Loading: () => <Loading />,
       NotAsked: () => <Loading />
     })

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/CoinifyCheckout/Content/Sell/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/CoinifyCheckout/Content/Sell/index.js
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux'
 import { getData } from './selectors'
 import Success from './template.success'
 import Loading from 'components/BuySell/Loading'
+import Failure from 'components/BuySell/Failure'
 
 class SellContainer extends React.Component {
   constructor (props) {
@@ -41,7 +42,7 @@ class SellContainer extends React.Component {
 
     const busy = coinifyBusy.cata({
       Success: () => false,
-      Failure: (err) => err,
+      Failure: (err) => <Failure error={err} />,
       Loading: () => true,
       NotAsked: () => false
     })

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/SfoxCheckout/Content/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/BuySell/SfoxCheckout/Content/index.js
@@ -5,7 +5,8 @@ import { bindActionCreators } from 'redux'
 import { getBase, getData, getErrors, getQuote, getSellQuote, getTrades, getPayment } from './selectors'
 import Success from './template.success'
 import Loading from 'components/BuySell/Loading'
-import { path, prop } from 'ramda'
+import { path } from 'ramda'
+import Failure from 'components/BuySell/Failure'
 
 class SfoxCheckout extends React.PureComponent {
   constructor (props) {
@@ -59,7 +60,7 @@ class SfoxCheckout extends React.PureComponent {
         buttonStatus={this.state.buttonStatus}
         siftScienceEnabled={siftScienceEnabled}
       />,
-      Failure: (error) => <div>Failure: {prop('message', error)}</div>,
+      Failure: (error) => <Failure error={error} />,
       Loading: () => <Loading />,
       NotAsked: () => <div>Not Asked</div>
     })


### PR DESCRIPTION
## Description
Adds a template for Failure state to buy/sell components

## Change Type
Please enter one or more of the following: 
- Feature

## Testing Steps
Throw an error in an important saga like fetching profile or trades, see a failure template

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

