### PR TITLE
Fix(XLM KvStore fetch)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/lockbox/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/lockbox/sagas.js
@@ -245,19 +245,8 @@ export default ({ api }) => {
             deviceType,
             transport
           )
-          if (publicKey) {
-            entry = Lockbox.utils.generateXlmAccountMDEntry(
-              deviceName,
-              publicKey
-            )
-            yield put(
-              actions.core.kvStore.lockbox.addCoinEntry(
-                deviceIndex,
-                coin,
-                entry
-              )
-            )
-          }
+          if (!publicKey) throw new Error('No XLM public key found')
+          entry = Lockbox.utils.generateXlmAccountMDEntry(deviceName, publicKey)
           yield put(actions.components.lockbox.setConnectionSuccess())
           yield delay(2000)
           yield put(actions.modals.closeAllModals())
@@ -265,6 +254,9 @@ export default ({ api }) => {
         default:
           throw new Error('unknown coin type')
       }
+      yield put(
+        actions.core.kvStore.lockbox.addCoinEntry(deviceIndex, coin, entry)
+      )
       yield take(
         actionTypes.core.kvStore.lockbox.FETCH_METADATA_LOCKBOX_SUCCESS
       )

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/lockbox/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/lockbox/sagas.js
@@ -245,7 +245,19 @@ export default ({ api }) => {
             deviceType,
             transport
           )
-          entry = Lockbox.utils.generateXlmAccountMDEntry(deviceName, publicKey)
+          if (publicKey) {
+            entry = Lockbox.utils.generateXlmAccountMDEntry(
+              deviceName,
+              publicKey
+            )
+            yield put(
+              actions.core.kvStore.lockbox.addCoinEntry(
+                deviceIndex,
+                coin,
+                entry
+              )
+            )
+          }
           yield put(actions.components.lockbox.setConnectionSuccess())
           yield delay(2000)
           yield put(actions.modals.closeAllModals())
@@ -253,9 +265,6 @@ export default ({ api }) => {
         default:
           throw new Error('unknown coin type')
       }
-      yield put(
-        actions.core.kvStore.lockbox.addCoinEntry(deviceIndex, coin, entry)
-      )
       yield take(
         actionTypes.core.kvStore.lockbox.FETCH_METADATA_LOCKBOX_SUCCESS
       )

--- a/packages/blockchain-wallet-v4-frontend/src/middleware/streamingXlm.js
+++ b/packages/blockchain-wallet-v4-frontend/src/middleware/streamingXlm.js
@@ -1,4 +1,14 @@
-import { compose, head, indexBy, map, pathOr, prop, unnest } from 'ramda'
+import {
+  compose,
+  head,
+  indexBy,
+  isNil,
+  map,
+  pathOr,
+  prop,
+  reject,
+  unnest
+} from 'ramda'
 import { actions, actionTypes } from 'data'
 
 const logLocation = 'middleware/streamingXlm'
@@ -50,7 +60,7 @@ const streamingMiddleware = (streamingService, api) => {
         map(prop('publicKey')),
         pathOr([], ['value', 'accounts'])
       )(payload)
-      addStreams(accountIds)
+      addStreams(reject(id => isNil(id), accountIds))
     }
     if (
       type === actionTypes.core.kvStore.lockbox.FETCH_METADATA_LOCKBOX_SUCCESS
@@ -61,7 +71,7 @@ const streamingMiddleware = (streamingService, api) => {
         map(pathOr([], ['xlm', 'accounts'])),
         pathOr([], ['value', 'devices'])
       )(payload)
-      addStreams(accountIds)
+      addStreams(reject(id => isNil(id), accountIds))
     }
     if (type === actionTypes.middleware.webSocket.xlm.STOP_STREAMS) {
       streamingService.close()

--- a/packages/blockchain-wallet-v4-frontend/src/middleware/streamingXlm.js
+++ b/packages/blockchain-wallet-v4-frontend/src/middleware/streamingXlm.js
@@ -60,7 +60,7 @@ const streamingMiddleware = (streamingService, api) => {
         map(prop('publicKey')),
         pathOr([], ['value', 'accounts'])
       )(payload)
-      addStreams(reject(id => isNil(id), accountIds))
+      addStreams(reject(isNil, accountIds))
     }
     if (
       type === actionTypes.core.kvStore.lockbox.FETCH_METADATA_LOCKBOX_SUCCESS
@@ -71,7 +71,7 @@ const streamingMiddleware = (streamingService, api) => {
         map(pathOr([], ['xlm', 'accounts'])),
         pathOr([], ['value', 'devices'])
       )(payload)
-      addStreams(reject(id => isNil(id), accountIds))
+      addStreams(reject(isNil, accountIds))
     }
     if (type === actionTypes.middleware.webSocket.xlm.STOP_STREAMS) {
       streamingService.close()


### PR DESCRIPTION
## Description
- Removes falsey values from accountId list before starting XLM stream
- Ensures future writes to Lockbox kvstore always have a public key

## Change Type
- Bug Fix
- CI/CD

## Testing Steps
- Wallets with Lockbox and kvStore XLM fetch errors should now load

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] No lint issues exist (verified via `yarn lint`)
- [ ] New and existing unit tests pass (verified via `yarn test`)
- [ ] `README.md` and other documentation is updated as needed