### PR TITLE
upgrade - added input & output bip69 sorting for btc/bch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3350,6 +3350,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "bip69": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/bip69/-/bip69-2.1.4.tgz",
+      "integrity": "sha512-L+S6h7X95CwUtQ726ux9O2SmcnRAKbmsut6u0/3Rug4nEqUHxs2w88+S7tyWSJdFuwyFA6Sjh9jO1vBcT1Wvhw==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "bitcoin-coinify-client": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/bitcoin-coinify-client/-/bitcoin-coinify-client-0.7.6.tgz",

--- a/packages/blockchain-wallet-v4/package.json
+++ b/packages/blockchain-wallet-v4/package.json
@@ -48,6 +48,7 @@
     "bigi": "1.4.2",
     "bignumber.js": "5.0.0",
     "bip39": "2.3.1",
+    "bip69": "2.1.4",
     "bitcoin-coinify-client": "0.7.6",
     "bitcoin-sfox-client": "0.4.0",
     "bitcoinforksjs-lib": "git://github.com/blockchain/bitcoinjs-lib.git#opt-in-bitcoincash-sighash",

--- a/packages/blockchain-wallet-v4/src/coinSelection/coin.js
+++ b/packages/blockchain-wallet-v4/src/coinSelection/coin.js
@@ -1,6 +1,7 @@
-import {curry, is, clamp, split, length, add, compose,
-  isNil, ifElse, always, complement, either, tryCatch} from 'ramda'
+import { curry, is, clamp, split, length, add, compose, sort,
+  isNil, ifElse, always, complement, either, tryCatch } from 'ramda'
 import { over, view } from 'ramda-lens'
+import { inputComparator, sortOutputs } from 'bip69'
 import Type from '../types/Type'
 import { addressToScript, scriptToAddress } from '../utils/bitcoin'
 
@@ -88,3 +89,7 @@ export const outputBytes = ifElse(either(complement(isCoin), compose(isNil, sele
 
 export const effectiveValue = curry((feePerByte, coin) =>
   clamp(0, Infinity, coin.value - feePerByte * inputBytes(coin)))
+
+export const bip69SortInputs = sort((inputA, inputB) =>
+  inputComparator(inputA.txHash, inputA.value, inputB.txHash, inputB.value))
+export const bip69SortOutputs = sortOutputs

--- a/packages/blockchain-wallet-v4/src/coinSelection/coin.spec.js
+++ b/packages/blockchain-wallet-v4/src/coinSelection/coin.spec.js
@@ -78,3 +78,213 @@ describe('Coin Selection', () => {
     })
   })
 })
