### PR TITLE
fix(SFOX): use body for doc upload PUT

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/sfox/index.js
+++ b/packages/blockchain-wallet-v4/src/network/api/sfox/index.js
@@ -2,7 +2,7 @@ export default () => {
   const uploadVerificationDocument = (url, file) =>
     fetch(url, {
       method: 'PUT',
-      data: file,
+      body: file,
       headers: new Headers({
         'Content-Type': 'application/octet-stream'
       })


### PR DESCRIPTION
## Description
Hotfix for issue where users were uploading docs and sfox received them as 0 byte files

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

