### PR TITLE
Fix/2fa

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -186,6 +186,9 @@ export default ({ api, coreSagas }) => {
         yield put(actions.alerts.displayInfo(C.TWOFA_REQUIRED_INFO))
       // Wrong password error
       } else if (error && is(String, error) && error.includes(wrongWalletPassErrorMessage)) {
+        // remove 2fa if password is wrong
+        // password error can only occur after 2fa validation
+        yield put(actions.auth.setAuthType(0))
         yield put(actions.form.clearFields('login', false, true, 'password'))
         yield put(actions.form.focus('login', 'password'))
         yield put(actions.auth.loginFailure(error))

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.spec.js
@@ -10,6 +10,7 @@ import authSagas, {
   defaultLoginErrorMessage,
   logLocation,
   wrongWalletPassErrorMessage,
+  wrongAuthCodeErrorMessage,
   guidNotFound2faErrorMessage,
   notEnabled2faErrorMessage,
   emailMismatch2faErrorMessage,
@@ -235,6 +236,56 @@ describe('authSagas', () => {
             .put(actions.alerts.displayInfo(C.TWOFA_REQUIRED_INFO))
             .next()
             .isDone()
+        })
+      })
+
+      describe('wrong password error', () => {
+        it('should set auth_type to 0', () => {
+          saga
+            .restore(beforeError)
+            .save(beforeError)
+            .throw(wrongWalletPassErrorMessage)
+            .put(actions.auth.setAuthType(0))
+        })
+
+        it('should clear password field', () => {
+          saga
+            .next()
+            .put(actions.form.clearFields('login', false, true, 'password'))
+        })
+ 
+        it('should focus password', () => {
+          saga
+            .next()
+            .put((actions.form.focus('login', 'password')))
+        })
+
+        it('should display login error', () => {
+          saga
+            .next()
+            .put(actions.auth.loginFailure(wrongWalletPassErrorMessage))
+        })
+      })
+
+      describe('wrong 2fa error', () => {
+        it('should clear code field', () => {
+          saga
+            .restore(beforeError)
+            .save(beforeError)
+            .throw(wrongAuthCodeErrorMessage)
+            .put(actions.form.clearFields('login', false, true, 'code'))
+        })
+
+        it('should focus password', () => {
+          saga
+            .next()
+            .put((actions.form.focus('login', 'code')))
+        })
+
+        it('should display login error', () => {
+          saga
+            .next()
+            .put(actions.auth.loginFailure(wrongAuthCodeErrorMessage))
         })
       })
 


### PR DESCRIPTION
## Description
1041
sms code was validated when first sent along with wrong password => no new code was issued, and resending it caused error.
2fa field is removed after initial validation, when password causes error

## Change Type
- Bug Fix

## Testing Steps
1. Logout & deauth
2. Enter wrong password
3. Validate email
4. Enter valid sms code
5. 2fa field must disappear, password error will occur

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

