### PR TITLE
Fix(Camera staying on after QR code login)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -323,7 +323,6 @@ export default ({ api, coreSagas }) => {
         yield put(actions.alerts.displayError(C.MOBILE_LOGIN_ERROR))
       }
     }
-    yield put(actions.modals.closeModal())
   }
   const register = function*(action) {
     try {

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Mobile/MobileLogin/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Mobile/MobileLogin/index.js
@@ -6,22 +6,16 @@ import { isNil, isEmpty } from 'ramda'
 import * as C from 'services/AlertService'
 import { actions } from 'data'
 import modalEnhancer from 'providers/ModalEnhancer'
-import MobileLogin from './template.js'
+import MobileLogin from './template'
 
 class MobileLoginContainer extends React.PureComponent {
-  constructor (props) {
-    super(props)
-    this.handleScan = this.handleScan.bind(this)
-    this.handleError = this.handleError.bind(this)
-  }
-
-  handleScan (result) {
+  handleScan = result => {
     if (!isNil(result) && !isEmpty(result)) {
       this.props.authActions.mobileLogin(result)
     }
   }
 
-  handleError (error) {
+  handleError = error => {
     if (isNil(error) && isEmpty(error)) {
       this.props.alertsActions.displayError(C.MOBILE_LOGIN_SCAN_ERROR)
     }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/index.js
@@ -39,7 +39,7 @@ import {
   LockboxConnectionPrompt,
   LockboxShowXPubs
 } from './Lockbox'
-import { MobileLogin, MobileNumberChange, MobileNumberVerify } from './Mobile'
+import { MobileNumberChange, MobileNumberVerify } from './Mobile'
 import {
   AirdropReminder,
   SwapGetStarted,
@@ -99,7 +99,6 @@ const Modals = () => (
     <LockboxShowXPubs />
     <MobileNumberChange />
     <MobileNumberVerify />
-    <MobileLogin />
     <Onfido />
     <PairingCode />
     <PromptInput />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/template.js
@@ -25,7 +25,6 @@ import {
   PasswordBox,
   TextBox
 } from 'components/Form'
-import Modals from 'modals'
 import MobileLogin from 'modals/Mobile/MobileLogin'
 
 const isSupportedBrowser =
@@ -99,9 +98,7 @@ const Login = props => {
 
   return (
     <Wrapper>
-      <Modals>
-        <MobileLogin />
-      </Modals>
+      <MobileLogin />
       <Header>
         <Text size='24px' weight={300} capitalize>
           <FormattedMessage


### PR DESCRIPTION
## Description
- Fixes issue where camera would stay on after user logs in via QR code.

## Notes
Im not entirely sure why this was happening, but it seems that having the `MobileLogin` modal added to the login template as well as added via the `Modals` wrapper in the `WalletLayout` caused the QR code library we are using to never unmount properly thus it would cause camera to stay on and loop inside an error hook.  

I removed the `MobileLogin` modal from being added in the `Modal` components wrapper to avoid the above scenario. 

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] `README.md` and other documentation is updated as needed

