### PR TITLE
fix(State select dropdown): placeholder text

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/defaultMessages.json
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/defaultMessages.json
@@ -931,7 +931,7 @@
   {
     "descriptors": [
       {
-        "defaultMessage": "Select country",
+        "defaultMessage": "Select state",
         "id": "components.selectboxstate.label"
       }
     ],

--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/en.json
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/en.json
@@ -404,7 +404,7 @@
   "components.selectboxcountry.label": "Select country",
   "components.selectboxregion.placeholder.region": "Select region",
   "components.selectboxregion.placeholder.state": "Select state",
-  "components.selectboxstate.label": "Select country",
+  "components.selectboxstate.label": "Select state",
   "components.selectboxtheme.complement": "Complement",
   "components.selectboxtheme.default": "Default",
   "components.selectboxtheme.grayscale": "Grayscale",

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxUSState/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxUSState/index.js
@@ -14,7 +14,7 @@ class SelectBoxUSState extends React.PureComponent {
         label={
           <FormattedMessage
             id='components.selectboxstate.label'
-            defaultMessage='Select country'
+            defaultMessage='Select state'
           />
         }
         elements={elements}


### PR DESCRIPTION
## Description
Fixed the placeholder text for state dropdowns to say 'select state' instead of 'select country': 1096, 1188

## Change Type

- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

