### PR TITLE
refactor(migration): Remove unused domain migration code.

### DIFF
--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -3,7 +3,6 @@
     "web": {
       "application": {
         "analyticsSiteId": 2,
-        "enableDomainMigrationRedirects": true,
         "environment": "dev",
         "announcements": {
           "lockbox": {},

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Public/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Public/index.js
@@ -10,13 +10,6 @@ import Alerts from 'components/Alerts'
 import ErrorBoundary from 'providers/ErrorBoundaryProvider'
 import { selectors } from 'data'
 import media from 'services/ResponsiveService'
-import { isOnDotInfo } from 'services/MigrationService'
-
-const defaultDomains = {
-  root: 'https://blockchain.info',
-  comWalletApp: 'https://login.blockchain.com',
-  comRoot: 'https://blockchain.com'
-}
 
 const Wrapper = styled.div`
   background-color: ${props => props.theme['brand-primary']};
@@ -57,20 +50,6 @@ const ContentContainer = styled.div`
 const ComponentContainer = styled.div``
 
 class PublicLayoutContainer extends React.PureComponent {
-  componentDidMount () {
-    const { domainsR, migrationRedirectsR, pathname } = this.props
-    const domains = domainsR.getOrElse(defaultDomains)
-    const enableRedirects = migrationRedirectsR.getOrElse(false)
-
-    if (enableRedirects && isOnDotInfo(domains)) {
-      if (pathname === '/wallet') {
-        window.location = `${domains.comRoot}/wallet`
-      } else {
-        window.location = `${domains.comWalletApp}/${pathname}`
-      }
-    }
-  }
-
   render () {
     const { component: Component, ...rest } = this.props
     return (
@@ -102,9 +81,7 @@ class PublicLayoutContainer extends React.PureComponent {
 }
 
 const mapStateToProps = state => ({
-  pathname: selectors.router.getPathname(state),
-  domainsR: selectors.core.walletOptions.getDomains(state),
-  migrationRedirectsR: selectors.core.walletOptions.getMigrationRedirects(state)
+  pathname: selectors.router.getPathname(state)
 })
 
 export default connect(mapStateToProps)(PublicLayoutContainer)

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Public/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Public/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import { Route } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -8,7 +7,6 @@ import Header from './Header'
 import Footer from './Footer'
 import Alerts from 'components/Alerts'
 import ErrorBoundary from 'providers/ErrorBoundaryProvider'
-import { selectors } from 'data'
 import media from 'services/ResponsiveService'
 
 const Wrapper = styled.div`
@@ -80,8 +78,4 @@ class PublicLayoutContainer extends React.PureComponent {
   }
 }
 
-const mapStateToProps = state => ({
-  pathname: selectors.router.getPathname(state)
-})
-
-export default connect(mapStateToProps)(PublicLayoutContainer)
+export default PublicLayoutContainer

--- a/packages/blockchain-wallet-v4-frontend/src/services/MigrationService/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/services/MigrationService/index.js
@@ -1,9 +1,0 @@
-export function isOnDotCom (domains) {
-  if (domains == null) throw new Error('isOnDotCom expects env domains')
-  return window.location.origin === domains.comWalletApp
-}
-
-export function isOnDotInfo (domains) {
-  if (domains == null) throw new Error('isOnDotInfo expects env domains')
-  return window.location.origin === domains.root
-}

--- a/packages/blockchain-wallet-v4/src/redux/walletOptions/__mocks__/wallet-options-v4.js
+++ b/packages/blockchain-wallet-v4/src/redux/walletOptions/__mocks__/wallet-options-v4.js
@@ -3,7 +3,6 @@ export default {
     web: {
       application: {
         analyticsSiteId: 1,
-        enableDomainMigrationRedirects: true,
         environment: 'dev',
         announcements: {
           lockbox: {},

--- a/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.js
+++ b/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.js
@@ -27,10 +27,6 @@ export const getAnalyticsSiteId = state =>
   getWebOptions(state).map(path(['application', 'analyticsSiteId']))
 export const getAnnouncements = state =>
   getWebOptions(state).map(path(['application', 'announcements']))
-export const getMigrationRedirects = state =>
-  getWebOptions(state).map(
-    path(['application', 'enableDomainMigrationRedirects'])
-  )
 export const getAdsBlacklist = state =>
   getWebOptions(state).map(path(['ads', 'blacklist']))
 export const getAdsUrl = state => getWebOptions(state).map(path(['ads', 'url']))

--- a/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.spec.js
+++ b/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.spec.js
@@ -31,12 +31,6 @@ describe('walletOptions selectors', () => {
     )
   })
 
-  it('getMigrationRedirects should return correct redirects', () => {
-    expect(selectors.getMigrationRedirects(successState)).toEqual(
-      Remote.of(true)
-    )
-  })
-
   it('getCoinAvailability should return correct btc availability', () => {
     const expected = {
       send: true,


### PR DESCRIPTION
## Description
@plondon:
> I think for this code what happened was we were preparing for .info .com move, and if v4 was
deployed before the migration we were going to need this redirect.  But we deployed v4 after, so
this code was preliminary and is no longer necessary.

**After this PR lands in production we should inform the backend team that we no longer consume the `enableDomainMigrationRedirects` option.**

## Change Type
Please enter one or more of the following: 
- Other (add explanation)
Refactor

## Testing Steps
No test.

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] `README.md` and other documentation is updated as needed

