### PR TITLE
fix: remove extra character before swap max error

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Exchange/ExchangeForm/Error/validationMessages.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Exchange/ExchangeForm/Error/validationMessages.js
@@ -141,7 +141,6 @@ export const MinimumAmountMessage = () => (
 export const MaximumAmountMessage = () => (
   <Wrapper>
     <Text size='12px' weight={300} color='error' data-e2e='exchangeAboveMax'>
-      >
       <FormattedMessage
         id='scenes.exchange.exchangeform.error.maximumamount'
         defaultMessage='Amount is above maximum.'


### PR DESCRIPTION
## Description
WEB4-2207 removed extra character from swap error message

## Change Type
Please enter one or more of the following: 
- Bug Fix

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] `README.md` and other documentation is updated as needed

