### PR TITLE
Retain functionality with remote data failure

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux'
 import Success from './template.success'
 import { Remote } from 'blockchain-wallet-v4/src'
 import { formValueSelector } from 'redux-form'
+import { values } from 'ramda'
 
 class ImportedAddressesContainer extends React.Component {
   constructor (props) {
@@ -42,7 +43,7 @@ class ImportedAddressesContainer extends React.Component {
   }
 
   render () {
-    const { search } = this.props
+    const { search, addressesWithoutRemoteData } = this.props
     return this.props.activeAddresses.cata({
       Success: value => (
         <Success
@@ -54,7 +55,16 @@ class ImportedAddressesContainer extends React.Component {
           onShowSignMessage={this.handleSignMessage}
         />
       ),
-      Failure: message => <div />,
+      Failure: message => (
+        <Success
+          failure
+          importedAddresses={values(addressesWithoutRemoteData)}
+          onClickImport={this.handleClickImport}
+          search={search && search.toLowerCase()}
+          onToggleArchived={this.handleToggleArchived}
+          onShowSignMessage={this.handleSignMessage}
+        />
+      ),
       Loading: () => <div />,
       NotAsked: () => <div />
     })
@@ -63,7 +73,8 @@ class ImportedAddressesContainer extends React.Component {
 
 const mapStateToProps = state => ({
   activeAddresses: selectors.core.common.btc.getActiveAddresses(state),
-  search: formValueSelector('settingsAddresses')(state, 'search')
+  search: formValueSelector('settingsAddresses')(state, 'search'),
+  addressesWithoutRemoteData: selectors.core.wallet.getAddresses(state)
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/template.success.js
@@ -39,7 +39,8 @@ const Success = ({
   onToggleArchived,
   onShowPriv,
   onShowSignMessage,
-  search
+  search,
+  failure
 }) => {
   const isMatch = address =>
     !search || address.addr.toLowerCase().indexOf(search) > -1
@@ -63,25 +64,25 @@ const Success = ({
             !address.priv
               ? []
               : [
-                  <ClickableText
-                    size='small'
-                    onClick={() => onShowPriv(address)}
-                  >
-                    <FormattedMessage
-                      id='scenes.settings.addresses.show_priv'
-                      defaultMessage='Private Key'
-                    />
-                  </ClickableText>,
-                  <ClickableText
-                    size='small'
-                    onClick={() => onShowSignMessage(address)}
-                  >
-                    <FormattedMessage
-                      id='scenes.settings.addresses.sign_message'
-                      defaultMessage='Sign Message'
-                    />
-                  </ClickableText>
-                ]
+                !failure && <ClickableText
+                  size='small'
+                  onClick={() => onShowPriv(address)}
+                >
+                  <FormattedMessage
+                    id='scenes.settings.addresses.show_priv'
+                    defaultMessage='Private Key'
+                  />
+                </ClickableText>,
+                <ClickableText
+                  size='small'
+                  onClick={() => onShowSignMessage(address)}
+                >
+                  <FormattedMessage
+                    id='scenes.settings.addresses.sign_message'
+                    defaultMessage='Sign Message'
+                  />
+                </ClickableText>
+              ]
           )
         }
       />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
@@ -2,11 +2,10 @@ import React from 'react'
 import { actions } from 'data'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { getData } from './selectors'
-import Success from './template.success'
+import { getData, getWalletsWithoutRemoteData } from './selectors'
+import Template from './template.success'
 import { Remote } from 'blockchain-wallet-v4/src'
 import { formValueSelector } from 'redux-form'
-import DataError from 'components/DataError'
 
 class BitcoinWalletsContainer extends React.Component {
   constructor (props) {
@@ -25,16 +24,16 @@ class BitcoinWalletsContainer extends React.Component {
   handleArchive = (address) => this.props.coreActions.setAddressArchived(address, true)
 
   render () {
-    const { search, data, ...rest } = this.props
+    const { search, data, walletsWithoutRemoteData, modalActions, coreActions, ...rest } = this.props
 
     return data.cata({
       Success: value => (
-        <Success
+        <Template
           wallets={value}
           search={search && search.toLowerCase()}
-          onUnarchive={i => this.props.coreActions.setAccountArchived(i, false)}
+          onUnarchive={i => coreActions.setAccountArchived(i, false)}
           handleClick={() =>
-            this.props.modalActions.showModal('AddBitcoinWallet', {
+            modalActions.showModal('AddBitcoinWallet', {
               wallets: value
             })
           }
@@ -42,7 +41,19 @@ class BitcoinWalletsContainer extends React.Component {
         />
       ),
       Failure: message => (
-          <DataError onClick={this.handleRefresh} onArchive={this.handleArchive} message={message} />
+        <Template
+          failure
+          message={message}
+          wallets={walletsWithoutRemoteData}
+          search={search && search.toLowerCase()}
+          onUnarchive={i => coreActions.setAccountArchived(i, false)}
+          handleClick={() =>
+            modalActions.showModal('AddBitcoinWallet', {
+              wallets: walletsWithoutRemoteData
+            })
+          }
+          {...rest}
+        />
       ),
       Loading: () => <div />,
       NotAsked: () => <div />
@@ -58,7 +69,8 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('settingsAddresses')(state, 'search')
+  search: formValueSelector('settingsAddresses')(state, 'search'),
+  walletsWithoutRemoteData: getWalletsWithoutRemoteData(state)
 })
 
 export default connect(

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
@@ -8,11 +8,6 @@ import { Remote } from 'blockchain-wallet-v4/src'
 import { formValueSelector } from 'redux-form'
 
 class BitcoinWalletsContainer extends React.Component {
-  constructor (props) {
-    super(props)
-    this.handleRefresh = this.handleRefresh.bind(this)
-  }
-
   shouldComponentUpdate (nextProps) {
     return !Remote.Loading.is(nextProps.data)
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
@@ -17,12 +17,6 @@ class BitcoinWalletsContainer extends React.Component {
     return !Remote.Loading.is(nextProps.data)
   }
 
-  handleRefresh () {
-    this.props.actions.fetchData()
-  }
-
-  handleArchive = (address) => this.props.coreActions.setAddressArchived(address, true)
-
   render () {
     const { search, data, walletsWithoutRemoteData, modalActions, coreActions, ...rest } = this.props
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/template.success.js
@@ -37,12 +37,18 @@ const WalletTableCell = styled(TableCell)`
 const LabelCell = styled(Text)`
   margin-right: 6px;
 `
+const ErrorWrapper = styled.div`
+  margin-bottom: 20px;
+`
+const ErrorMessageText = styled(Text)`
+  margin-top: 5px;
+`
 
-const Success = ({ wallets, handleClick, onUnarchive, search }) => {
+const Success = ({ wallets, handleClick, onUnarchive, search, failure, message }) => {
   const isMatch = wallet =>
     !search || wallet.label.toLowerCase().indexOf(search) > -1
 
-  const walletTableRows = filter(isMatch, wallets).map(wallet => {
+  const walletTableRows = wallets && filter(isMatch, wallets).map(wallet => {
     return (
       <TableRow key={wallet.index}>
         <WalletTableCell width='50%'>
@@ -103,6 +109,25 @@ const Success = ({ wallets, handleClick, onUnarchive, search }) => {
 
   return (
     <Wrapper>
+      {
+        failure && <ErrorWrapper>
+          <Banner type='warning'>
+            <Text size='14px' color='error'>
+              <FormattedMessage
+                id='scenes.settings.addresses.btc.failurealert'
+                defaultMessage='There is an issue with the wallet and this page may have limited functionality, such as balances not showing.'
+              />
+              <ErrorMessageText size='14px' color='error'>
+                <FormattedMessage
+                  id='scenes.settings.addresses.btc.failuremessage'
+                  defaultMessage='Message: {errorMessage}'
+                  values={{ errorMessage: message || <span>Please contact<Link size='14px' href='https://support.blockchain.com/hc/en-us/requests/new' target='_blank'>support</Link> for help resolving the problem</span> }}
+                />
+              </ErrorMessageText>
+            </Text>
+          </Banner>
+        </ErrorWrapper>
+      }
       <BitcoinWalletsAddressesSettingHeader>
         <FormattedMessage
           id='scenes.settings.addresses.btc.wallets.bitcoinwallets'


### PR DESCRIPTION
## Description
Related to https://github.com/blockchain/blockchain-wallet-v4-frontend/issues/998

## Change Type
Please enter one or more of the following: 
- Feature

## Testing Steps
1) on prod, import a vulnerable address (1AzoywD7PezZoVV2YeRcrrfBb6KEhYYW9Z, for ex)
2) go to settings --> wallets
3) the page should still be usable


## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed

