### PR TITLE
Add exchangeTo and exchangeFrom checks for swap

### DIFF
--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -79,7 +79,7 @@
           "send": true,
           "request": true,
           "lockbox": true,
-          "exchangeTo": false,
+          "exchangeTo": true,
           "exchangeFrom": true
         }
       },

--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -67,7 +67,8 @@
           "send": true,
           "request": true,
           "lockbox": true,
-          "exchange": true
+          "exchangeTo": true,
+          "exchangeFrom": true
         },
         "config": {
           "network": "bitcoin"
@@ -78,7 +79,8 @@
           "send": true,
           "request": true,
           "lockbox": true,
-          "exchange": true
+          "exchangeTo": false,
+          "exchangeFrom": true
         }
       },
       "bsv": {
@@ -86,7 +88,8 @@
           "send": true,
           "request": false,
           "lockbox": false,
-          "exchange": true
+          "exchangeTo": false,
+          "exchangeFrom": true
         }
       },
       "eth": {
@@ -94,7 +97,8 @@
           "send": true,
           "request": true,
           "lockbox": true,
-          "exchange": true
+          "exchangeTo": true,
+          "exchangeFrom": true
         },
         "lastTxFuse": 86400,
         "config": {
@@ -106,7 +110,8 @@
           "send": true,
           "request": true,
           "lockbox": true,
-          "exchange": true
+          "exchangeTo": true,
+          "exchangeFrom": true
         },
         "config": {
           "network": "public"

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/rates/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/rates/sagas.js
@@ -1,4 +1,4 @@
-import { all, compose, prop } from 'ramda'
+import { and, compose, head, last, prop } from 'ramda'
 import { put, select, call } from 'redux-saga/effects'
 
 import { actions, selectors } from 'data'
@@ -45,13 +45,18 @@ export default ({ api }) => {
       const getCoinAvailability = yield select(
         selectors.core.walletOptions.getCoinAvailability
       )
+      const getExchangeTypeAvailability = (type, coin) =>
+        getCoinAvailability(coin)
+          .map(prop(type))
+          .getOrElse(false)
+
       const walletAvailablePairs = pairs.filter(
         compose(
-          all(coin =>
-            getCoinAvailability(coin)
-              .map(prop('exchange'))
-              .getOrElse(false)
-          ),
+          coins =>
+            and(
+              getExchangeTypeAvailability('exchangeTo', last(coins)),
+              getExchangeTypeAvailability('exchangeFrom', head(coins))
+            ),
           splitPair
         )
       )

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/rates/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/rates/sagas.spec.js
@@ -1,5 +1,5 @@
 import { testSaga } from 'redux-saga-test-plan'
-
+import { Remote } from 'blockchain-wallet-v4/src'
 import * as A from './actions'
 import { selectors } from 'data'
 import sagas from './sagas'
@@ -18,6 +18,9 @@ const mockPairs = [
   'BCH-ETH',
   'XLM-ETH'
 ]
+
+const mockCoinAvailability = coin =>
+  Remote.of({ exchangeFrom: true, exchangeTo: true })
 
 const api = {
   fetchAvailablePairs: jest.fn(() => mockPairs)
@@ -40,6 +43,9 @@ describe('Exchanges rates sagas', () => {
       saga
         .next({ pairs: mockPairs })
         .select(selectors.core.walletOptions.getCoinAvailability)
+    })
+    it('should set available pairs', () => {
+      saga.next(mockCoinAvailability).put(A.availablePairsSuccess(mockPairs))
     })
   })
 


### PR DESCRIPTION
## Description
For BSV we only allow exchangeFrom not exchangeTo, this adds logic to the getAvailablePairs selector and wallet-options, one day we may also want to disable exchangeFrom for w/e reason so added that too

## Change Type
- Upgrades

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] `README.md` and other documentation is updated as needed

