### PR TITLE
fix(Metadata): pass network to magic from md api

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/kvStore/index.js
+++ b/packages/blockchain-wallet-v4/src/network/api/kvStore/index.js
@@ -63,7 +63,7 @@ export default ({ apiUrl, networks }) => {
     }
 
     return request('PUT', kv.address, body).map(res => {
-      let magicHash = KV.magic(encPayloadBuffer, kv.magicHash)
+      let magicHash = KV.magic(encPayloadBuffer, kv.magicHash, networks.btc)
       return set(KV.magicHash, magicHash, kv)
     })
   }


### PR DESCRIPTION
## Description
1296
Because a `network` was not passed to KV.magic() a function was returned instead and set as the kv's magicHash. The next time a user tried to interact with this entry an error would be thrown because magicHash was not a buffer but a function.

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

