### PR TITLE
fix(BCH): Use script instead of coin.script to construct outputs

### DIFF
--- a/packages/blockchain-wallet-v4/src/signer/bch.js
+++ b/packages/blockchain-wallet-v4/src/signer/bch.js
@@ -123,9 +123,7 @@ export const signWithLockbox = function*(
 
     amount.writeUInt32LE(coin.value)
     outputs +=
-      amount.toString('hex') +
-      intToHex(script.length) +
-      coin.script.toString('hex')
+      amount.toString('hex') + intToHex(script.length) + script.toString('hex')
   })
 
   const dustTxHex = yield api.getBchRawTx(coinDust.txHash)


### PR DESCRIPTION
Assigning @salomegeo because I miss you

## Description
2140

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
1. swap from lockbox bch

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] `README.md` and other documentation is updated as needed

