### PR TITLE
fix(Btc Send): made invalid btc QR code throw error

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/QRCodeCapture/index.js
@@ -66,6 +66,8 @@ class QRCodeCaptureContainer extends React.PureComponent {
           this.props.updateUI({ btcAddress: { toggled: false } })
           return
         }
+
+        throw Error('invalid_btc_addr')
       } catch (e) {
         this.props.alertActions.displayError(C.BTC_ADDRESS_INVALID)
         this.props.updateUI({ btcAddress: { toggled: false } })


### PR DESCRIPTION
## Description
If you held up an invalid btc qr code it wouldn't throw error. Now it does.
#799

## Change Type
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

