### PR TITLE
Feat(Add BTC 1.3 app support to Lockbox onboard)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Tooltips/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Tooltips/index.js
@@ -7,6 +7,12 @@ class Tooltips extends React.PureComponent {
     return (
       <div>
         <Tooltip id='addr' multiline offset={{ bottom: 8 }} />
+        <Tooltip id='lockbox.exportkeys'>
+          <FormattedMessage
+            id='modals.lockboxsetup.pairdevice.tooltip'
+            defaultMessage='Exporting the public keys from the device allows the app to show your hardware wallets balances even when the device is not connected to your computer.'
+          />
+        </Tooltip>
         <Tooltip id='isx.expiredtooltip'>
           <FormattedMessage
             id='scenes.buysell.coinify.isx.expiredtooltip'

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/lockbox/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/lockbox/sagas.js
@@ -425,6 +425,9 @@ export default ({ api }) => {
         connection.deviceType,
         connection.transport
       )
+      // increase transport timeout in case BTC app version > 1.3 as user will
+      // have to manually allow the export of pub keys on device
+      connection.transport.exchangeTimeout = 45000
       // derive device info (chaincodes and xpubs)
       const newDeviceInfo = yield call(
         Lockbox.utils.deriveDeviceInfo,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Lockbox/LockboxSetup/PairDeviceStep/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Lockbox/LockboxSetup/PairDeviceStep/template.js
@@ -10,7 +10,9 @@ import {
   Image,
   Link,
   Text,
-  TextGroup
+  TextGroup,
+  TooltipHost,
+  TooltipIcon
 } from 'blockchain-info-components'
 
 const Wrapper = styled.div`
@@ -20,9 +22,14 @@ const Wrapper = styled.div`
   align-items: center;
 `
 const IntroText = styled(Text)`
-  margin: 16px 0 40px;
+  margin-top: 16px;
   text-align: center;
 `
+const ExportKeysText = styled(Text)`
+  margin: 10px 0 40px;
+  text-align: center;
+`
+
 const ClickableText = styled(Text)`
   color: ${props => props.theme['brand-secondary']};
   cursor: pointer;
@@ -51,6 +58,11 @@ const SupportListItem = styled(FormItem)`
 const CheckboxLabel = styled.label`
   margin-top: 3px;
   margin-left: 12px;
+`
+const Tooltip = styled(TooltipHost)`
+  & > span {
+    font-size: 12px;
+  }
 `
 const PairDeviceStep = props => {
   const {
@@ -194,6 +206,19 @@ const PairDeviceStep = props => {
           values={{ deviceType }}
         />
       </IntroText>
+      <ExportKeysText size='12px' weight={300}>
+        <FormattedHTMLMessage
+          id='modals.lockboxsetup.pairdevice.exportkeys'
+          defaultMessage='After the app has been opened, check for instructions on the device as you may have to allow the export of your public keys multiple times.'
+        />
+        <Tooltip
+          id='lockbox.exportkeys'
+          data-place='right'
+          style={{ marginTop: '3px' }}
+        >
+          <TooltipIcon name='question-in-circle' />
+        </Tooltip>
+      </ExportKeysText>
       <TextGroup inline style={{ marginBottom: '14px' }}>
         <Text size='10px' weight={300}>
           <FormattedHTMLMessage

--- a/packages/blockchain-wallet-v4-frontend/src/services/LockboxService/apps.js
+++ b/packages/blockchain-wallet-v4-frontend/src/services/LockboxService/apps.js
@@ -16,8 +16,8 @@ import constants from './constants'
 const uninstallApp = (transport, baseUrl, targetId, appInfo) => {
   return new Promise(async (resolve, reject) => {
     try {
-      // ensure timeout is always ong enough for uninstall to complete
-      transport.exchangeTimeout = 60000
+      // ensure timeout is long enough for user to allow device access
+      transport.exchangeTimeout = 20000
       // socket params
       const params = {
         targetId,
@@ -62,8 +62,8 @@ const uninstallApp = (transport, baseUrl, targetId, appInfo) => {
 const installApp = (transport, baseUrl, targetId, appName, appInfos) => {
   return new Promise(async (resolve, reject) => {
     try {
-      // ensure timeout is always ong enough for install to complete
-      transport.exchangeTimeout = 60000
+      // ensure timeout is long enough for user to allow device access
+      transport.exchangeTimeout = 20000
       // derive latest app info
       const latestAppInfo = find(propEq('app', constants.appIds[appName]))(
         appInfos


### PR DESCRIPTION
## Description
- latest BTC app requires the user to allow the export of public keys on the actual device.  Since we do this during device setup, we need copy to inform the user that this may be required.
- Increased BTC app transport during the xpub derivation process to account for user needed to allow the export on device.
- decreased the default app uninstall/install timeout to 20 seconds 

## Change Type
- Feature

## Testing Steps
Device must have BTC app version of 1.3.2

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] `README.md` and other documentation is updated as needed

