### PR TITLE
Feat(Service announcements fix & redux-persist v5 migration)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/package.json
+++ b/packages/blockchain-wallet-v4-frontend/package.json
@@ -136,7 +136,7 @@
     "redux": "3.6.0",
     "redux-form": "7.3.0",
     "redux-logger": "3.0.6",
-    "redux-persist": "4.8.3",
+    "redux-persist": "5.7.0",
     "redux-saga": "0.16.0",
     "redux-ui": "0.1.1",
     "reselect": "3.0.1",

--- a/packages/blockchain-wallet-v4-frontend/src/components/Announcements/Service/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Announcements/Service/selectors.js
@@ -16,20 +16,12 @@ export const getData = (state, ownProps) =>
         const announcement = announcements[ownProps.alertArea]
         const cachedState =
           announcementCached && announcementCached[announcement.id]
-        const isCacheLoaded = announcementCached !== undefined
 
         return {
           announcements: announcements,
-          collapsed:
-            cachedState && cachedState.collapsed
-              ? cachedState.collapsed
-              : false,
+          collapsed: cachedState && cachedState.collapsed,
           language: language,
-          showAnnounce: !isCacheLoaded
-            ? false
-            : announcementCached[announcement.id]
-              ? !announcementCached[announcement.id].dismissed
-              : true
+          showAnnounce: !(cachedState && cachedState.dismissed)
         }
       } else {
         return { announcements: {} }

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/sendBch/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/sendBch/sagas.spec.js
@@ -3,6 +3,7 @@ import { expectSaga, testSaga } from 'redux-saga-test-plan'
 import { initialize } from 'redux-form'
 import { path, prop } from 'ramda'
 import { call } from 'redux-saga-test-plan/matchers'
+import { combineReducers } from 'redux'
 
 import rootReducer from '../../rootReducer'
 import { coreSagasFactory, Remote } from 'blockchain-wallet-v4/src'
@@ -189,7 +190,7 @@ describe('sendBch sagas', () => {
 
       beforeEach(async () => {
         resultingState = await expectSaga(initialized, { payload })
-          .withReducer(rootReducer)
+          .withReducer(combineReducers(rootReducer))
           .provide([
             [
               select(selectors.core.common.bch.getAccountsBalances),

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/sendBtc/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/sendBtc/sagas.spec.js
@@ -3,6 +3,7 @@ import { expectSaga, testSaga } from 'redux-saga-test-plan'
 import { initialize } from 'redux-form'
 import { path, prop } from 'ramda'
 import { call } from 'redux-saga-test-plan/matchers'
+import { combineReducers } from 'redux'
 
 import rootReducer from '../../rootReducer'
 import { coreSagasFactory, Remote } from 'blockchain-wallet-v4/src'
@@ -199,7 +200,7 @@ describe('sendBtc sagas', () => {
 
       beforeEach(async () => {
         resultingState = await expectSaga(initialized, { payload })
-          .withReducer(rootReducer)
+          .withReducer(combineReducers(rootReducer))
           .provide([
             [
               select(selectors.core.common.btc.getAccountsBalances),

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/sendEth/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/sendEth/sagas.spec.js
@@ -1,6 +1,7 @@
 import { expectSaga, testSaga } from 'redux-saga-test-plan'
 import { initialize } from 'redux-form'
 import { path, prop } from 'ramda'
+import { combineReducers } from 'redux'
 
 import rootReducer from '../../rootReducer'
 import { coreSagasFactory, Remote } from 'blockchain-wallet-v4/src'
@@ -171,7 +172,7 @@ describe('sendEth sagas', () => {
 
       beforeEach(async () => {
         resultingState = await expectSaga(initialized, { payload })
-          .withReducer(rootReducer)
+          .withReducer(combineReducers(rootReducer))
           .run()
           .then(prop('storeState'))
       })

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/sendXlm/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/sendXlm/sagas.spec.js
@@ -1,6 +1,7 @@
 import { expectSaga, testSaga } from 'redux-saga-test-plan'
 import { initialize, touch } from 'redux-form'
 import { path, prop } from 'ramda'
+import { combineReducers } from 'redux'
 
 import rootReducer from '../../rootReducer'
 import { coreSagasFactory, Remote } from 'blockchain-wallet-v4/src'
@@ -151,7 +152,7 @@ describe('sendXlm sagas', () => {
 
       beforeEach(async () => {
         resultingState = await expectSaga(initialized, { payload })
-          .withReducer(rootReducer)
+          .withReducer(combineReducers(rootReducer))
           .run()
           .then(prop('storeState'))
       })

--- a/packages/blockchain-wallet-v4-frontend/src/data/rootReducer.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/rootReducer.js
@@ -1,4 +1,3 @@
-import { combineReducers } from 'redux'
 import { reducer as reduxUiReducer } from 'redux-ui'
 import { coreReducers, paths } from 'blockchain-wallet-v4/src'
 import componentsReducer from './components/reducers'
@@ -20,7 +19,7 @@ import settingsReducer from './modules/settings/reducers.js'
 import sfoxSignupReducer from './modules/sfox/reducers.js'
 import qaReducer from './modules/qa/reducers.js'
 
-const rootReducer = combineReducers({
+const rootReducer = {
   alerts: alertsReducer,
   auth: authReducer,
   coinify: coinifyReducer,
@@ -45,6 +44,6 @@ const rootReducer = combineReducers({
   [paths.settingsPath]: coreReducers.settings,
   [paths.walletOptionsPath]: coreReducers.walletOptions,
   [paths.kvStorePath]: coreReducers.kvStore
-})
+}
 
 export default rootReducer

--- a/packages/blockchain-wallet-v4-frontend/src/index.dev.js
+++ b/packages/blockchain-wallet-v4-frontend/src/index.dev.js
@@ -8,23 +8,34 @@ import configureLocales from 'services/LocalesService'
 import App from 'scenes/app.js'
 import Error from './index.error'
 
-const renderApp = (Component, store, history) => {
+const renderApp = (Component, store, history, persistor) => {
   const { messages } = configureLocales(store)
 
-  const render = (Component, store, history, messages) => {
+  const render = (Component, store, history, messages, persistor) => {
     ReactDOM.render(
       <AppContainer key={Math.random()} warnings={false}>
-        <Component store={store} history={history} messages={messages} />
+        <Component
+          store={store}
+          history={history}
+          messages={messages}
+          persistor={persistor}
+        />
       </AppContainer>,
       document.getElementById('app')
     )
   }
 
-  render(App, store, history, messages)
+  render(App, store, history, messages, persistor)
 
   if (module.hot) {
     module.hot.accept('./scenes/app.js', () =>
-      render(require('./scenes/app.js').default, store, history, messages)
+      render(
+        require('./scenes/app.js').default,
+        store,
+        history,
+        messages,
+        persistor
+      )
     )
   }
 }
@@ -35,12 +46,9 @@ const renderError = e => {
   ReactDOM.render(<Error />, document.getElementById('app'))
 }
 
-// =============================================================================
-// ================================= APP =======================================
-// =============================================================================
 configureStore()
-  .then(x => {
-    renderApp(App, x.store, x.history)
+  .then(root => {
+    renderApp(App, root.store, root.history, root.persistor)
   })
   .catch(e => {
     renderError(e)

--- a/packages/blockchain-wallet-v4-frontend/src/index.prod.js
+++ b/packages/blockchain-wallet-v4-frontend/src/index.prod.js
@@ -7,10 +7,15 @@ import configureLocales from 'services/LocalesService'
 import App from 'scenes/app.js'
 import Error from './index.error'
 
-const renderApp = (Component, store, history) => {
+const renderApp = (Component, store, history, persistor) => {
   const { messages } = configureLocales(store)
   ReactDOM.render(
-    <Component store={store} history={history} messages={messages} />,
+    <Component
+      store={store}
+      history={history}
+      messages={messages}
+      persistor={persistor}
+    />,
     document.getElementById('app')
   )
 }
@@ -19,12 +24,9 @@ const renderError = () => {
   ReactDOM.render(<Error />, document.getElementById('app'))
 }
 
-// =============================================================================
-// ================================= APP =======================================
-// =============================================================================
 configureStore()
-  .then(x => {
-    renderApp(App, x.store, x.history)
+  .then(root => {
+    renderApp(App, root.store, root.history, root.persistor)
   })
   .catch(e => {
     renderError(e)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/app.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/app.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Redirect, Switch } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import { ConnectedRouter } from 'connected-react-router'
+import { PersistGate } from 'redux-persist/integration/react'
 
 import { MediaContextProvider } from 'providers/MatchMediaProvider'
 import ConnectedIntlProvider from 'providers/ConnectedIntlProvider'
@@ -38,114 +39,122 @@ import Transactions from './Transactions'
 
 class App extends React.PureComponent {
   render () {
-    const { store, history, messages } = this.props
+    const { store, history, messages, persistor } = this.props
     return (
       <Provider store={store}>
         <ConnectedIntlProvider messages={messages}>
-          <ThemeProvider>
-            <MediaContextProvider>
-              <ConnectedRouter history={history}>
-                <Switch>
-                  <PublicLayout path='/login' component={Login} />
-                  <PublicLayout path='/logout' component={Logout} />
-                  <PublicLayout path='/help' component={Help} />
-                  <PublicLayout path='/recover' component={Recover} />
-                  <PublicLayout path='/reminder' component={Reminder} />
-                  <PublicLayout path='/reset-2fa' component={Reset2FA} />
-                  <PublicLayout
-                    path='/reset-two-factor'
-                    component={Reset2FAToken}
-                  />
-                  <PublicLayout
-                    path='/verify-email'
-                    component={VerifyEmailToken}
-                  />
-                  <PublicLayout path='/signup' component={Register} />
-                  <PublicLayout
-                    path='/authorize-approve'
-                    component={AuthorizeLogin}
-                  />
-                  <PublicLayout
-                    path='/upload-document/success'
-                    component={UploadDocumentsSuccess}
-                    exact
-                  />
-                  <PublicLayout
-                    path='/upload-document/:token'
-                    component={UploadDocuments}
-                  />
-                  <PublicLayout path='/wallet' component={Login} />
-                  <WalletLayout path='/home' component={Home} />
-                  <WalletLayout path='/buy-sell' component={BuySell} />
-                  <WalletLayout
-                    path='/btc/transactions'
-                    component={Transactions}
-                    coin='BTC'
-                  />
-                  <WalletLayout
-                    path='/eth/transactions'
-                    component={Transactions}
-                    coin='ETH'
-                  />
-                  <WalletLayout
-                    path='/bch/transactions'
-                    component={Transactions}
-                    coin='BCH'
-                  />
-                  <WalletLayout
-                    path='/xlm/transactions'
-                    component={Transactions}
-                    coin='XLM'
-                  />
-                  <WalletLayout
-                    path='/exchange/history'
-                    component={ExchangeHistory}
-                  />
-                  <WalletLayout path='/exchange' component={Exchange} exact />
-                  <WalletLayout
-                    path='/security-center'
-                    component={SecurityCenter}
-                  />
-                  <WalletLayout path='/settings/profile' component={Profile} />
-                  <WalletLayout
-                    path='/settings/preferences'
-                    component={Preferences}
-                  />
-                  <WalletLayout
-                    path='/settings/addresses/btc/:index'
-                    component={BtcManageAddresses}
-                  />
-                  <WalletLayout
-                    path='/settings/addresses/btc'
-                    component={Addresses}
-                    exact
-                  />
-                  <WalletLayout
-                    path='/settings/addresses/bch'
-                    component={BchAddresses}
-                  />
-                  <WalletLayout path='/settings/general' component={General} />
-                  <WalletLayout path='/lockbox' component={Lockbox} exact />
-                  <WalletLayout
-                    path='/lockbox/dashboard/:deviceIndex'
-                    component={LockboxDashboard}
-                    exact
-                  />
-                  <WalletLayout
-                    path='/lockbox/onboard'
-                    component={LockboxOnboard}
-                    exact
-                  />
-                  <WalletLayout
-                    path='/lockbox/settings/:deviceIndex'
-                    component={LockboxDashboard}
-                    exact
-                  />
-                  <Redirect from='/' to='/login' />
-                </Switch>
-              </ConnectedRouter>
-            </MediaContextProvider>
-          </ThemeProvider>
+          <PersistGate loading={null} persistor={persistor}>
+            <ThemeProvider>
+              <MediaContextProvider>
+                <ConnectedRouter history={history}>
+                  <Switch>
+                    <PublicLayout path='/login' component={Login} />
+                    <PublicLayout path='/logout' component={Logout} />
+                    <PublicLayout path='/help' component={Help} />
+                    <PublicLayout path='/recover' component={Recover} />
+                    <PublicLayout path='/reminder' component={Reminder} />
+                    <PublicLayout path='/reset-2fa' component={Reset2FA} />
+                    <PublicLayout
+                      path='/reset-two-factor'
+                      component={Reset2FAToken}
+                    />
+                    <PublicLayout
+                      path='/verify-email'
+                      component={VerifyEmailToken}
+                    />
+                    <PublicLayout path='/signup' component={Register} />
+                    <PublicLayout
+                      path='/authorize-approve'
+                      component={AuthorizeLogin}
+                    />
+                    <PublicLayout
+                      path='/upload-document/success'
+                      component={UploadDocumentsSuccess}
+                      exact
+                    />
+                    <PublicLayout
+                      path='/upload-document/:token'
+                      component={UploadDocuments}
+                    />
+                    <PublicLayout path='/wallet' component={Login} />
+                    <WalletLayout path='/home' component={Home} />
+                    <WalletLayout path='/buy-sell' component={BuySell} />
+                    <WalletLayout
+                      path='/btc/transactions'
+                      component={Transactions}
+                      coin='BTC'
+                    />
+                    <WalletLayout
+                      path='/eth/transactions'
+                      component={Transactions}
+                      coin='ETH'
+                    />
+                    <WalletLayout
+                      path='/bch/transactions'
+                      component={Transactions}
+                      coin='BCH'
+                    />
+                    <WalletLayout
+                      path='/xlm/transactions'
+                      component={Transactions}
+                      coin='XLM'
+                    />
+                    <WalletLayout
+                      path='/exchange/history'
+                      component={ExchangeHistory}
+                    />
+                    <WalletLayout path='/exchange' component={Exchange} exact />
+                    <WalletLayout
+                      path='/security-center'
+                      component={SecurityCenter}
+                    />
+                    <WalletLayout
+                      path='/settings/profile'
+                      component={Profile}
+                    />
+                    <WalletLayout
+                      path='/settings/preferences'
+                      component={Preferences}
+                    />
+                    <WalletLayout
+                      path='/settings/addresses/btc/:index'
+                      component={BtcManageAddresses}
+                    />
+                    <WalletLayout
+                      path='/settings/addresses/btc'
+                      component={Addresses}
+                      exact
+                    />
+                    <WalletLayout
+                      path='/settings/addresses/bch'
+                      component={BchAddresses}
+                    />
+                    <WalletLayout
+                      path='/settings/general'
+                      component={General}
+                    />
+                    <WalletLayout path='/lockbox' component={Lockbox} exact />
+                    <WalletLayout
+                      path='/lockbox/dashboard/:deviceIndex'
+                      component={LockboxDashboard}
+                      exact
+                    />
+                    <WalletLayout
+                      path='/lockbox/onboard'
+                      component={LockboxOnboard}
+                      exact
+                    />
+                    <WalletLayout
+                      path='/lockbox/settings/:deviceIndex'
+                      component={LockboxDashboard}
+                      exact
+                    />
+                    <Redirect from='/' to='/login' />
+                  </Switch>
+                </ConnectedRouter>
+              </MediaContextProvider>
+            </ThemeProvider>
+          </PersistGate>
         </ConnectedIntlProvider>
       </Provider>
     )

--- a/packages/blockchain-wallet-v4-frontend/src/store/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/store/index.js
@@ -2,8 +2,13 @@ import { createStore, applyMiddleware, compose } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 import { persistStore, persistCombineReducers } from 'redux-persist'
 import storage from 'redux-persist/lib/storage'
+import getStoredStateMigrateV4 from 'redux-persist/lib/integration/getStoredStateMigrateV4'
 import { createHashHistory } from 'history'
 import { connectRouter, routerMiddleware } from 'connected-react-router'
+import { head } from 'ramda'
+import Bitcoin from 'bitcoinjs-lib'
+import BitcoinCash from 'bitcoinforksjs-lib'
+
 import appConfig from 'config'
 import { coreMiddleware } from 'blockchain-wallet-v4/src'
 import {
@@ -22,9 +27,6 @@ import {
   webSocketEth,
   webSocketRates
 } from '../middleware'
-import { head } from 'ramda'
-import Bitcoin from 'bitcoinjs-lib'
-import BitcoinCash from 'bitcoinforksjs-lib'
 
 const devToolsConfig = {
   maxAge: 1000,
@@ -95,14 +97,18 @@ const configureStore = () => {
         getAuthCredentials,
         networks
       })
+      const persistWhitelist = ['session', 'preferences', 'cache']
 
       const store = createStore(
         connectRouter(history)(
           persistCombineReducers(
             {
+              getStoredState: getStoredStateMigrateV4({
+                whitelist: persistWhitelist
+              }),
               key: 'root',
               storage,
-              whitelist: ['session', 'preferences', 'cache']
+              whitelist: persistWhitelist
             },
             rootReducer
           )

--- a/packages/blockchain-wallet-v4-frontend/src/store/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/store/index.js
@@ -100,7 +100,7 @@ const configureStore = () => {
         connectRouter(history)(
           persistCombineReducers(
             {
-              key: 'primary',
+              key: 'root',
               storage,
               whitelist: ['session', 'preferences', 'cache']
             },

--- a/packages/blockchain-wallet-v4-frontend/src/store/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/store/index.js
@@ -99,6 +99,7 @@ const configureStore = () => {
       })
       const persistWhitelist = ['session', 'preferences', 'cache']
 
+      // TODO: remove getStoredStateMigrateV4 someday (at least a year from now)
       const store = createStore(
         connectRouter(history)(
           persistCombineReducers(

--- a/packages/blockchain-wallet-v4-frontend/src/store/index.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/store/index.spec.js
@@ -7,45 +7,33 @@ import {
   ApiSocket,
   Socket
 } from 'blockchain-wallet-v4/src/network'
-import { persistStore, autoRehydrate } from 'redux-persist'
+import { persistStore } from 'redux-persist'
 // setup mocks
-jest.mock('redux-saga', () => () => {
-  return {
-    run: () => {
-      jest.fn()
-    }
-  }
-})
+jest.mock('redux-saga', () => () => ({
+  run: () => jest.fn()
+}))
 
-jest.mock('redux-persist', () => {
-  return {
-    autoRehydrate: jest.fn(),
-    persistStore: jest.fn()
-  }
-})
+jest.mock('redux-persist', () => ({
+  persistCombineReducers: jest.fn(),
+  persistStore: jest.fn()
+}))
 
-jest.mock('connected-react-router', () => {
-  return {
-    connectRouter: () => () => jest.fn(),
-    routerMiddleware: jest.fn()
-  }
-})
+jest.mock('connected-react-router', () => ({
+  connectRouter: () => () => jest.fn(),
+  routerMiddleware: jest.fn()
+}))
 
-jest.mock('blockchain-wallet-v4/src/network', () => {
-  return {
-    Socket: jest.fn().mockImplementation(() => 'FAKE_SOCKET'),
-    ApiSocket: jest.fn().mockImplementation(() => 'FAKE_API_SOCKET'),
-    createWalletApi: jest.fn().mockImplementation(() => 'FAKE_WALLET_API'),
-    HorizonStreamingService: jest.fn()
-  }
-})
+jest.mock('blockchain-wallet-v4/src/network', () => ({
+  Socket: jest.fn().mockImplementation(() => 'FAKE_SOCKET'),
+  ApiSocket: jest.fn().mockImplementation(() => 'FAKE_API_SOCKET'),
+  createWalletApi: jest.fn().mockImplementation(() => 'FAKE_WALLET_API'),
+  HorizonStreamingService: jest.fn()
+}))
 
-jest.mock('config', () => {
-  return {
-    WALLET_PAYLOAD_PATH: 'MOCK_WALLET_PATH',
-    WALLET_KVSTORE_PATH: 'MOCK_KVSTORE_PATH'
-  }
-})
+jest.mock('config', () => ({
+  WALLET_PAYLOAD_PATH: 'MOCK_WALLET_PATH',
+  WALLET_KVSTORE_PATH: 'MOCK_KVSTORE_PATH'
+}))
 
 describe('App Store Config', () => {
   let apiKey = '1770d5d9-bcea-4d28-ad21-6cbd5be018a8'
@@ -168,14 +156,11 @@ describe('App Store Config', () => {
     // middleware compose
     expect(composeSpy).toHaveBeenCalledTimes(1)
     expect(applyMiddlewareSpy).toHaveBeenCalledTimes(1)
-    expect(autoRehydrate.mock.calls.length).toBe(1)
     // store creation
     expect(createStoreSpy).toHaveBeenCalledTimes(1)
     expect(persistStore.mock.calls.length).toBe(1)
     expect(persistStore.mock.calls[0][0]).toEqual(expect.any(Object))
-    expect(persistStore.mock.calls[0][1]).toEqual({
-      whitelist: ['session', 'preferences', 'cache']
-    })
+    expect(persistStore.mock.calls[0][1]).toEqual(null)
     expect(mockStore.history).toBeDefined()
     expect(mockStore.store).toBeDefined()
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10085,7 +10085,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.4, lodash-es@^4.17.5, lodash-es@^4.2.1:
+lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
@@ -13220,14 +13220,10 @@ redux-mock-store@1.5.3:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-redux-persist@4.8.3:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.8.3.tgz#fbad95e7582483635c91a3dd83da4789e7a09107"
-  integrity sha512-d5hkgy+Ue+p82o8DAUsWTRZfPmA2ecduaDKNU9FppJiIoXGn2qU+5igb8CwzJ6Xm7y3oQbADiGc+TEIxnyPo6g==
-  dependencies:
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.4"
-    lodash-es "^4.17.4"
+redux-persist@5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.7.0.tgz#b2d9a7c885b1ba29dd802106899970943072390d"
+  integrity sha512-syOx6uBbDf6nmU9YdwviGRTP5xTnDMvQokUtPt8mU0ohiOgr/FqiEZN1hsQ8DdkX9vbB8kETAh5o/jduwKTTig==
 
 redux-saga-test-plan@3.7.0:
   version "3.7.0"


### PR DESCRIPTION
## Description
- Fix to ensure service announcements show even when there is cache miss for announcement states (e.g. incognito browsing)
- Easiest fix was to update to v5 of `redux-persist` that adds the `PersistGate` component that will not render the UI until the cache is completely loaded. Without this there would be screen flickering of the banner if it was previously dismissed
- Followed the v4 to v5 migration guide [here](https://github.com/rt2zz/redux-persist/blob/master/docs/MigrationGuide-v5.md#experimental-v4-to-v5-state-migration)

## Change Type
- Bug Fix
- Upgrades

## Testing Steps
- Ensure your wallet GUID is still being auto-loaded from cache upon signon

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed