### PR TITLE
Feature(localhost SSL support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ packages/blockchain-wallet-v4-frontend/package-lock.json
 # Config Files
 config/env/development.js
 config/env/staging.js
+config/ssl/cert.pem
+config/ssl/key.pem

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This repo contains the three codebases/packages listed below.
 4. Start the application in development mode: `yarn start`
 5. The frontend application will now be accessible via browser at `localhost:8080`
 
+If you require the application to run locally over HTTPS, follow the instructions [here](./config/ssl/ssl.md).
+
 ### Windows Support
 To ensure proper support for Windows, please take the following actions before running the above setup isntructions.
 1. Open a Powershell window with rights elevated to an Administrator.

--- a/config/ssl/ssl.md
+++ b/config/ssl/ssl.md
@@ -1,0 +1,19 @@
+## Local SSL
+
+### Overview
+Certain features of the application require HTTPS/SSL to run properly. 
+By default the Webpack dev server will use HTTP.  However, if the instructions below are followed
+and this folder contains both `cert.pem` and `key.pem` files, the dev server will be started over HTTPS.
+
+### Creating/Managing Certificates
+Each developer will need to create their own self-signed certificate for use on their local machine.
+Please see the following resources for doing so:
+
+- (MacOS) https://certsimple.com/blog/localhost-ssl-fix
+- (Windows) https://technet.microsoft.com/itpro/powershell/windows/pkiclient/new-selfsignedcertificate
+
+Be sure to follow the instructions on how to separate your new `.pem` file into separate key and cert files. 
+Name these files `cert.pem` and `key.pem` and place within this directory.
+
+After that is all completed, the dev server will now auto-start with SSL enabled at [https://localhost:8080]()
+

--- a/config/ssl/ssl.md
+++ b/config/ssl/ssl.md
@@ -7,13 +7,24 @@ and this folder contains both `cert.pem` and `key.pem` files, the dev server wil
 
 ### Creating/Managing Certificates
 Each developer will need to create their own self-signed certificate for use on their local machine.
-Please see the following resources for doing so:
 
-- (MacOS) https://certsimple.com/blog/localhost-ssl-fix
-- (Windows) https://technet.microsoft.com/itpro/powershell/windows/pkiclient/new-selfsignedcertificate
+Follow these steps for MacOs:
+1) From the application root run the following command: 
+    ```$sh
+    cd ./config/ssl
+    ```
+2) Next generate pem files by running the following command:
+    ```$sh
+    openssl req -x509 -out cert.pem -keyout key.pem \
+      -newkey rsa:2048 -nodes -sha256 \
+      -subj '/CN=localhost' -extensions EXT -config <( \
+       printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
+    ```
+3) Open Chrome and navigate to `chrome://flags/#allow-insecure-localhost` via the URL
+4) Enable the "Allow invalid certificates for resources loaded from localhost." setting
+5) Now simply start the HTTPS enabled server via `yarn start` and navigate to [https://localhost:8080]()
 
-Be sure to follow the instructions on how to separate your new `.pem` file into separate key and cert files. 
-Name these files `cert.pem` and `key.pem` and place within this directory.
+NOTE: Chrome will still warn you that the connection is "Not Secure" via red letters but that is OK for our purposes
 
-After that is all completed, the dev server will now auto-start with SSL enabled at [https://localhost:8080]()
-
+Windows
+- TODO

--- a/packages/blockchain-wallet-v4-frontend/webpack.config.js
+++ b/packages/blockchain-wallet-v4-frontend/webpack.config.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -20,22 +21,37 @@ let envConfig = {}
 let mockWalletOptions
 let iSignThisDomain
 
+/* eslint-disable no-console */
 // only configure app if we will be using the webpack dev server
 if (!isCiBuild) {
   mockWalletOptions = require('./../../config/wallet-options-v4.json')
-  iSignThisDomain = mockWalletOptions.platforms.web.coinify.config.iSignThisDomain
+  iSignThisDomain =
+    mockWalletOptions.platforms.web.coinify.config.iSignThisDomain
 
   try {
     envConfig = require(PATHS.envConfig + process.env.NODE_ENV + '.js')
   } catch (e) {
-    console.log(chalk.red('\u{1F6A8} WARNING \u{1F6A8} ') + chalk.yellow(`Failed to load ${process.env.NODE_ENV}.js config file! Using the production config instead.\n`))
+    console.log(
+      chalk.red('\u{1F6A8} WARNING \u{1F6A8} ') +
+        chalk.yellow(
+          `Failed to load ${
+            process.env.NODE_ENV
+          }.js config file! Using the production config instead.\n`
+        )
+    )
     envConfig = require(PATHS.envConfig + 'production.js')
   } finally {
     console.log(chalk.blue('\u{1F6A7} CONFIGURATION \u{1F6A7}'))
     console.log(chalk.cyan('Root URL') + `: ${envConfig.ROOT_URL}`)
     console.log(chalk.cyan('API Domain') + `: ${envConfig.API_DOMAIN}`)
-    console.log(chalk.cyan('Wallet Helper Domain') + ': ' + chalk.blue(envConfig.WALLET_HELPER_DOMAIN))
-    console.log(chalk.cyan('Web Socket URL') + ': ' + chalk.blue(envConfig.WEB_SOCKET_URL))
+    console.log(
+      chalk.cyan('Wallet Helper Domain') +
+        ': ' +
+        chalk.blue(envConfig.WALLET_HELPER_DOMAIN)
+    )
+    console.log(
+      chalk.cyan('Web Socket URL') + ': ' + chalk.blue(envConfig.WEB_SOCKET_URL)
+    )
   }
 }
 
@@ -44,36 +60,34 @@ module.exports = {
   entry: {
     app: [
       'babel-polyfill',
-      ...(isCiBuild ? [] : [
-        'react-hot-loader/patch',
-        'webpack-dev-server/client?http://localhost:8080',
-        'webpack/hot/only-dev-server'
-      ]),
+      ...(isCiBuild
+        ? []
+        : [
+            'react-hot-loader/patch',
+            'webpack-dev-server/client?http://localhost:8080',
+            'webpack/hot/only-dev-server'
+          ]),
       PATHS.src + '/index.js'
     ]
   },
   output: {
-    path: isCiBuild ? (PATHS.dist) : (PATHS.lib),
+    path: isCiBuild ? PATHS.dist : PATHS.lib,
     chunkFilename: '[name].[chunkhash:10].js',
     publicPath: '/',
     crossOriginLoading: 'anonymous'
   },
   module: {
     rules: [
-      (isCiBuild ? {
-        test: /\.js$/,
-        use: [
-          'thread-loader',
-          'babel-loader'
-        ]
-      } : {
-        test: /\.js$/,
-        include: /src|blockchain-info-components.src|blockchain-wallet-v4.src/,
-        use: [
-          'thread-loader',
-          'babel-loader'
-        ]
-      }),
+      isCiBuild
+        ? {
+            test: /\.js$/,
+            use: ['thread-loader', 'babel-loader']
+          }
+        : {
+            test: /\.js$/,
+            include: /src|blockchain-info-components.src|blockchain-wallet-v4.src/,
+            use: ['thread-loader', 'babel-loader']
+          },
       {
         test: /\.(eot|ttf|otf|woff|woff2)$/,
         use: {
@@ -100,21 +114,24 @@ module.exports = {
             name: 'resources/[name]-[hash].[ext]'
           }
         }
-      }, {
+      },
+      {
         test: /\.css$/,
-        use: [
-          {loader: 'style-loader'},
-          {loader: 'css-loader'}
-        ]
+        use: [{ loader: 'style-loader' }, { loader: 'css-loader' }]
       }
     ]
   },
   plugins: [
     new CleanWebpackPlugin([PATHS.dist, PATHS.lib], { allowExternal: true }),
     new CaseSensitivePathsPlugin(),
-    new Webpack.DefinePlugin({ APP_VERSION: JSON.stringify(require(PATHS.pkgJson).version) }),
-    new HtmlWebpackPlugin({ template: PATHS.src + '/index.html', filename: 'index.html' }),
-    ...(!isCiBuild ? [ new Webpack.HotModuleReplacementPlugin() ] : []),
+    new Webpack.DefinePlugin({
+      APP_VERSION: JSON.stringify(require(PATHS.pkgJson).version)
+    }),
+    new HtmlWebpackPlugin({
+      template: PATHS.src + '/index.html',
+      filename: 'index.html'
+    }),
+    ...(!isCiBuild ? [new Webpack.HotModuleReplacementPlugin()] : []),
     ...(runBundleAnalyzer ? [new BundleAnalyzerPlugin({})] : [])
   ],
   optimization: {
@@ -156,10 +173,17 @@ module.exports = {
           priority: -10,
           test: function (module) {
             // ensure other packages in mono repo don't get put into vendor bundle
-            return module.resource &&
-              module.resource.indexOf('blockchain-wallet-v4-frontend/src') === -1 &&
-              module.resource.indexOf('node_modules/blockchain-info-components/src') === -1 &&
-              module.resource.indexOf('node_modules/blockchain-wallet-v4/src') === -1
+            return (
+              module.resource &&
+              module.resource.indexOf('blockchain-wallet-v4-frontend/src') ===
+                -1 &&
+              module.resource.indexOf(
+                'node_modules/blockchain-info-components/src'
+              ) === -1 &&
+              module.resource.indexOf(
+                'node_modules/blockchain-wallet-v4/src'
+              ) === -1
+            )
           }
         }
       }
@@ -169,6 +193,7 @@ module.exports = {
     disableHostCheck: true,
     contentBase: PATHS.src,
     host: 'localhost',
+    https: true,
     port: 8080,
     hot: !isCiBuild,
     historyApiFallback: true,
@@ -176,12 +201,12 @@ module.exports = {
       app.get('/Resources/wallet-options-v4.json', function (req, res) {
         // combine wallet options base with custom environment config
         mockWalletOptions.domains = {
-          'root': envConfig.ROOT_URL,
-          'api': envConfig.API_DOMAIN,
-          'webSocket': envConfig.WEB_SOCKET_URL,
-          'walletHelper': envConfig.WALLET_HELPER_DOMAIN,
-          'comWalletApp': envConfig.COM_WALLET_APP,
-          'comRoot': envConfig.COM_ROOT
+          root: envConfig.ROOT_URL,
+          api: envConfig.API_DOMAIN,
+          webSocket: envConfig.WEB_SOCKET_URL,
+          walletHelper: envConfig.WALLET_HELPER_DOMAIN,
+          comWalletApp: envConfig.COM_WALLET_APP,
+          comRoot: envConfig.COM_ROOT
         }
 
         res.json(mockWalletOptions)
@@ -190,66 +215,72 @@ module.exports = {
       // TODO:: DEPRECATE
       // This is to locally test transferring cookies from transfer_stored_values.html
       app.get('/Resources/transfer_stored_values.html', function (req, res) {
-        res.sendFile(path.join(__dirname, '/../../config/transfer_stored_values.html'))
+        res.sendFile(
+          path.join(__dirname, '/../../config/transfer_stored_values.html')
+        )
       })
 
       app.get('/Resources/wallet-options.json', function (req, res) {
         mockWalletOptions.domains = {
-          'comWalletApp': 'http://localhost:8080'
+          comWalletApp: 'http://localhost:8080'
         }
 
         res.json(mockWalletOptions)
       })
     },
-    proxy: [{
-      path: /\/a\/.*/,
-      bypass: function (req, res, proxyOptions) {
-        return '/index.html'
+    proxy: [
+      {
+        path: /\/a\/.*/,
+        bypass: function (req, res, proxyOptions) {
+          return '/index.html'
+        }
       }
-    }],
+    ],
     overlay: !isCiBuild && {
       warnings: true,
       errors: true
     },
     headers: {
       'Access-Control-Allow-Origin': '*',
-      'Content-Security-Policy': isCiBuild ? [] : [
-        "img-src 'self' data: blob:",
-        "style-src 'self' 'unsafe-inline'",
-        `frame-src ${iSignThisDomain} ${envConfig.WALLET_HELPER_DOMAIN} ${envConfig.ROOT_URL} http://localhost:8080`,
-        `child-src ${iSignThisDomain} ${envConfig.WALLET_HELPER_DOMAIN} blob:`,
-        // 'unsafe-eval' is only used by webpack for development. It should not
-        // be present on production!
-        "script-src 'self' 'unsafe-eval'",
-        // 'ws://localhost:8080' is only used by webpack for development and
-        // should not be present on production.
-        [
-          'connect-src',
-          "'self'",
-          'ws://localhost:8080',
-          envConfig.WEB_SOCKET_URL,
-          envConfig.WEB_SOCKET_URL.replace('/inv', '/eth/inv'),
-          envConfig.WEB_SOCKET_URL.replace('/inv', '/bch/inv'),
-          envConfig.ROOT_URL,
-          envConfig.API_DOMAIN,
-          envConfig.WALLET_HELPER_DOMAIN,
-          'https://app-api.coinify.com',
-          'https://app-api.sandbox.coinify.com',
-          'https://api.sfox.com',
-          'https://api.staging.sfox.com',
-          'https://quotes.sfox.com',
-          `https://quotes.staging.sfox.com`,
-          'https://sfox-kyc.s3.amazonaws.com',
-          'https://sfox-kyctest.s3.amazonaws.com',
-          'https://testnet5.blockchain.info',
-          'https://api.testnet.blockchain.info',
-          'wss://ws.testnet.blockchain.info/inv',
-          'https://shapeshift.io'
-        ].join(' '),
-        "object-src 'none'",
-        "media-src 'self' https://storage.googleapis.com/bc_public_assets/ data: mediastream: blob:",
-        "font-src 'self'"
-      ].join('; ')
+      'Content-Security-Policy': isCiBuild
+        ? []
+        : [
+            "img-src 'self' data: blob:",
+            "style-src 'self' 'unsafe-inline'",
+            `frame-src ${iSignThisDomain} ${envConfig.WALLET_HELPER_DOMAIN} ${
+              envConfig.ROOT_URL
+            } https://localhost:8080`,
+            `child-src ${iSignThisDomain} ${
+              envConfig.WALLET_HELPER_DOMAIN
+            } blob:`,
+            "script-src 'self' 'unsafe-eval'",
+            [
+              'connect-src',
+              "'self'",
+              'ws://localhost:8080',
+              envConfig.WEB_SOCKET_URL,
+              envConfig.WEB_SOCKET_URL.replace('/inv', '/eth/inv'),
+              envConfig.WEB_SOCKET_URL.replace('/inv', '/bch/inv'),
+              envConfig.ROOT_URL,
+              envConfig.API_DOMAIN,
+              envConfig.WALLET_HELPER_DOMAIN,
+              'https://app-api.coinify.com',
+              'https://app-api.sandbox.coinify.com',
+              'https://api.sfox.com',
+              'https://api.staging.sfox.com',
+              'https://quotes.sfox.com',
+              `https://quotes.staging.sfox.com`,
+              'https://sfox-kyc.s3.amazonaws.com',
+              'https://sfox-kyctest.s3.amazonaws.com',
+              'https://testnet5.blockchain.info',
+              'https://api.testnet.blockchain.info',
+              'wss://ws.testnet.blockchain.info/inv',
+              'https://shapeshift.io'
+            ].join(' '),
+            "object-src 'none'",
+            "media-src 'self' https://storage.googleapis.com/bc_public_assets/ data: mediastream: blob:",
+            "font-src 'self'"
+          ].join('; ')
     }
   }
 }

--- a/packages/blockchain-wallet-v4-frontend/webpack.config.js
+++ b/packages/blockchain-wallet-v4-frontend/webpack.config.js
@@ -24,7 +24,7 @@ let mockWalletOptions
 let iSignThisDomain
 let sslEnabled
 
-/* eslint-disable no-console */
+/* eslint-disable */
 
 // only configure app if we will be using the webpack dev server
 if (!isCiBuild) {
@@ -200,9 +200,11 @@ module.exports = {
   },
   devServer: {
     disableHostCheck: true,
-    cert: sslEnabled ? PATHS.sslConfig + 'cert.pem' : '',
+    cert: sslEnabled
+      ? fs.readFileSync(PATHS.sslConfig + 'cert.pem', 'utf8')
+      : '',
     contentBase: PATHS.src,
-    key: sslEnabled ? PATHS.sslConfig + 'key.pem' : '',
+    key: sslEnabled ? fs.readFileSync(PATHS.sslConfig + 'key.pem', 'utf8') : '',
     host: 'localhost',
     https: sslEnabled,
     port: 8080,

--- a/packages/blockchain-wallet-v4-frontend/webpack.config.js
+++ b/packages/blockchain-wallet-v4-frontend/webpack.config.js
@@ -1,3 +1,6 @@
+/* eslint-disable */
+/* prettier-ignore */
+
 const chalk = require('chalk')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin
@@ -24,8 +27,6 @@ let mockWalletOptions
 let iSignThisDomain
 let sslEnabled
 
-/* eslint-disable */
-
 // only configure app if we will be using the webpack dev server
 if (!isCiBuild) {
   mockWalletOptions = require('./../../config/wallet-options-v4.json')
@@ -45,15 +46,16 @@ if (!isCiBuild) {
     )
     envConfig = require(PATHS.envConfig + 'production.js')
   } finally {
-    console.log(chalk.red('\u{1F6A7} CONFIGURATION \u{1F6A7}'))
-    console.log(chalk.cyan('Root URL: ') + `${envConfig.ROOT_URL}`)
-    console.log(chalk.cyan('API Domain: ') + `${envConfig.API_DOMAIN}`)
+    console.log(chalk.blue('\u{1F6A7} CONFIGURATION \u{1F6A7}'))
+    console.log(chalk.cyan('Root URL') + `: ${envConfig.ROOT_URL}`)
+    console.log(chalk.cyan('API Domain') + `: ${envConfig.API_DOMAIN}`)
     console.log(
-      chalk.cyan('Wallet Helper Domain: ') +
-        chalk.blue(`${envConfig.WALLET_HELPER_DOMAIN}`)
+      chalk.cyan('Wallet Helper Domain') +
+        ': ' +
+        chalk.blue(envConfig.WALLET_HELPER_DOMAIN)
     )
     console.log(
-      chalk.cyan('Web Socket URL: ') + chalk.blue(`${envConfig.WEB_SOCKET_URL}`)
+      chalk.cyan('Web Socket URL') + ': ' + chalk.blue(envConfig.WEB_SOCKET_URL)
     )
   }
 }
@@ -199,14 +201,14 @@ module.exports = {
     }
   },
   devServer: {
-    disableHostCheck: true,
     cert: sslEnabled
       ? fs.readFileSync(PATHS.sslConfig + 'cert.pem', 'utf8')
       : '',
     contentBase: PATHS.src,
-    key: sslEnabled ? fs.readFileSync(PATHS.sslConfig + 'key.pem', 'utf8') : '',
+    disableHostCheck: true,
     host: 'localhost',
     https: sslEnabled,
+    key: sslEnabled ? fs.readFileSync(PATHS.sslConfig + 'key.pem', 'utf8') : '',
     port: 8080,
     hot: !isCiBuild,
     historyApiFallback: true,
@@ -239,6 +241,7 @@ module.exports = {
             ? 'https://localhost:8080'
             : 'http://localhost:8080'
         }
+
         res.json(mockWalletOptions)
       })
     },
@@ -267,7 +270,11 @@ module.exports = {
             `child-src ${iSignThisDomain} ${
               envConfig.WALLET_HELPER_DOMAIN
             } blob:`,
+            // 'unsafe-eval' is only used by webpack for development. It should not
+            // be present on production!
             "script-src 'self' 'unsafe-eval'",
+            // 'ws://localhost:8080' is only used by webpack for development and
+            // should not be present on production.
             [
               'connect-src',
               "'self'",


### PR DESCRIPTION
## Description
Upcoming features will require application to be served over HTTPS. This PR allows the Webpack dev server to auto-start with HTTPS enabled if `.pem` files are found in the `config/ssl` folder.  If the files are not found, the server will fallback to HTTP

## Change Type
Feature

## Testing Steps
Follow readme instructions to enable SSL

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

