### PR TITLE
Include BCH imported addresses in total balance

### DIFF
--- a/packages/blockchain-wallet-v4/data/index.js
+++ b/packages/blockchain-wallet-v4/data/index.js
@@ -1,3 +1,10 @@
+import { Types } from '../src'
+
 export { default as walletV1 } from './wallet.v1'
 export { default as walletV2 } from './wallet.v2'
 export { default as walletV3 } from './wallet.v3'
+export { default as walletV3WithLegacy } from './wallet.v3-with-legacy'
+
+export const createMockState = wallet => ({
+  walletPath: Types.Wrapper.fromJS({ wallet })
+})

--- a/packages/blockchain-wallet-v4/data/wallet.v3-with-legacy.json
+++ b/packages/blockchain-wallet-v4/data/wallet.v3-with-legacy.json
@@ -1,0 +1,60 @@
+{
+  "guid": "e01a59a0-31f2-4403-8488-32ffd8fdb3cc",
+  "sharedKey": "5d7e1444-82c3-4489-a63a-97e06b0f0434",
+  "double_encryption": false,
+  "options": {
+    "pbkdf2_iterations": 1200,
+    "fee_per_kb": 10000,
+    "html5_notifications": false,
+    "logout_time": 600000
+  },
+  "address_book": [],
+  "tx_notes": {},
+  "tx_names": [],
+  "keys": [
+    {
+      "addr": "1EGW5YZs4EXExhLiCVvRXTRVmfLjs69bZc",
+      "priv": "3jqZaXvzgV9Zp8BqJHovefNZ8nc1BHsLrbZRFuQPrZtG",
+      "created_time": 0,
+      "created_device_name": "javascript_iphone_app",
+      "created_device_version": "0.1 BETA",
+      "tag": 0,
+      "label": "Aaaa"
+    },
+    {
+      "addr": "12BeccoHhdZ5DtoZbuphji1FbQEgNNhy3P",
+      "priv": null,
+      "created_time": 0,
+      "created_device_name": "javascript_iphone_app",
+      "created_device_version": "0.1 BETA",
+      "tag": 0,
+      "label": "Bbbb"
+    }
+  ],
+  "paidTo": {},
+  "hd_wallets": [
+    {
+      "seed_hex": "cd704d52e010f5b374fd95945a4b11e2",
+      "passphrase": "",
+      "mnemonic_verified": false,
+      "default_account_idx": 0,
+      "accounts": [
+        {
+          "label": "My Bitcoin Wallet",
+          "archived": false,
+          "xpriv":
+            "xprv9yb4M8aKinUDAwNrs7Y4Qp8J2yoRZHox2NiaDWEkg2TSF11j8VDYezATWJMs49i4LtYWSYs9rCg1LUW8pBj1j8LTkHaYcitXjqBsXhzNebJ",
+          "xpub":
+            "xpub6CaQke7DZA2WPRTKy954mx52b1duxkXoPbeB1teNEMzR7oLsg2XoCnUwMbK8WDvKJYfuvWxfeH2f7HdoyGDEZs7Kj11AuQiKeJhLBd2GciM",
+          "address_labels": [],
+          "cache": {
+            "receiveAccount":
+              "xpub6DrWPuoPBCE2dtHyQtErZimnm4rNTSaueiU2Xfj1BgaE6T8UUXTLYhbkei765HNzJWTLFXvVHMUyQiE739C7rYTtK2yPReojEqsNLFE15St",
+            "changeAccount":
+              "xpub6DrWPuoPBCE2fzxhqQUa12HJQnmHEKrdL1vTphHoE55pyAPph8paBDwSDu8rUDeY9BKirZZidtxgGyiyFCxbnbNtvL5R2Ks1EK4iidNyqda"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/bch/selectors.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/bch/selectors.js
@@ -58,7 +58,7 @@ export const getContext = createDeepEqualSelector(
 export const getSpendableContext = createDeepEqualSelector(
   [
     walletSelectors.getHDAccounts,
-    walletSelectors.getSpendableContext,
+    walletSelectors.getSpendableAddrContext,
     getAccounts
   ],
   (btcHDAccounts, spendableAddresses, metadataAccountsR) => {
@@ -71,8 +71,7 @@ export const getSpendableContext = createDeepEqualSelector(
       return map(prop('xpub'), activeAccounts)
     }
     const activeAccounts = metadataAccountsR.map(transform).getOrElse([])
-    const addresses = keysIn(spendableAddresses)
-    return concat(activeAccounts, addresses)
+    return concat(activeAccounts, spendableAddresses)
   }
 )
 

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/bch/selectors.spec.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/bch/selectors.spec.js
@@ -1,6 +1,7 @@
-import { assocPath } from 'ramda'
+import { assocPath, merge } from 'ramda'
 import Remote from '../../../remote'
 import * as selectors from './selectors'
+import { createMockState, walletV3, walletV3WithLegacy } from '../../../../data'
 
 describe('kvstore bch selectors', () => {
   const accounts = [
@@ -24,6 +25,47 @@ describe('kvstore bch selectors', () => {
       bch: Remote.Success(bchMetadata)
     }
   }
+
+  const mockState = merge(createMockState(walletV3), successState)
+  const mockStateLegacy = merge(
+    createMockState(walletV3WithLegacy),
+    successState
+  )
+
+  describe('getContext', () => {
+    it('should return the context', () => {
+      let context = selectors.getContext(mockState)
+      expect(context).toEqual([
+        'xpub6CaQke7DZA2WPRTKy954mx52b1duxkXoPbeB1teNEMzR7oLsg2XoCnUwMbK8WDvKJYfuvWxfeH2f7HdoyGDEZs7Kj11AuQiKeJhLBd2GciM'
+      ])
+    })
+
+    it('should return context with legacy and watch-only addresses', () => {
+      let context = selectors.getContext(mockStateLegacy)
+      expect(context).toEqual([
+        'xpub6CaQke7DZA2WPRTKy954mx52b1duxkXoPbeB1teNEMzR7oLsg2XoCnUwMbK8WDvKJYfuvWxfeH2f7HdoyGDEZs7Kj11AuQiKeJhLBd2GciM',
+        '1EGW5YZs4EXExhLiCVvRXTRVmfLjs69bZc',
+        '12BeccoHhdZ5DtoZbuphji1FbQEgNNhy3P'
+      ])
+    })
+  })
+
+  describe('getSpendableContext', () => {
+    it('should return the context', () => {
+      let context = selectors.getSpendableContext(mockState)
+      expect(context).toEqual([
+        'xpub6CaQke7DZA2WPRTKy954mx52b1duxkXoPbeB1teNEMzR7oLsg2XoCnUwMbK8WDvKJYfuvWxfeH2f7HdoyGDEZs7Kj11AuQiKeJhLBd2GciM'
+      ])
+    })
+
+    it('should return context with legacy addresses', () => {
+      let context = selectors.getSpendableContext(mockStateLegacy)
+      expect(context).toEqual([
+        'xpub6CaQke7DZA2WPRTKy954mx52b1duxkXoPbeB1teNEMzR7oLsg2XoCnUwMbK8WDvKJYfuvWxfeH2f7HdoyGDEZs7Kj11AuQiKeJhLBd2GciM',
+        '1EGW5YZs4EXExhLiCVvRXTRVmfLjs69bZc'
+      ])
+    })
+  })
 
   it('getMetadata should return success of metadata', () => {
     const expectedResult = Remote.Success(bchMetadata)

--- a/packages/blockchain-wallet-v4/src/redux/wallet/selectors.js
+++ b/packages/blockchain-wallet-v4/src/redux/wallet/selectors.js
@@ -37,6 +37,11 @@ export const getSpendableContext = compose(
   Wallet.selectSpendableContext,
   getWallet
 )
+export const getSpendableAddrContext = compose(
+  ImtoJS,
+  Wallet.selectSpendableAddrContext,
+  getWallet
+)
 export const getUnspendableContext = compose(
   ImtoJS,
   Wallet.selectUnspendableContext,

--- a/packages/blockchain-wallet-v4/src/redux/wallet/walletSelectors.spec.js
+++ b/packages/blockchain-wallet-v4/src/redux/wallet/walletSelectors.spec.js
@@ -1,12 +1,13 @@
-import { Wrapper } from '../../types'
 import * as selectors from './selectors'
-import { walletV1, walletV2, walletV3 } from '../../../data'
+import {
+  createMockState,
+  walletV1,
+  walletV2,
+  walletV3,
+  walletV3WithLegacy
+} from '../../../data'
 
 describe('selectors.core.wallet', () => {
-  let createMockState = wallet => ({
-    walletPath: Wrapper.fromJS({ wallet })
-  })
-
   describe('isHdWallet', () => {
     it('should return true for a v3 wallet', () => {
       let mockState = createMockState(walletV3)
@@ -24,6 +25,22 @@ describe('selectors.core.wallet', () => {
       let mockState = createMockState(walletV1)
       let isHdWallet = selectors.isHdWallet(mockState)
       expect(isHdWallet).toEqual(false)
+    })
+  })
+
+  describe('getSpendableAddrContext', () => {
+    it('should return empty if there is no spendable context', () => {
+      let mockState = createMockState(walletV3)
+      let spendableAddrContext = selectors.getSpendableAddrContext(mockState)
+      expect(spendableAddrContext).toEqual([])
+    })
+
+    it('should return the spendable context', () => {
+      let mockState = createMockState(walletV3WithLegacy)
+      let spendableAddrContext = selectors.getSpendableAddrContext(mockState)
+      expect(spendableAddrContext).toEqual([
+        '1EGW5YZs4EXExhLiCVvRXTRVmfLjs69bZc'
+      ])
     })
   })
 })


### PR DESCRIPTION
## Description
Fixes 0-balance issue for imported addresses with a BCH balance. The problem was with the selection of the address context: an unnecessary call to `keysIn` resulted in the address context consisting of the address array indices (rather than the actual addresses).

## Change Type
- Bug Fix

## Testing Steps
1. Imported an address with a BCH balance
2. See that the wallet-level BCH balance remains at 0

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed