### PR TITLE
fix(linter): Remove eslint for *.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,13 @@
   },
   "lint-staged": {
     "linters": {
-      "*.{js,json}": [
+      "*.js": [
         "prettier --write",
         "eslint --fix",
+        "git add"
+      ],
+      "*.json": [
+        "prettier --write",
         "git add"
       ]
     },


### PR DESCRIPTION
- eslint does not support json files. It causes errors during pre-commit hook

Resolves #839 

## Description
Removed eslint on json files in `lint-staged` as it causes parsing errors.

## Change Type
- Bug Fix

## Testing Steps
Stage a json file and trigger pre-commit hook

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

