### PR TITLE
Imported Address Request

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Bch/RequestBch/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Bch/RequestBch/index.js
@@ -83,8 +83,8 @@ class RequestBchContainer extends React.PureComponent {
           handleSubmit={this.handleSubmit}
           type={value.type}
           closeAll={closeAll}
-          excludeLockbox={value.excludeLockbox}
-          requestToImportedAddress={this.props.requestToImportedAddress}
+          excludeLockbox={value.excludeLocokbox}
+          receiveAddressFromProps={this.props.receiveAddressFromProps}
         />
       ),
       NotAsked: () => <DataError onClick={this.handleRefresh} />,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Bch/RequestBch/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Bch/RequestBch/index.js
@@ -84,6 +84,7 @@ class RequestBchContainer extends React.PureComponent {
           type={value.type}
           closeAll={closeAll}
           excludeLockbox={value.excludeLockbox}
+          requestToImportedAddress={this.props.requestToImportedAddress}
         />
       ),
       NotAsked: () => <DataError onClick={this.handleRefresh} />,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Bch/RequestBch/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Bch/RequestBch/selectors.js
@@ -42,14 +42,16 @@ export const getData = (state, ownProps) => {
   const type = prop('type', to)
 
   const initialValuesR = getInitialValues(state, ownProps)
-  const receiveAddressR = extractAddress(
-    getReceiveAddressWallet,
-    getReceiveAddressLockbox,
-    to
-  ).map(
-    address =>
-      address && isCashAddr(address) ? address : toCashAddr(address, true)
-  )
+  const receiveAddressR = !prop('requestToImportedAddress', ownProps)
+    ? extractAddress(
+      getReceiveAddressWallet,
+      getReceiveAddressLockbox,
+      to
+    ).map(
+      address =>
+        address && isCashAddr(address) ? address : toCashAddr(address, true)
+    )
+    : Remote.of(prop('requestToImportedAddress', ownProps))
 
   const transform = (receiveAddress, initialValues) => ({
     type,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Bch/RequestBch/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Bch/RequestBch/selectors.js
@@ -42,7 +42,7 @@ export const getData = (state, ownProps) => {
   const type = prop('type', to)
 
   const initialValuesR = getInitialValues(state, ownProps)
-  const receiveAddressR = !prop('requestToImportedAddress', ownProps)
+  const receiveAddressR = !prop('receiveAddressFromProps', ownProps)
     ? extractAddress(
       getReceiveAddressWallet,
       getReceiveAddressLockbox,
@@ -51,7 +51,7 @@ export const getData = (state, ownProps) => {
       address =>
         address && isCashAddr(address) ? address : toCashAddr(address, true)
     )
-    : Remote.of(prop('requestToImportedAddress', ownProps))
+    : Remote.of(prop('receiveAddressFromProps', ownProps))
 
   const transform = (receiveAddress, initialValues) => ({
     type,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/index.js
@@ -99,6 +99,7 @@ class FirstStepContainer extends React.PureComponent {
           handleSubmit={this.handleSubmit}
           importedAddresses={importedAddresses}
           excludeLockbox={value.excludeLockbox}
+          requestToImportedAddress={this.props.requestToImportedAddress}
         />
       ),
       NotAsked: () => <DataError onClick={this.handleRefresh} />,
@@ -110,7 +111,7 @@ class FirstStepContainer extends React.PureComponent {
 
 const mapStateToProps = (state, ownProps) => ({
   initialValues: getInitialValues(state, ownProps),
-  data: getData(state),
+  data: getData(state, ownProps),
   importedAddresses: getImportedAddresses(state)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/index.js
@@ -99,7 +99,7 @@ class FirstStepContainer extends React.PureComponent {
           handleSubmit={this.handleSubmit}
           importedAddresses={importedAddresses}
           excludeLockbox={value.excludeLockbox}
-          requestToImportedAddress={this.props.requestToImportedAddress}
+          receiveAddressFromProps={this.props.receiveAddressFromProps}
         />
       ),
       NotAsked: () => <DataError onClick={this.handleRefresh} />,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/selectors.js
@@ -32,7 +32,7 @@ const extractAccountIdx = value =>
         : Remote.of(value.xpub)
     : Remote.NotAsked
 
-export const getData = state => {
+export const getData = (state, ownProps) => {
   const networkR = selectors.core.walletOptions.getBtcNetwork(state)
   const network = networkR.getOrElse('bitcoin')
   const availability = selectors.core.walletOptions.getCoinAvailability(
@@ -79,11 +79,9 @@ export const getData = state => {
     getReceiveIdxLockbox,
     to
   )
-  const receiveAddressR = extractAddress(
-    getReceiveAddressWallet,
-    getReceiveAddressLockbox,
-    to
-  )
+  const receiveAddressR = !prop('requestToImportedAddress', ownProps)
+    ? extractAddress(getReceiveAddressWallet, getReceiveAddressLockbox, to)
+    : Remote.of(prop('requestToImportedAddress', ownProps))
 
   const transform = (receiveAddress, accountIdx, addressIdx) => ({
     type,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/selectors.js
@@ -79,9 +79,9 @@ export const getData = (state, ownProps) => {
     getReceiveIdxLockbox,
     to
   )
-  const receiveAddressR = !prop('requestToImportedAddress', ownProps)
+  const receiveAddressR = !prop('receiveAddressFromProps', ownProps)
     ? extractAddress(getReceiveAddressWallet, getReceiveAddressLockbox, to)
-    : Remote.of(prop('requestToImportedAddress', ownProps))
+    : Remote.of(prop('receiveAddressFromProps', ownProps))
 
   const transform = (receiveAddress, accountIdx, addressIdx) => ({
     type,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/template.success.js
@@ -65,8 +65,7 @@ const FirstStep = props => {
     handleClickQRCode,
     handleOpenLockbox,
     importedAddresses,
-    excludeLockbox,
-    requestToImportedAddress
+    excludeLockbox
   } = props
 
   return (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/FirstStep/template.success.js
@@ -65,7 +65,8 @@ const FirstStep = props => {
     handleClickQRCode,
     handleOpenLockbox,
     importedAddresses,
-    excludeLockbox
+    excludeLockbox,
+    requestToImportedAddress
   } = props
 
   return (
@@ -125,6 +126,16 @@ const FirstStep = props => {
           </Banner>
         </BannerContainer>
       )}
+      {contains(receiveAddress, importedAddresses) && (
+        <BannerContainer>
+          <Banner type='warning'>
+            <FormattedMessage
+              id='modals.requestbitcoin.firststep.importedwarning'
+              defaultMessage='You are about to receive to a watch-only address. You can only spend these funds if you have access to the private key.'
+            />
+          </Banner>
+        </BannerContainer>
+      )}
       <Separator margin={'20px 0'}>
         <Text size='14px' weight={300} uppercase>
           <FormattedMessage
@@ -165,16 +176,6 @@ const FirstStep = props => {
             includeAll={false}
             validate={[required]}
           />
-          {contains(receiveAddress, importedAddresses) && (
-            <BannerContainer>
-              <Banner type='warning'>
-                <FormattedMessage
-                  id='modals.requestbitcoin.firststep.importedwarning'
-                  defaultMessage='You are about to receive to a watch-only address. You can only spend these funds if you have access to the private key.'
-                />
-              </Banner>
-            </BannerContainer>
-          )}
         </FormItem>
       </FormGroup>
       <FormGroup margin={'20px'}>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/index.js
@@ -15,7 +15,7 @@ class ImportedAddressesContainer extends React.Component {
 
   handleAddressClick = (address) => {
     this.props.actions.showModal('RequestBch', {
-      requestToImportedAddress: prop('addr', address)
+      receiveAddressFromProps: prop('addr', address)
     })
   }
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/index.js
@@ -6,16 +6,23 @@ import { getData } from './selectors'
 import Success from './template.success'
 import { formValueSelector } from 'redux-form'
 import { Remote } from 'blockchain-wallet-v4/src'
+import { prop } from 'ramda'
 
 class ImportedAddressesContainer extends React.Component {
   shouldComponentUpdate (nextProps) {
     return !Remote.Loading.is(nextProps.data)
   }
 
+  handleAddressClick = (address) => {
+    this.props.actions.showModal('RequestBch', {
+      requestToImportedAddress: prop('addr', address)
+    })
+  }
+
   render () {
     const { data, ...rest } = this.props
     return data.cata({
-      Success: value => <Success importedAddresses={value} {...rest} />,
+      Success: value => <Success importedAddresses={value} handleAddressClick={this.handleAddressClick} {...rest} />,
       Failure: message => <div>{message}</div>,
       Loading: () => <div />,
       NotAsked: () => <div />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/template.success.js
@@ -28,14 +28,14 @@ const WarningWrapper = styled.div`
 `
 
 const Success = props => {
-  const { importedAddresses, search } = props
+  const { importedAddresses, search, handleAddressClick } = props
 
   const isMatch = address =>
     !search || address.addr.toLowerCase().indexOf(search) > -1
 
   const importedAddressesTableRows = filter(isMatch, importedAddresses).map(
     address => {
-      return <AddressRow key={address.addr} address={address} coin='BCH' />
+      return <AddressRow key={address.addr} address={address} onAddressClick={() => handleAddressClick(address)} coin="BCH" />
     }
   )
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/AddressRow.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/AddressRow.js
@@ -37,11 +37,15 @@ const MoreOptions = () => (
   </Link>
 )
 
-const AddressRow = ({ address, archived, coin, renderOptions }) => {
+const AddressRow = ({ address, archived, coin, renderOptions, onAddressClick }) => {
   return (
     <TableRow>
       <AddressTableCell width='50%'>
-        <AddressCell size='13px'>{address.addr}</AddressCell>
+        <AddressCell>
+          <Link size='13px' weight={300} onClick={onAddressClick}>
+            {address.addr}
+          </Link>
+        </AddressCell>
         {address.priv == null && (
           <Banner label type='informational'>
             <FormattedMessage

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
@@ -14,7 +14,7 @@ class ImportedAddressesContainer extends React.Component {
 
   handleAddressClick = (address) => {
     this.props.modalsActions.showModal('RequestBtc', {
-      requestToImportedAddress: prop('addr', address)
+      receiveAddressFromProps: prop('addr', address)
     })
   }
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
@@ -5,22 +5,20 @@ import { connect } from 'react-redux'
 import Success from './template.success'
 import { Remote } from 'blockchain-wallet-v4/src'
 import { formValueSelector } from 'redux-form'
-import { values } from 'ramda'
+import { values, prop } from 'ramda'
 
 class ImportedAddressesContainer extends React.Component {
-  constructor (props) {
-    super(props)
-    this.handleClickImport = this.handleClickImport.bind(this)
-    this.handleToggleArchived = this.handleToggleArchived.bind(this)
-    this.handleShowPriv = this.handleShowPriv.bind(this)
-    this.handleSignMessage = this.handleSignMessage.bind(this)
-  }
-
   shouldComponentUpdate (nextProps) {
     return !Remote.Loading.is(nextProps.data)
   }
 
-  handleClickImport () {
+  handleAddressClick = (address) => {
+    this.props.modalsActions.showModal('RequestBtc', {
+      requestToImportedAddress: prop('addr', address)
+    })
+  }
+
+  handleClickImport = () => {
     this.props.modalsActions.showModal('ImportBtcAddress')
   }
 
@@ -28,20 +26,20 @@ class ImportedAddressesContainer extends React.Component {
     this.props.modalsActions.showModal('VerifyMessage')
   }
 
-  handleShowPriv (address) {
+  handleShowPriv = (address) => {
     this.props.modalsActions.showModal('ShowBtcPrivateKey', {
       addr: address.addr,
       balance: address.info.final_balance
     })
   }
 
-  handleSignMessage (address) {
+  handleSignMessage = (address) => {
     this.props.modalsActions.showModal('SignMessage', {
       address: address.addr
     })
   }
 
-  handleToggleArchived (address) {
+  handleToggleArchived = (address) => {
     let isArchived = address.tag === 2
     this.props.coreActions.setAddressArchived(address.addr, !isArchived)
   }
@@ -51,6 +49,7 @@ class ImportedAddressesContainer extends React.Component {
     return this.props.activeAddresses.cata({
       Success: value => (
         <Success
+          handleAddressClick={this.handleAddressClick}
           importedAddresses={value}
           onClickImport={this.handleClickImport}
           onClickVerify={this.handleClickVerify}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/template.success.js
@@ -36,6 +36,7 @@ const ClickableText = styled(Text)`
 `
 
 const Success = ({
+  handleAddressClick,
   importedAddresses,
   onClickImport,
   onClickVerify,
@@ -52,6 +53,7 @@ const Success = ({
       <AddressRow
         key={address.addr}
         address={address}
+        onAddressClick={() => handleAddressClick(address)}
         renderOptions={() =>
           [
             <ClickableText
@@ -67,27 +69,27 @@ const Success = ({
             !address.priv
               ? []
               : [
-                  !failure && (
-                    <ClickableText
-                      size='small'
-                      onClick={() => onShowPriv(address)}
-                    >
-                      <FormattedMessage
-                        id='scenes.settings.addresses.show_priv'
-                        defaultMessage='Private Key'
-                      />
-                    </ClickableText>
-                  ),
+                !failure && (
                   <ClickableText
                     size='small'
-                    onClick={() => onShowSignMessage(address)}
+                    onClick={() => onShowPriv(address)}
                   >
                     <FormattedMessage
-                      id='scenes.settings.addresses.sign_message'
-                      defaultMessage='Sign Message'
+                      id='scenes.settings.addresses.show_priv'
+                      defaultMessage='Private Key'
                     />
                   </ClickableText>
-                ]
+                ),
+                <ClickableText
+                  size='small'
+                  onClick={() => onShowSignMessage(address)}
+                >
+                  <FormattedMessage
+                    id='scenes.settings.addresses.sign_message'
+                    defaultMessage='Sign Message'
+                  />
+                </ClickableText>
+              ]
           )
         }
       />


### PR DESCRIPTION
## Description
998 - implements v3 functionality for clicking on an imported address from Wallets & Addresses

## Change Type
Please enter one or more of the following: 
- Feature

## Testing Steps
- go to settings --> wallets & addresses
- import an address
- click the address, see that request opens with the imported address

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] `README.md` and other documentation is updated as needed

