### PR TITLE
Fix(BTC, BCH 0 confirmation logic)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/TransactionListItem/Confirmations/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/TransactionListItem/Confirmations/index.js
@@ -66,7 +66,7 @@ const getMinConfirms = coin => {
 const Confirmations = props => {
   const { blockHeight, coin, txBlockHeight } = props
   const conf = blockHeight - txBlockHeight + 1
-  const confirmations = conf > 0 ? conf : 0
+  const confirmations = conf > 0 && txBlockHeight ? conf : 0
   const minConfirmations = getMinConfirms(coin)
 
   return (


### PR DESCRIPTION
## Description
- Fix issue for BTC/BCH showing tx confirmed when there are 0 confirmations. A missing `txBlockHeight` property inherently means 0 confirmations

## Change Type
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] `README.md` and other documentation is updated as needed

