### PR TITLE
Fix(Lockbox remove hash from install/uninstall WS urls)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/services/LockboxService/apps.js
+++ b/packages/blockchain-wallet-v4-frontend/src/services/LockboxService/apps.js
@@ -42,6 +42,7 @@ const uninstallApp = (transport, baseUrl, targetId, appInfo) => {
       // ensure timeout is long enough for user to allow device access
       transport.exchangeTimeout = 20000
       // socket params
+      // `hash` property may need to be added back again in the future
       const params = {
         targetId,
         perso: appInfo.perso,
@@ -91,6 +92,7 @@ const installApp = (transport, baseUrl, targetId, appName, appInfos) => {
         appInfos
       )
       // socket params
+      // `hash` property may need to be added back again in the future
       const params = {
         targetId,
         perso: latestAppInfo.perso,

--- a/packages/blockchain-wallet-v4-frontend/src/services/LockboxService/apps.js
+++ b/packages/blockchain-wallet-v4-frontend/src/services/LockboxService/apps.js
@@ -47,8 +47,7 @@ const uninstallApp = (transport, baseUrl, targetId, appInfo) => {
         perso: appInfo.perso,
         deleteKey: appInfo.delete_key,
         firmware: appInfo.delete,
-        firmwareKey: appInfo.delete_key,
-        hash: appInfo.hash
+        firmwareKey: appInfo.delete_key
       }
 
       // build socket url
@@ -97,8 +96,7 @@ const installApp = (transport, baseUrl, targetId, appName, appInfos) => {
         perso: latestAppInfo.perso,
         deleteKey: latestAppInfo.delete_key,
         firmware: latestAppInfo.firmware,
-        firmwareKey: latestAppInfo.firmware_key,
-        hash: latestAppInfo.hash
+        firmwareKey: latestAppInfo.firmware_key
       }
 
       // build socket url


### PR DESCRIPTION
## Description
- `hash` is not used by Ledger yet.  Sending an empty one can apparently break things at times. Remove hash.

## Change Type
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] `README.md` and other documentation is updated as needed