### PR TITLE
fix: used fetchTimebounds instead of setTimeout for xlm txs

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/xlm/index.js
+++ b/packages/blockchain-wallet-v4/src/network/api/xlm/index.js
@@ -23,6 +23,8 @@ export default ({ apiUrl, horizonUrl, network, get }) => {
 
   const getXlmAccount = publicKey => server.loadAccount(publicKey)
 
+  const getTimebounds = waitTime => server.fetchTimebounds(waitTime)
+
   const getXlmFees = () =>
     get({
       url: apiUrl,
@@ -76,6 +78,7 @@ export default ({ apiUrl, horizonUrl, network, get }) => {
     getXlmFees,
     getXlmTransactions,
     getXlmTicker,
+    getTimebounds,
     pushXlmTx
   }
 }


### PR DESCRIPTION
## Description
changed setTimeout to fetchTimebounds, which uses the server to get the time, not local time. Should hopefully resolve tx_too_late errors

## Change Type
Please enter one or more of the following: 
- Bug Fix


## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] `README.md` and other documentation is updated as needed

