### PR TITLE
upgrade - added unused labeled addresses to notificaions sync;

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/kvStore/btc/selectors.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/btc/selectors.js
@@ -1,6 +1,7 @@
-import { path } from 'ramda'
+import { path, keys } from 'ramda'
 import { kvStorePath } from '../../paths'
 import { BTC } from '../config'
 
 export const getMetadata = path([kvStorePath, BTC])
 export const getAddressLabel = (address, state) => getMetadata(state).map(path(['value', 'address_labels', address]))
+export const getAddressLabels = (state) => keys(getMetadata(state).map(path(['value', 'address_labels'])).getOrElse({}))


### PR DESCRIPTION
## Description
Added unused labeled addresses to active addresses sync.

## Change Type
- Upgrades

## Testing Steps
1. Turn off notifications
2. Add labeled address to account
3. Receive funds through request to get account's receive index past the labeled address index.
  Look for receive index in `dataPath.bitcoin.addresses[account's xpub].account_index`.
  Look for labeled addresses receive index in `walletPath.wallet.hd_wallets[0].account[find your account].address_labels[find your label].index`
4. Turn on notifications
5. Send funds to labeled address
6. Receive notification

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

