### PR TITLE
Coinify use payment redirect url

### DIFF
--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -142,8 +142,9 @@
         "config": {
           "production": false,
           "availability": true,
-          "partnerId": 24,
+          "partnerId": 35,
           "iSignThisDomain": "https://stage-verify.isignthis.com",
+          "coinifyPaymentDomain": "https://pay.sandbox.coinify.com",
           "surveyLinks": [
             "https://blockchain.co1.qualtrics.com/SE/?SID=SV_8pupOEQPGkXx8Kp",
             "https://blockchain.co1.qualtrics.com/jfe/form/SV_205rqJvYy7mRxnn",

--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -142,7 +142,7 @@
         "config": {
           "production": false,
           "availability": true,
-          "partnerId": 35,
+          "partnerId": 24,
           "iSignThisDomain": "https://stage-verify.isignthis.com",
           "coinifyPaymentDomain": "https://pay.sandbox.coinify.com",
           "surveyLinks": [

--- a/packages/blockchain-wallet-v4-frontend/src/modals/CoinifyExchangeData/ISignThis/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/CoinifyExchangeData/ISignThis/index.js
@@ -111,6 +111,9 @@ class ISignThisContainer extends Component {
     const iSignThisDomain = this.props.walletOptions
       .map(path(['platforms', 'web', 'coinify', 'config', 'iSignThisDomain']))
       .getOrElse(null)
+    const coinifyPaymentDomain = this.props.walletOptions
+      .map(path(['platforms', 'web', 'coinify', 'config', 'coinifyPaymentDomain']))
+      .getOrElse(null)
 
     var _isx = {
       transactionId: '',
@@ -170,8 +173,8 @@ class ISignThisContainer extends Component {
         function (e) {
           // Check for the domain who sent the messageEvent
           let origin = e.origin || e.originalEvent.origin
-          if (origin !== iSignThisDomain) {
-            // Event not generated from ISX, simply return
+          if ( ![iSignThisDomain, coinifyPaymentDomain].includes(origin) ) {
+            // Event not generated from ISX or coinifyPaymentDomain, simply return
             return
           }
 
@@ -258,8 +261,12 @@ class ISignThisContainer extends Component {
       ['platforms', 'web', 'coinify', 'config', 'iSignThisDomain'],
       walletOpts
     )
-    const srcUrl = `${iSignThisDomain}/landing/${iSignThisId}?embed=true`
+
     const isxType = path(['data', 'constructor', 'name'], trade)
+
+    const srcUrl = isxType !== 'Trade' ?
+      `${iSignThisDomain}/landing/${iSignThisId}?embed=true` : // Url for KYC
+      `${iSignThisId}` // Url for payment
 
     return (
       <Fragment>

--- a/packages/blockchain-wallet-v4-frontend/webpack.config.dev.js
+++ b/packages/blockchain-wallet-v4-frontend/webpack.config.dev.js
@@ -13,7 +13,9 @@ const PATHS = require('../../config/paths')
 const mockWalletOptions = require('../../config/mocks/wallet-options-v4.json')
 const runBundleAnalyzer = process.env.ANALYZE
 const iSignThisDomain =
-  mockWalletOptions.platforms.web.coinify.config.iSignThisDomain
+  mockWalletOptions.platforms.web.coinify.config.iSignThisDomain;
+const coinifyPaymentDomain =
+  mockWalletOptions.platforms.web.coinify.config.coinifyPaymentDomain;
 
 let envConfig = {}
 let manifestCacheBust = new Date().getTime()
@@ -250,10 +252,10 @@ module.exports = {
         "img-src 'self' data: blob:",
         "script-src 'self' 'unsafe-eval'",
         "style-src 'self' 'unsafe-inline'",
-        `frame-src ${iSignThisDomain} ${envConfig.WALLET_HELPER_DOMAIN} ${
+        `frame-src ${iSignThisDomain} ${coinifyPaymentDomain} ${envConfig.WALLET_HELPER_DOMAIN} ${
           envConfig.ROOT_URL
         } https://localhost:8080 http://localhost:8080`,
-        `child-src ${iSignThisDomain} ${envConfig.WALLET_HELPER_DOMAIN} blob:`,
+        `child-src ${iSignThisDomain} ${coinifyPaymentDomain} ${envConfig.WALLET_HELPER_DOMAIN} blob:`,
         [
           'connect-src',
           "'self'",

--- a/packages/blockchain-wallet-v4-frontend/webpack.debug.js
+++ b/packages/blockchain-wallet-v4-frontend/webpack.debug.js
@@ -10,7 +10,9 @@ const fs = require('fs')
 const PATHS = require('../../config/paths')
 const mockWalletOptions = require('../../config/mocks/wallet-options-v4.json')
 const iSignThisDomain =
-  mockWalletOptions.platforms.web.coinify.config.iSignThisDomain
+  mockWalletOptions.platforms.web.coinify.config.iSignThisDomain;
+const coinifyPaymentDomain =
+  mockWalletOptions.platforms.web.coinify.config.coinifyPaymentDomain;
 
 let envConfig = {}
 let manifestCacheBust = new Date().getTime()
@@ -241,10 +243,10 @@ module.exports = {
         "img-src 'self' data: blob:",
         "script-src 'self'",
         "style-src 'self' 'unsafe-inline'",
-        `frame-src ${iSignThisDomain} ${envConfig.WALLET_HELPER_DOMAIN} ${
+        `frame-src ${iSignThisDomain} ${coinifyPaymentDomain} ${envConfig.WALLET_HELPER_DOMAIN} ${
           envConfig.ROOT_URL
         } https://localhost:8080 http://localhost:8080`,
-        `child-src ${iSignThisDomain} ${envConfig.WALLET_HELPER_DOMAIN} blob:`,
+        `child-src ${iSignThisDomain} ${coinifyPaymentDomain} ${envConfig.WALLET_HELPER_DOMAIN} blob:`,
         [
           'connect-src',
           "'self'",


### PR DESCRIPTION
## Description
Use Coinify's redirect URL to show payment page instead of embedded iST.

## Change Type
- Feature

## Testing Steps
Create a buy BTC transaction and pay with credit card.

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] No lint issues exist (verified via `yarn lint`)
- [x] New and existing unit tests pass (verified via `yarn test`)
- [x] `README.md` and other documentation is updated as needed
