### PR TITLE
fix(Swap): prevented latest eth tx check error from popping up every time

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/exchange/exchange.sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/exchange/exchange.sagas.js
@@ -171,7 +171,7 @@ export default ({ api, coreSagas, networks }) => {
   const getAmounts = function*(pair) {
     const amountsR = yield select(S.getAmounts(pair))
 
-    if (Remote.Loading.is(amountsR)) {
+    if (Remote.Loading.is(amountsR) || Remote.NotAsked.is(amountsR)) {
       const quote = yield take(actionTypes.modules.rates.SET_PAIR_QUOTE)
       return compose(
         S.adviceToAmount,
@@ -330,13 +330,13 @@ export default ({ api, coreSagas, networks }) => {
   }
 
   const checkLatestTx = function*(coin) {
+    const currentError = yield select(formErrorSelector)
     try {
       yield put(A.setTxError(null))
       if (coin !== 'ETH') return
       yield put(actions.form.startAsyncValidation(EXCHANGE_FORM))
       const provisionalPayment = yield call(getProvisionalPayment, false)
       if (provisionalPayment.unconfirmedTx) throw LATEST_TX_ERROR
-      yield put(actions.form.stopAsyncValidation(EXCHANGE_FORM))
     } catch (e) {
       if (e === MIN_ERROR) return
       yield put(
@@ -344,6 +344,9 @@ export default ({ api, coreSagas, networks }) => {
           e === LATEST_TX_ERROR ? LATEST_TX_ERROR : LATEST_TX_FETCH_FAILED_ERROR
         )
       )
+    } finally {
+      const errors = currentError ? { _error: currentError } : undefined
+      yield put(actions.form.stopAsyncValidation(EXCHANGE_FORM, errors))
     }
   }
 
@@ -507,10 +510,10 @@ export default ({ api, coreSagas, networks }) => {
       }
 
       yield call(startValidation)
-      yield call(checkLatestTx, sourceCoin)
       yield call(clearMinMax)
       yield call(unsubscribeFromCurrentAdvice, form)
       yield call(changeSubscription, true)
+      yield call(checkLatestTx, sourceCoin)
       yield call(updateSourceFee)
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'changeSource', e))
@@ -540,9 +543,9 @@ export default ({ api, coreSagas, networks }) => {
       }
 
       yield call(startValidation)
-      yield call(checkLatestTx, newSourceCoin || sourceCoin)
       yield call(unsubscribeFromCurrentAdvice, form)
       yield call(changeSubscription, true)
+      yield call(checkLatestTx, newSourceCoin || sourceCoin)
       yield call(updateSourceFee)
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'changeTarget', e))
@@ -558,7 +561,6 @@ export default ({ api, coreSagas, networks }) => {
       yield put(
         actions.form.change(EXCHANGE_FORM, getActiveFieldName(form), amount)
       )
-      yield call(checkLatestTx, path(['source', 'coin'], form))
       yield put(A.setShowError(true))
       yield call(changeSubscription)
       yield call(updateSourceFee)
@@ -581,8 +583,8 @@ export default ({ api, coreSagas, networks }) => {
         actions.form.change(EXCHANGE_FORM, newInputField, newInputAmount)
       )
       yield call(startValidation)
-      yield call(checkLatestTx, path(['source', 'coin'], form))
       yield call(changeSubscription)
+      yield call(checkLatestTx, path(['source', 'coin'], form))
       yield call(updateMinMax)
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'changeFix', e))
@@ -612,9 +614,9 @@ export default ({ api, coreSagas, networks }) => {
         actions.form.change(EXCHANGE_FORM, oppositeField, currentFieldAmount)
       )
       yield call(startValidation)
-      yield call(checkLatestTx, prop('source', target))
       yield call(unsubscribeFromCurrentAdvice, { source, target })
       yield call(changeSubscription, true)
+      yield call(checkLatestTx, prop('source', target))
       yield call(clearMinMax)
       yield call(updateSourceFee)
     } catch (e) {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Exchange/ExchangeForm/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Exchange/ExchangeForm/index.js
@@ -114,7 +114,8 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   logExchangeClick: () =>
     dispatch(actions.analytics.logEvent(FIRST_STEP_SUBMIT)),
-  actions: bindActionCreators(actions.components.exchange, dispatch)
+  actions: bindActionCreators(actions.components.exchange, dispatch),
+  formActions: bindActionCreators(actions.form, dispatch)
 })
 
 const enhance = compose(


### PR DESCRIPTION
## Description
1. Fixed 'Failed to fetch latest tx' error when switching to eth
2. Fixed swap button becoming enabled when changing amount

## Change Type
Please enter one or more of the following: 
- Feature
- Bug Fix
- CI/CD
- Upgrades
- Other (add explanation)

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] `README.md` and other documentation is updated as needed

