### PR TITLE
fix(shapeShift): sorting trades latest first

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/kvStore/shapeShift/selectors.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/shapeShift/selectors.js
@@ -6,6 +6,8 @@ import {
   head,
   path,
   reverse,
+  sortBy,
+  prop,
   contains
 } from 'ramda'
 import { SHAPESHIFT } from '../config'
@@ -18,6 +20,7 @@ export const getTrades = state =>
   getMetadata(state).map(
     compose(
       reverse,
+      sortBy(prop('timestamp')),
       path(['value', 'trades'])
     )
   )


### PR DESCRIPTION
## Description
fixes 1308

## Change Type
- Bug Fix

## Testing Steps
Use account with trades from v3 and v4.
Trades should be sorted with no dependency on wallet version

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed

