### PR TITLE
fixed redux form issue with ipwhitelist

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/SecurityCenter/Advanced/IPWhitelist/Settings/index.js
@@ -19,7 +19,7 @@ class SettingsContainer extends React.PureComponent {
   componentWillMount () {
     if (!isEmpty(this.props.currentWhitelist)) {
       this.props.formActions.initialize('settingIPWhitelist', {
-        IPWhitelist: this.props.currentWhitelist.data
+        IPWhitelist: this.props.currentWhitelist.data || ''
       })
     }
   }


### PR DESCRIPTION
## Description
Fixes: When a new wallet is created, the user isn't able to clear the ip whitelist because redux doesn't like the fact that it doesn't have an initial data value. 

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
New wallet > Advanced Security settings > add ip to whitelist > remove ip from whitelist

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

