### PR TITLE
Feat(Update XLM memo to exchange style and copy)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Xlm/SendXlm/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Xlm/SendXlm/FirstStep/template.success.js
@@ -236,11 +236,14 @@ const FirstStep = props => {
               </MemoField>
             </FormItem>
             {isDestinationExchange && (
-              <WarningBanners type='info' data-e2e='sendXlmToExchangeAddress'>
+              <WarningBanners
+                type='warning'
+                data-e2e='sendXlmToExchangeAddress'
+              >
                 <Text color='warning' size='12px'>
                   <FormattedMessage
-                    id='modals.sendxlm.firststep.sendtoexchange'
-                    defaultMessage='Sending XLM to an exchange often requires adding a memo. Be sure to add a memo if required.'
+                    id='modals.sendxlm.firststep.sendtoexchange2'
+                    defaultMessage='Sending XLM to an exchange often requires adding a memo. Failing to include a required memo may result in a loss of funds!'
                   />
                   <Link
                     href='https://support.blockchain.com/hc/en-us/articles/360018797312-Stellar-memos'
@@ -248,6 +251,7 @@ const FirstStep = props => {
                     size='11px'
                     weight={700}
                     altFont
+                    color='red'
                   >
                     <FormattedMessage
                       id='modals.sendxlm.firststep.sendtoexchangelearn'


### PR DESCRIPTION
## Description
- Updates copy and styles the alert red to warn users about not adding a memo when sending XLM to a known exchange address

## Change Type
- Feature

## Testing Steps
Detail the steps required for the reviewer(s) to verify and test these changes.

## Code Checklist
- [ ] Code compiles successfully (verified via `yarn start`)
- [ ] `README.md` and other documentation is updated as needed