### PR TITLE
Fix(BSV tech debt)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
@@ -31,7 +31,7 @@ export default () => {
   const loadMore = function*() {
     try {
       const formValues = yield select(
-        selectors.form.getFormValues('transactions')
+        selectors.form.getFormValues('walletTxSearch')
       )
       const source = prop('source', formValues)
       const onlyShow = equals(source, 'all')

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/bsvTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/bsvTransactions/sagas.js
@@ -23,7 +23,7 @@ export default () => {
   const loadMore = function*() {
     try {
       const formValues = yield select(
-        selectors.form.getFormValues('transactions')
+        selectors.form.getFormValues('walletTxSearch')
       )
       const source = prop('source', formValues)
       const onlyShow = equals(source, 'all')

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.js
@@ -31,7 +31,7 @@ export default () => {
   const loadMore = function*() {
     try {
       const formValues = yield select(
-        selectors.form.getFormValues('transactions')
+        selectors.form.getFormValues('walletTxSearch')
       )
       const source = prop('source', formValues)
       const onlyShow = equals(source, 'all')

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/sendBsv/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/sendBsv/sagas.js
@@ -57,10 +57,10 @@ export default ({ coreSagas }) => {
 
   const firstStepSubmitClicked = function*() {
     try {
-      let p = yield select(S.getPayment)
       yield put(A.sendBsvPaymentUpdated(Remote.Loading))
-      let payment = coreSagas.payment.bsv.create({
-        payment: p.getOrElse({}),
+      let payment = (yield select(S.getPayment)).getOrElse({})
+      payment = coreSagas.payment.bsv.create({
+        payment,
         network: settings.NETWORK_BSV
       })
       payment = yield payment.build()
@@ -79,9 +79,9 @@ export default ({ coreSagas }) => {
       const payload = prop('payload', action)
       if (!equals(FORM, form)) return
 
-      let p = yield select(S.getPayment)
-      let payment = coreSagas.payment.bsv.create({
-        payment: p.getOrElse({}),
+      let payment = (yield select(S.getPayment)).getOrElse({})
+      payment = coreSagas.payment.bsv.create({
+        payment,
         network: settings.NETWORK_BSV
       })
 

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/sendBsv/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/sendBsv/sagas.spec.js
@@ -229,18 +229,16 @@ describe('sendBsv sagas', () => {
     const saga = testSaga(firstStepSubmitClicked)
     const beforeError = 'beforeError'
 
+    it('should put loading action', () => {
+      saga.next().put(A.sendBsvPaymentUpdated(Remote.Loading))
+    })
+
     it('should select payment', () => {
       saga.next().select(S.getPayment)
     })
 
-    it('should put loading action', () => {
-      saga
-        .next(Remote.of(paymentMock))
-        .put(A.sendBsvPaymentUpdated(Remote.Loading))
-    })
-
     it('should create payment from state value', () => {
-      saga.next()
+      saga.next(Remote.of(paymentMock))
       expect(coreSagas.payment.bsv.create).toHaveBeenCalledTimes(1)
       expect(coreSagas.payment.bsv.create).toHaveBeenCalledWith({
         payment: paymentMock,

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/template.js
@@ -94,7 +94,7 @@ const WalletLayout = props => {
               />
             )}
             {location.pathname.includes('/settings/addresses') && (
-              <SettingsAddressesMenu />
+              <SettingsAddressesMenu location={location} />
             )}
             {location.pathname.includes('/settings/profile') && (
               <ExchangeProfileMenu />

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/template.js
@@ -15,6 +15,7 @@ import Menu from 'scenes/Transactions/Menu'
 import LockboxMenu from '../../scenes/Lockbox/Menu'
 import ExchangeMenu from 'scenes/Exchange/Menu'
 import ExchangeProfileMenu from 'scenes/Settings/Profile/Menu'
+import SettingsAddressesMenu from 'scenes/Settings/Addresses/Menu'
 
 import media from 'services/ResponsiveService'
 
@@ -91,6 +92,9 @@ const WalletLayout = props => {
               <ExchangeMenu
                 historySelected={location.pathname.includes('/swap/history')}
               />
+            )}
+            {location.pathname.includes('/settings/addresses') && (
+              <SettingsAddressesMenu />
             )}
             {location.pathname.includes('/settings/profile') && (
               <ExchangeProfileMenu />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/index.js
@@ -29,7 +29,7 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('settingsAddresses')(state, 'search')
+  search: formValueSelector('walletTxSearch')(state, 'search')
 })
 
 export default connect(

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/Wallets/index.js
@@ -61,7 +61,7 @@ class BchWalletsContainer extends React.Component {
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('settingsAddresses')(state, 'search')
+  search: formValueSelector('walletTxSearch')(state, 'search')
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Transactions/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Transactions/index.js
@@ -8,6 +8,7 @@ import { actions } from 'data'
 import TransactionList from 'scenes/Transactions/Content'
 import { SettingHeader } from 'components/Setting'
 import { Text } from 'blockchain-info-components'
+import { getHasTransactions } from './selectors'
 
 const Wrapper = styled.section`
   box-sizing: border-box;
@@ -32,8 +33,15 @@ const TableHeader = styled.div`
   background-color: ${props => props.theme['brand-quaternary']};
 `
 const TableCell = styled.div``
+const NoBsv = styled.div`
+  margin: 20px;
+`
 
 class BsvTransactionsContainer extends React.Component {
+  componentDidMount () {
+    this.props.txActions.initialized()
+  }
+
   render () {
     return (
       <Wrapper>
@@ -70,13 +78,24 @@ class BsvTransactionsContainer extends React.Component {
             >
               <Text size='13px' weight={500}>
                 <FormattedMessage
-                  id='scenes.settings.addresses.bch.wallets.amount'
+                  id='scenes.settings.addresses.bsv.wallets.amount'
                   defaultMessage='Amount'
                 />
               </Text>
             </TableCell>
           </TableHeader>
-          <TransactionList coin='BSV' />
+          {this.props.hasTransactions ? (
+            <TransactionList coin='BSV' />
+          ) : (
+            <NoBsv>
+              <Text size='14px'>
+                <FormattedMessage
+                  id='scenes.settings.addresses.bsv.empty'
+                  defaultMessage='No Transactions Found'
+                />
+              </Text>
+            </NoBsv>
+          )}
         </Table>
       </Wrapper>
     )
@@ -84,15 +103,14 @@ class BsvTransactionsContainer extends React.Component {
 }
 
 const mapDispatchToProps = dispatch => ({
-  kvStoreBchActions: bindActionCreators(actions.core.kvStore.bch, dispatch),
-  addressesBchActions: bindActionCreators(
-    actions.modules.addressesBch,
-    dispatch
-  ),
-  modalsActions: bindActionCreators(actions.modals, dispatch)
+  txActions: bindActionCreators(actions.components.bsvTransactions, dispatch)
+})
+
+const mapStateToProps = state => ({
+  hasTransactions: getHasTransactions(state)
 })
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(BsvTransactionsContainer)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Transactions/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Transactions/index.js
@@ -8,7 +8,7 @@ import { actions } from 'data'
 import TransactionList from 'scenes/Transactions/Content'
 import { SettingHeader } from 'components/Setting'
 import { Text } from 'blockchain-info-components'
-import { getHasTransactions } from './selectors'
+import { getAreThereBsvTransactions } from './selectors'
 
 const Wrapper = styled.section`
   box-sizing: border-box;
@@ -37,7 +37,7 @@ const NoBsv = styled.div`
   margin: 20px;
 `
 
-class BsvTransactionsContainer extends React.Component {
+class BsvTransactionsContainer extends React.PureComponent {
   componentDidMount () {
     this.props.txActions.initialized()
   }
@@ -84,7 +84,7 @@ class BsvTransactionsContainer extends React.Component {
               </Text>
             </TableCell>
           </TableHeader>
-          {this.props.hasTransactions ? (
+          {this.props.areThereBsvTransactions ? (
             <TransactionList coin='BSV' />
           ) : (
             <NoBsv>
@@ -107,7 +107,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const mapStateToProps = state => ({
-  hasTransactions: getHasTransactions(state)
+  areThereBsvTransactions: getAreThereBsvTransactions(state)
 })
 
 export default connect(

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Transactions/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Transactions/selectors.js
@@ -1,7 +1,7 @@
 import { selectors } from 'data'
 import { all, isEmpty } from 'ramda'
 
-export const getHasTransactions = state => {
+export const getAreThereBsvTransactions = state => {
   const txs = selectors.core.common.bsv.getWalletTransactions(state)
   const empty = page => isEmpty(page.data)
   return !all(empty)(txs)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Transactions/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Transactions/selectors.js
@@ -1,0 +1,8 @@
+import { selectors } from 'data'
+import { all, isEmpty } from 'ramda'
+
+export const getHasTransactions = state => {
+  const txs = selectors.core.common.bsv.getWalletTransactions(state)
+  const empty = page => isEmpty(page.data)
+  return !all(empty)(txs)
+}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Wallets/index.js
@@ -42,7 +42,7 @@ class BsvWalletsContainer extends React.Component {
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('settingsAddresses')(state, 'search')
+  search: formValueSelector('walletTxSearch')(state, 'search')
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ArchivedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ArchivedAddresses/index.js
@@ -43,7 +43,7 @@ const selectArchived = compose(
 
 const mapStateToProps = state => ({
   archivedAddresses: selectArchived(state).toArray(),
-  search: formValueSelector('settingsAddresses')(state, 'search')
+  search: formValueSelector('walletTxSearch')(state, 'search')
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
@@ -79,7 +79,7 @@ class ImportedAddressesContainer extends React.Component {
 
 const mapStateToProps = state => ({
   activeAddresses: selectors.core.common.btc.getActiveAddresses(state),
-  search: formValueSelector('settingsAddresses')(state, 'search'),
+  search: formValueSelector('walletTxSearch')(state, 'search'),
   addressesWithoutRemoteData: selectors.core.wallet.getAddresses(state)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ManageAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ManageAddresses/index.js
@@ -20,6 +20,6 @@ class ManageAddressesContainer extends React.PureComponent {
   }
 }
 
-export default reduxForm({ form: 'settingsAddresses' })(
-  ManageAddressesContainer
-)
+export default reduxForm({
+  form: 'walletTxSearch'
+})(ManageAddressesContainer)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
@@ -65,7 +65,7 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('settingsAddresses')(state, 'search'),
+  search: formValueSelector('walletTxSearch')(state, 'search'),
   walletsWithoutRemoteData: getWalletsWithoutRemoteData(state)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Menu/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Menu/index.js
@@ -87,4 +87,6 @@ const MenuTop = () => (
   </Wrapper>
 )
 
-export default reduxForm({ form: 'settingsAddresses' })(MenuTop)
+export default reduxForm({
+  form: 'walletTxSearch'
+})(MenuTop)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/index.js
@@ -2,7 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import { withRouter, Route, Redirect, Switch } from 'react-router-dom'
 
-import Menu from './Menu'
 import Btc from './Btc'
 import BtcManage from './Btc/ManageAddresses'
 import Bch from './Bch'
@@ -22,7 +21,6 @@ class AddressesContainer extends React.PureComponent {
   render () {
     return (
       <Wrapper>
-        <Menu location={this.props.location} />
         <ContentWrapper>
           <Switch>
             <Route

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Content/Empty/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Content/Empty/index.js
@@ -3,9 +3,7 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { FormattedMessage } from 'react-intl'
 
-import { Text } from 'blockchain-info-components'
 import { actions } from 'data'
 import CoinWelcome from './CoinWelcome'
 
@@ -15,22 +13,10 @@ const Wrapper = styled.div`
   padding: 30px;
   box-sizing: border-box;
 `
-const NoBsv = styled.div`
-  margin: 20px;
-`
 class EmptyContainer extends React.PureComponent {
   render () {
     const { coin, handleRequest } = this.props
-    return coin === 'BSV' ? (
-      <NoBsv>
-        <Text size='14px'>
-          <FormattedMessage
-            id='scenes.transaction.content.empty.nobsv'
-            defaultMessage='No Transactions Found'
-          />
-        </Text>
-      </NoBsv>
-    ) : (
+    return (
       <Wrapper>
         <CoinWelcome coin={coin} handleRequest={handleRequest} />
       </Wrapper>
@@ -43,7 +29,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 EmptyContainer.propTypes = {
-  coin: PropTypes.oneOf(['BTC', 'BCH', 'BSV', 'ETH', 'XLM']).isRequired
+  coin: PropTypes.oneOf(['BTC', 'BCH', 'ETH', 'XLM']).isRequired
 }
 
 export default connect(

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Content/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Content/selectors.js
@@ -59,24 +59,15 @@ const coinSelectorMap = {
 export const getData = (state, coin) =>
   createSelector(
     [
-      selectors.form.getFormValues('transactions'),
-      selectors.form.getFormValues('settingsAddresses'),
+      selectors.form.getFormValues('walletTxSearch'),
       coinSelectorMap[coin],
       selectors.core.kvStore.buySell.getMetadata,
       selectors.core.settings.getCurrency
     ],
-    (txSearch, bsvSearch, pages, buySellMetadata, currencyR) => {
+    (userSearch, pages, buySellMetadata, currencyR) => {
       const empty = page => isEmpty(page.data)
-      let search, status
-      // use different search form for BSV txs
-      if (coin === 'BSV') {
-        search = propOr('', 'search', bsvSearch)
-        status = propOr('', 'status', bsvSearch)
-      } else {
-        search = propOr('', 'search', txSearch)
-        status = propOr('', 'status', txSearch)
-      }
-
+      const search = propOr('', 'search', userSearch)
+      const status = propOr('', 'status', userSearch)
       const filteredPages = !isEmpty(pages)
         ? pages.map(map(filterTransactions(status, search)))
         : []

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Menu/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Menu/template.js
@@ -202,6 +202,6 @@ const Menu = props => {
 }
 
 export default reduxForm({
-  form: 'transactions',
+  form: 'walletTxSearch',
   initialValues: { source: 'all' }
 })(Menu)


### PR DESCRIPTION
## Description
- Use a single redux form (`walletTxSearch`) for all sub-menu search boxes (transaction list pages & settings/address pages)
- Small refactor for send BSV sagas to avoid setting unneeded variables

## Change Type
- Tech Debt

## Testing Steps
- BSV send works
- Transaction list and wallet list searches work

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] `README.md` and other documentation is updated as needed