### PR TITLE
do not use getOrFail

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/CoinifyExchangeData/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/CoinifyExchangeData/index.js
@@ -117,7 +117,7 @@ const mapStateToProps = state => ({
   data: getData(state),
   signupStep: path(['coinify', 'signupStep'], state),
   signupComplete: path(['coinify', 'signupComplete'], state),
-  trade: selectors.core.data.coinify.getTrade(state).getOrFail('No trade found')
+  trade: selectors.core.data.coinify.getTrade(state).getOrElse()
 })
 
 const enhance = compose(


### PR DESCRIPTION
## Description
I missed this when I went through the `.data` cleanup. We shouldn't use getOrFail here, because the trade is not always required. For a new account, for example, this was breaking the Coinify experience. QA would have been blocked by this.

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