+
+describe('bip69SortInputs', () => {
+  const { bip69SortInputs } = Coin
+  it('should sort inputs by hash', () => {
+    const assortedInputs = [
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 1
+      },
+      {
+        txHash: 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        value: 2
+      },
+      {
+        txHash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        value: 3
+      },
+      {
+        txHash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbff',
+        value: 4
+      },
+      {
+        txHash: 'ffbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        value: 5
+      }
+    ].map((input) => new Coin.Coin(input))
+    const sortedInputs = [
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 1
+      },
+      {
+        txHash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        value: 3
+      },
+      {
+        txHash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbff',
+        value: 4
+      },
+      {
+        txHash: 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        value: 2
+      },
+      {
+        txHash: 'ffbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        value: 5
+      }
+    ].map((input) => new Coin.Coin(input))
+    expect(bip69SortInputs(assortedInputs)).toEqual(sortedInputs)
+  })
+
+  it('should sort inputs with equal hash by value', () => {
+    const assortedInputs = [
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 1
+      },
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 0
+      },
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 3
+      },
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 10
+      },
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 2
+      }
+    ].map((input) => new Coin.Coin(input))
+    const sortedInputs = [
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 0
+      },
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 1
+      },
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 2
+      },
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 3
+      },
+      {
+        txHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        value: 10
+      }
+    ].map((input) => new Coin.Coin(input))
+    expect(bip69SortInputs(assortedInputs)).toEqual(sortedInputs)
+  })
+})
+
+describe('bip69SortOutputs', () => {
+  const { bip69SortOutputs } = Coin
+  it('should sort ouputs by value', () => {
+    const assortedOutputs = [
+      {
+        script: '00000000',
+        value: 1
+      },
+      {
+        script: '11111111',
+        value: 0
+      },
+      {
+        script: '00000000',
+        value: 3
+      },
+      {
+        script: '11111111',
+        value: 10
+      },
+      {
+        script: '22222222',
+        value: 2
+      }
+    ].map((output) => new Coin.Coin({
+      ...output,
+      script: Buffer.from(output.script, 'hex')
+    }))
+    const sortedOutputs = [
+      {
+        script: '11111111',
+        value: 0
+      },
+      {
+        script: '00000000',
+        value: 1
+      },
+      {
+        script: '22222222',
+        value: 2
+      },
+      {
+        script: '00000000',
+        value: 3
+      },
+      {
+        script: '11111111',
+        value: 10
+      }
+    ].map((output) => new Coin.Coin({
+      ...output,
+      script: Buffer.from(output.script, 'hex')
+    }))
+    expect(bip69SortOutputs(assortedOutputs)).toEqual(sortedOutputs)
+  })
+
+  it('should sort outups with equal value by script', () => {
+    const assortedOutputs = [
+      {
+        script: '00000000',
+        value: 0
+      },
+      {
+        script: '11111111',
+        value: 0
+      },
+      {
+        script: '00000000',
+        value: 0
+      },
+      {
+        script: '11111111',
+        value: 0
+      },
+      {
+        script: '22222222',
+        value: 0
+      }
+    ].map((output) => new Coin.Coin({
+      ...output,
+      script: Buffer.from(output.script, 'hex')
+    }))
+    const sortedOutputs = [
+      {
+        script: '00000000',
+        value: 0
+      },
+      {
+        script: '00000000',
+        value: 0
+      },
+      {
+        script: '11111111',
+        value: 0
+      },
+      {
+        script: '11111111',
+        value: 0
+      },
+      {
+        script: '22222222',
+        value: 0
+      }
+    ].map((output) => new Coin.Coin({
+      ...output,
+      script: Buffer.from(output.script, 'hex')
+    }))
+    expect(bip69SortOutputs(assortedOutputs)).toEqual(sortedOutputs)
+  })
+})

--- a/packages/blockchain-wallet-v4/src/signer/bch.js
+++ b/packages/blockchain-wallet-v4/src/signer/bch.js
@@ -26,6 +26,12 @@ export const signSelection = curry((network, selection) => {
   return { txHex: signedTx.toHex(), txId: signedTx.getId() }
 })
 
+export const sortSelection = (selection) => ({
+  ...selection,
+  inputs: Coin.bip69SortInputs(selection.inputs),
+  outputs: Coin.bip69SortOutputs(selection.outputs)
+})
+
 // signHDWallet :: network -> password -> wrapper -> selection -> Task selection
 export const signHDWallet = curry((network, secondPassword, wrapper, selection) =>
   addHDWalletWIFS(network, secondPassword, wrapper, selection)
@@ -47,5 +53,5 @@ export const wifToKeys = curry((network, selection) =>
 
 // signWithWIF :: network -> selection -> selection
 export const signWithWIF = curry((network, selection) =>
-  compose(signSelection(network), wifToKeys(network))(selection)
+  compose(signSelection(network), sortSelection, wifToKeys(network))(selection)
 )

--- a/packages/blockchain-wallet-v4/src/signer/btc.js
+++ b/packages/blockchain-wallet-v4/src/signer/btc.js
@@ -20,6 +20,12 @@ export const signSelection = curry((network, selection) => {
   return { txHex: signedTx.toHex(), txId: signedTx.getId() }
 })
 
+export const sortSelection = (selection) => ({
+  ...selection,
+  inputs: Coin.bip69SortInputs(selection.inputs),
+  outputs: Coin.bip69SortOutputs(selection.outputs)
+})
+
 // signHDWallet :: network -> password -> wrapper -> selection -> Task selection
 export const signHDWallet = curry((network, secondPassword, wrapper, selection) =>
   addHDWalletWIFS(network, secondPassword, wrapper, selection)
@@ -41,7 +47,7 @@ export const wifToKeys = curry((network, selection) =>
 
 // signWithWIF :: network -> selection -> selection
 export const signWithWIF = curry((network, selection) =>
-  compose(signSelection(network), wifToKeys(network))(selection)
+  compose(signSelection(network), sortSelection, wifToKeys(network))(selection)
 )
 
 export const signMessage = (priv, addr, message) => {


### PR DESCRIPTION
## Description
Inputs and outputs are now sorted according to [bip69 spec](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki)

## Change Type
Please enter one or more of the following: 
- Upgrades

## Testing Steps

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

