### PR TITLE
feat(header/footer): links rename 

### DIFF
--- a/packages/blockchain-info-components/src/Footer/index.js
+++ b/packages/blockchain-info-components/src/Footer/index.js
@@ -274,9 +274,7 @@ class Footer extends PureComponent {
                     <NavBadge>Info</NavBadge>
                   </li>
                   <li>
-                    <Link href='https://bps.blockchain.com/'>
-                      Principal Strategies
-                    </Link>
+                    <Link href='/markets'>Markets</Link>
                   </li>
                   <li>
                     <Link locale={this.lang} href={'/api'}>
@@ -290,8 +288,8 @@ class Footer extends PureComponent {
                 <h5>Data</h5>
                 <ul>
                   <li>
-                    <Link locale={this.lang} href={'/markets'}>
-                      Markets
+                    <Link locale={this.lang} href={'/prices'}>
+                      Prices
                     </Link>
                     <NavBadge>New</NavBadge>
                   </li>

--- a/packages/blockchain-info-components/src/Navigation/index.js
+++ b/packages/blockchain-info-components/src/Navigation/index.js
@@ -239,10 +239,7 @@ const productsList = [
   },
   {
     title: (
-      <FormattedMessage
-        id='header.products.bps'
-        defaultMessage='Principal Strategies'
-      />
+      <FormattedMessage id='header.products.markets' defaultMessage='Markets' />
     ),
     desc: (
       <FormattedMessage
@@ -250,7 +247,7 @@ const productsList = [
         defaultMessage='Institutional Portal'
       />
     ),
-    link: 'https://bps.blockchain.com',
+    link: '/markets',
     locale: LOCALE,
     event: 'header_principal'
   },
@@ -275,18 +272,16 @@ const productsList = [
 
 const dataList = [
   {
-    title: (
-      <FormattedMessage id='header.data.markets' defaultMessage='Markets' />
-    ),
+    title: <FormattedMessage id='header.data.prices' defaultMessage='Prices' />,
     desc: (
       <FormattedMessage
-        id='header.data.markets-desc'
-        defaultMessage='Prices, Quotes, and More'
+        id='header.data.prices-desc'
+        defaultMessage='Quotes, News, and More'
       />
     ),
-    link: '/markets',
+    link: '/prices',
     locale: LOCALE,
-    event: 'header_markets'
+    event: 'header_prices'
   },
   {
     title: <FormattedMessage id='header.data.charts' defaultMessage='Charts' />,


### PR DESCRIPTION

## Description
Navigation/Footer: Update links for markets relaunch,
Data - Markets (links to "/markets") => Data - Prices (links to "/prices")
Products - Principal Strategies (links to "bps.blockchain.com") => Products - Markets (links to "/markets")

## Change Type
- Feature

## Testing Steps
Open verify header/footer links work

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)

