### PR TITLE
fix(Forms): use model so form names dont get out of sync

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
@@ -1,8 +1,9 @@
 import { select, put } from 'redux-saga/effects'
 import { equals, path, prop } from 'ramda'
-import { actions, selectors } from 'data'
+import { actions, selectors, model } from 'data'
 
 export default () => {
+  const { WALLET_TX_SEARCH } = model.form
   const logLocation = 'components/bchTransactions/sagas'
 
   const initialized = function*() {
@@ -13,7 +14,7 @@ export default () => {
         status: '',
         search: ''
       }
-      yield put(actions.form.initialize('transactions', initialValues))
+      yield put(actions.form.initialize(WALLET_TX_SEARCH, initialValues))
       yield put(actions.core.data.bch.fetchTransactions('', true))
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'initialized', e))
@@ -31,7 +32,7 @@ export default () => {
   const loadMore = function*() {
     try {
       const formValues = yield select(
-        selectors.form.getFormValues('walletTxSearch')
+        selectors.form.getFormValues(WALLET_TX_SEARCH)
       )
       const source = prop('source', formValues)
       const onlyShow = equals(source, 'all')
@@ -48,7 +49,7 @@ export default () => {
       const form = path(['meta', 'form'], action)
       const field = path(['meta', 'field'], action)
       const payload = prop('payload', action)
-      if (!equals('transactions', form)) return
+      if (!equals(WALLET_TX_SEARCH, form)) return
 
       switch (field) {
         case 'source':

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
@@ -1,10 +1,10 @@
 import { select, put } from 'redux-saga/effects'
 import { equals, path, prop } from 'ramda'
 import { actions, selectors, model } from 'data'
+export const logLocation = 'components/bchTransactions/sagas'
 
 export default () => {
   const { WALLET_TX_SEARCH } = model.form
-  const logLocation = 'components/bchTransactions/sagas'
 
   const initialized = function*() {
     try {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.spec.js
@@ -1,0 +1,132 @@
+import { testSaga } from 'redux-saga-test-plan'
+import { coreSagasFactory } from 'blockchain-wallet-v4/src'
+import * as actions from '../../actions'
+import bchTransactionsSagas, { logLocation } from './sagas'
+import { model } from 'data'
+
+const coreSagas = coreSagasFactory()
+
+jest.mock('blockchain-wallet-v4/src/redux/sagas')
+
+describe('bchTransactions sagas', () => {
+  describe('initialized', () => {
+    let { initialized } = bchTransactionsSagas({ coreSagas })
+
+    let saga = testSaga(initialized)
+
+    const defaultSource = 'all'
+    const initialValues = {
+      source: defaultSource,
+      status: '',
+      search: ''
+    }
+
+    it('should initialize the form with initial values', () => {
+      saga
+        .next()
+        .put(
+          actions.form.initialize(model.form.WALLET_TX_SEARCH, initialValues)
+        )
+    })
+
+    it('should dispatch an action to fetch txs', () => {
+      saga.next().put(actions.core.data.bch.fetchTransactions('', true))
+    })
+
+    describe('error handling', () => {
+      const error = new Error('ERROR')
+      it('should log the error', () => {
+        saga
+          .restart()
+          .next()
+          .throw(error)
+          .put(actions.logs.logErrorMessage(logLocation, 'initialized', error))
+      })
+    })
+  })
+
+  describe('reportClicked', () => {
+    let { reportClicked } = bchTransactionsSagas({ coreSagas })
+    let saga = testSaga(reportClicked)
+
+    it('should open the modal', () => {
+      saga
+        .next()
+        .put(actions.modals.showModal('TransactionReport', { coin: 'BCH' }))
+    })
+
+    describe('error handling', () => {
+      const error = new Error('ERROR')
+      it('should log the error', () => {
+        saga
+          .restart()
+          .next()
+          .throw(error)
+          .put(
+            actions.logs.logErrorMessage(logLocation, 'reportClicked', error)
+          )
+      })
+    })
+  })
+
+  describe('formChanged with show all', () => {
+    let { formChanged } = bchTransactionsSagas({ coreSagas })
+    const action = {
+      meta: {
+        form: model.form.WALLET_TX_SEARCH,
+        field: 'source'
+      },
+      payload: 'all'
+    }
+
+    let saga = testSaga(formChanged, action)
+
+    it('should fetch transactions', () => {
+      saga
+        .next()
+        .put(
+          actions.core.data.bch.fetchTransactions(
+            action.payload === 'all' ? '' : 'some_address',
+            true
+          )
+        )
+    })
+
+    describe('error handling', () => {
+      const error = new Error()
+      it('should log the error', () => {
+        saga
+          .restart()
+          .next()
+          .throw(error)
+          .put(actions.logs.logErrorMessage(logLocation, 'formChanged', error))
+      })
+    })
+  })
+
+  describe('formChanged with show one address', () => {
+    let { formChanged } = bchTransactionsSagas({ coreSagas })
+    const action = {
+      meta: {
+        form: model.form.WALLET_TX_SEARCH,
+        field: 'source'
+      },
+      payload: {
+        address: 'some_address'
+      }
+    }
+
+    let saga = testSaga(formChanged, action)
+
+    it('should fetch transactions', () => {
+      saga
+        .next()
+        .put(
+          actions.core.data.bch.fetchTransactions(
+            action.payload === 'all' ? '' : 'some_address',
+            true
+          )
+        )
+    })
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/bsvTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/bsvTransactions/sagas.js
@@ -1,8 +1,9 @@
 import { select, put } from 'redux-saga/effects'
 import { equals, path, prop } from 'ramda'
-import { actions, selectors } from 'data'
+import { actions, selectors, model } from 'data'
 
 export default () => {
+  const { WALLET_TX_SEARCH } = model.form
   const logLocation = 'components/bsvTransactions/sagas'
 
   const initialized = function*() {
@@ -13,7 +14,7 @@ export default () => {
         status: '',
         search: ''
       }
-      yield put(actions.form.initialize('transactions', initialValues))
+      yield put(actions.form.initialize(WALLET_TX_SEARCH, initialValues))
       yield put(actions.core.data.bsv.fetchTransactions('', true))
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'initialized', e))
@@ -23,7 +24,7 @@ export default () => {
   const loadMore = function*() {
     try {
       const formValues = yield select(
-        selectors.form.getFormValues('walletTxSearch')
+        selectors.form.getFormValues(WALLET_TX_SEARCH)
       )
       const source = prop('source', formValues)
       const onlyShow = equals(source, 'all')
@@ -40,7 +41,7 @@ export default () => {
       const form = path(['meta', 'form'], action)
       const field = path(['meta', 'field'], action)
       const payload = prop('payload', action)
-      if (!equals('transactions', form)) return
+      if (!equals(WALLET_TX_SEARCH, form)) return
 
       switch (field) {
         case 'source':

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.js
@@ -1,10 +1,11 @@
 import { select, put } from 'redux-saga/effects'
 import { equals, path, prop } from 'ramda'
-import { actions, selectors } from 'data'
+import { actions, selectors, model } from 'data'
 
 export const logLocation = 'components/btcTransactions/sagas'
 
 export default () => {
+  const { WALLET_TX_SEARCH } = model.form
   const initialized = function*() {
     try {
       const defaultSource = 'all'
@@ -13,7 +14,7 @@ export default () => {
         status: '',
         search: ''
       }
-      yield put(actions.form.initialize('transactions', initialValues))
+      yield put(actions.form.initialize(WALLET_TX_SEARCH, initialValues))
       yield put(actions.core.data.bitcoin.fetchTransactions('', true))
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'initialized', e))
@@ -31,7 +32,7 @@ export default () => {
   const loadMore = function*() {
     try {
       const formValues = yield select(
-        selectors.form.getFormValues('walletTxSearch')
+        selectors.form.getFormValues(WALLET_TX_SEARCH)
       )
       const source = prop('source', formValues)
       const onlyShow = equals(source, 'all')
@@ -48,7 +49,7 @@ export default () => {
       const form = path(['meta', 'form'], action)
       const field = path(['meta', 'field'], action)
       const payload = prop('payload', action)
-      if (!equals('transactions', form)) return
+      if (!equals(WALLET_TX_SEARCH, form)) return
 
       switch (field) {
         case 'source':

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.spec.js
@@ -2,6 +2,7 @@ import { testSaga } from 'redux-saga-test-plan'
 import { coreSagasFactory } from 'blockchain-wallet-v4/src'
 import * as actions from '../../actions'
 import btcTransactionsSagas, { logLocation } from './sagas'
+import { model } from 'data'
 
 const coreSagas = coreSagasFactory()
 
@@ -21,7 +22,7 @@ describe('btcTransactions sagas', () => {
     }
 
     it('should initialize the form with initial values', () => {
-      saga.next().put(actions.form.initialize('transactions', initialValues))
+      saga.next().put(actions.form.initialize(model.form.WALLET_TX_SEARCH, initialValues))
     })
 
     it('should dispatch an action to fetch txs', () => {
@@ -68,7 +69,7 @@ describe('btcTransactions sagas', () => {
     let { formChanged } = btcTransactionsSagas({ coreSagas })
     const action = {
       meta: {
-        form: 'transactions',
+        form: model.form.WALLET_TX_SEARCH,
         field: 'source'
       },
       payload: 'all'
@@ -103,7 +104,7 @@ describe('btcTransactions sagas', () => {
     let { formChanged } = btcTransactionsSagas({ coreSagas })
     const action = {
       meta: {
-        form: 'transactions',
+        form: model.form.WALLET_TX_SEARCH,
         field: 'source'
       },
       payload: {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/ethTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/ethTransactions/sagas.js
@@ -1,8 +1,9 @@
 import { put } from 'redux-saga/effects'
 import { equals, path } from 'ramda'
-import { actions } from 'data'
+import { actions, model } from 'data'
 
 export default () => {
+  const { WALLET_TX_SEARCH } = model.form
   const logLocation = 'components/ethTransactions/sagas'
   const initialized = function*() {
     try {
@@ -10,7 +11,7 @@ export default () => {
         status: '',
         search: ''
       }
-      yield put(actions.form.initialize('transactions', initialValues))
+      yield put(actions.form.initialize(WALLET_TX_SEARCH, initialValues))
       yield put(actions.core.data.ethereum.fetchTransactions(null, true))
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'initialized', e))
@@ -29,7 +30,7 @@ export default () => {
     try {
       const form = path(['meta', 'form'], action)
       const field = path(['meta', 'field'], action)
-      if (!equals('transactions', form)) return
+      if (!equals(WALLET_TX_SEARCH, form)) return
       switch (field) {
         case 'source':
           yield put(actions.core.data.ethereum.fetchTransactions())

--- a/packages/blockchain-wallet-v4-frontend/src/data/form/model.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/form/model.js
@@ -1,0 +1,1 @@
+export const WALLET_TX_SEARCH = 'walletTxSearch'

--- a/packages/blockchain-wallet-v4-frontend/src/data/middleware/webSocket/bch/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/middleware/webSocket/bch/sagas.js
@@ -4,6 +4,7 @@ import * as actions from '../../../actions'
 import * as selectors from '../../../selectors'
 import * as T from 'services/AlertService'
 import { Socket } from 'blockchain-wallet-v4/src/network'
+import { WALLET_TX_SEARCH } from '../../../form/model'
 
 // TO REVIEW
 export default ({ api, bchSocket }) => {
@@ -69,12 +70,12 @@ export default ({ api, bchSocket }) => {
           const pathname = yield select(selectors.router.getPathname)
           if (equals(pathname, '/bch/transactions')) {
             const formValues = yield select(
-              selectors.form.getFormValues('bchTransactions')
+              selectors.form.getFormValues(WALLET_TX_SEARCH)
             )
             const source = prop('source', formValues)
             const onlyShow = equals(source, 'all')
               ? ''
-              : source.xpub || source.address
+              : prop('xpub', source) || prop('address', source)
             yield put(actions.core.data.bch.fetchTransactions(onlyShow, true))
           }
           break

--- a/packages/blockchain-wallet-v4-frontend/src/data/middleware/webSocket/btc/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/middleware/webSocket/btc/sagas.js
@@ -5,6 +5,7 @@ import * as selectors from '../../../selectors'
 import * as T from 'services/AlertService'
 import { Wrapper } from 'blockchain-wallet-v4/src/types'
 import { Socket } from 'blockchain-wallet-v4/src/network'
+import { WALLET_TX_SEARCH } from '../../../form/model'
 
 export default ({ api, btcSocket }) => {
   const send = btcSocket.send.bind(btcSocket)
@@ -81,12 +82,12 @@ export default ({ api, btcSocket }) => {
           const pathname = yield select(selectors.router.getPathname)
           if (equals(pathname, '/btc/transactions')) {
             const formValues = yield select(
-              selectors.form.getFormValues('btcTransactions')
+              selectors.form.getFormValues(WALLET_TX_SEARCH)
             )
             const source = prop('source', formValues)
             const onlyShow = equals(source, 'all')
               ? ''
-              : source.xpub || source.address
+              : prop('xpub', source) || prop('address', source)
             yield put(
               actions.core.data.bitcoin.fetchTransactions(onlyShow, true)
             )

--- a/packages/blockchain-wallet-v4-frontend/src/data/model.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/model.js
@@ -2,5 +2,6 @@ import * as analytics from './analytics/model'
 import * as rates from './modules/rates/model'
 import * as profile from './modules/profile/model'
 import * as components from './components/model'
+import * as form from './form/model'
 
-export { analytics, rates, profile, components }
+export { analytics, form, rates, profile, components }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/ImportedAddresses/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
-import { actions } from 'data'
+import { actions, model } from 'data'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { getData } from './selectors'
 import Success from './template.success'
 import { formValueSelector } from 'redux-form'
 import { Remote } from 'blockchain-wallet-v4/src'
+const { WALLET_TX_SEARCH } = model.form
 
 class ImportedAddressesContainer extends React.Component {
   shouldComponentUpdate (nextProps) {
@@ -29,7 +30,7 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('walletTxSearch')(state, 'search')
+  search: formValueSelector(WALLET_TX_SEARCH)(state, 'search')
 })
 
 export default connect(

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bch/Wallets/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { actions } from 'data'
+import { actions, model } from 'data'
 import { getData } from './selectors'
 import Wallets from './template'
 import { formValueSelector } from 'redux-form'
 import { Remote } from 'blockchain-wallet-v4/src'
+const { WALLET_TX_SEARCH } = model.form
 
 class BchWalletsContainer extends React.Component {
   shouldComponentUpdate (nextProps) {
@@ -61,7 +62,7 @@ class BchWalletsContainer extends React.Component {
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('walletTxSearch')(state, 'search')
+  search: formValueSelector(WALLET_TX_SEARCH)(state, 'search')
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Bsv/Wallets/index.js
@@ -7,6 +7,7 @@ import { Remote } from 'blockchain-wallet-v4/src'
 import { actions, model } from 'data'
 import { getData } from './selectors'
 import Wallets from './template'
+const { WALLET_TX_SEARCH } = model.form
 
 class BsvWalletsContainer extends React.Component {
   shouldComponentUpdate (nextProps) {
@@ -42,7 +43,7 @@ class BsvWalletsContainer extends React.Component {
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('walletTxSearch')(state, 'search')
+  search: formValueSelector(WALLET_TX_SEARCH)(state, 'search')
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ArchivedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ArchivedAddresses/index.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators, compose } from 'redux'
-import { actions, selectors } from 'data'
+import { actions, selectors, model } from 'data'
 import Success from './template.success'
 import { Types } from 'blockchain-wallet-v4/src'
 import { formValueSelector } from 'redux-form'
+const { WALLET_TX_SEARCH } = model.form
 
 class ArchivedAddressesContainer extends React.PureComponent {
   constructor (props) {
@@ -43,7 +44,7 @@ const selectArchived = compose(
 
 const mapStateToProps = state => ({
   archivedAddresses: selectArchived(state).toArray(),
-  search: formValueSelector('walletTxSearch')(state, 'search')
+  search: formValueSelector(WALLET_TX_SEARCH)(state, 'search')
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ImportedAddresses/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
-import { actions, selectors } from 'data'
+import { actions, selectors, model } from 'data'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import Success from './template.success'
 import { Remote } from 'blockchain-wallet-v4/src'
 import { formValueSelector } from 'redux-form'
 import { values } from 'ramda'
+const { WALLET_TX_SEARCH } = model.form
 
 class ImportedAddressesContainer extends React.Component {
   constructor (props) {
@@ -79,7 +80,7 @@ class ImportedAddressesContainer extends React.Component {
 
 const mapStateToProps = state => ({
   activeAddresses: selectors.core.common.btc.getActiveAddresses(state),
-  search: formValueSelector('walletTxSearch')(state, 'search'),
+  search: formValueSelector(WALLET_TX_SEARCH)(state, 'search'),
   addressesWithoutRemoteData: selectors.core.wallet.getAddresses(state)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ManageAddresses/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/ManageAddresses/index.js
@@ -4,6 +4,8 @@ import { reduxForm } from 'redux-form'
 
 import UnusedAddresses from './UnusedAddresses'
 import UsedAddresses from './UsedAddresses'
+import { model } from 'data'
+const { WALLET_TX_SEARCH } = model.form
 
 const Wrapper = styled.section`
   box-sizing: border-box;
@@ -21,5 +23,5 @@ class ManageAddressesContainer extends React.PureComponent {
 }
 
 export default reduxForm({
-  form: 'walletTxSearch'
+  form: WALLET_TX_SEARCH
 })(ManageAddressesContainer)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Btc/Wallets/index.js
@@ -1,11 +1,13 @@
 import React from 'react'
-import { actions } from 'data'
+import { actions, model } from 'data'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { getData, getWalletsWithoutRemoteData } from './selectors'
 import Template from './template.success'
 import { Remote } from 'blockchain-wallet-v4/src'
 import { formValueSelector } from 'redux-form'
+
+const { WALLET_TX_SEARCH } = model.form
 
 class BitcoinWalletsContainer extends React.Component {
   shouldComponentUpdate (nextProps) {
@@ -65,7 +67,7 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = state => ({
   data: getData(state),
-  search: formValueSelector('walletTxSearch')(state, 'search'),
+  search: formValueSelector(WALLET_TX_SEARCH)(state, 'search'),
   walletsWithoutRemoteData: getWalletsWithoutRemoteData(state)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Menu/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/Addresses/Menu/index.js
@@ -6,6 +6,8 @@ import { LinkContainer } from 'react-router-bootstrap'
 
 import { Icon, TabMenu, TabMenuItem } from 'blockchain-info-components'
 import { TextBox } from 'components/Form'
+import { model } from 'data'
+const { WALLET_TX_SEARCH } = model.form
 
 const Wrapper = styled.div`
   width: 100%;
@@ -88,5 +90,5 @@ const MenuTop = () => (
 )
 
 export default reduxForm({
-  form: 'walletTxSearch'
+  form: WALLET_TX_SEARCH
 })(MenuTop)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Content/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Content/selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect'
-import { selectors } from 'data'
+import { selectors, model } from 'data'
 import {
   all,
   curry,
@@ -17,6 +17,8 @@ import {
   propOr
 } from 'ramda'
 import { hasAccount } from 'services/ExchangeService'
+
+const { WALLET_TX_SEARCH } = model.form
 
 const filterTransactions = curry((status, criteria, transactions) => {
   const isOfType = curry((filter, tx) =>
@@ -59,7 +61,7 @@ const coinSelectorMap = {
 export const getData = (state, coin) =>
   createSelector(
     [
-      selectors.form.getFormValues('walletTxSearch'),
+      selectors.form.getFormValues(WALLET_TX_SEARCH),
       coinSelectorMap[coin],
       selectors.core.kvStore.buySell.getMetadata,
       selectors.core.settings.getCurrency

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Menu/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/Menu/template.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { Field, reduxForm } from 'redux-form'
 import { contains, flatten, prop } from 'ramda'
 import { FormattedMessage } from 'react-intl'
-
+import { model } from 'data'
 import { ComponentDropdown, Icon, Link, Text } from 'blockchain-info-components'
 import {
   SelectBoxBtcAddresses,
@@ -11,6 +11,8 @@ import {
   TextBox,
   TabMenuTransactionStatus
 } from 'components/Form'
+
+const { WALLET_TX_SEARCH } = model.form
 
 const Wrapper = styled.div`
   width: 100%;
@@ -202,6 +204,6 @@ const Menu = props => {
 }
 
 export default reduxForm({
-  form: 'walletTxSearch',
+  form: WALLET_TX_SEARCH,
   initialValues: { source: 'all' }
 })(Menu)


### PR DESCRIPTION
## Description
The form name for the transactions search/filter component was not consistent across the app.

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
- see BTC and BCH web sockets now properly work when updating tx feed
- tx feed form should work

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] `README.md` and other documentation is updated as needed

