### PR TITLE
fix(LinkContext): create full deep link with required parameters

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmailToken/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmailToken/index.js
@@ -9,6 +9,9 @@ import Error from './template.error'
 import { Wrapper } from 'components/Public'
 
 const VALID_CONTEXTS = ['PIT_SIGNUP', 'KYC', 'SETTINGS']
+const PARAM_DEEP_LINK_PATH = 'email_verified'
+const PARAM_ISI = '493253309'
+const PARAM_IBI = 'com.rainydayapps.Blockchain'
 
 class VerifyEmailToken extends React.PureComponent {
   state = {
@@ -27,12 +30,21 @@ class VerifyEmailToken extends React.PureComponent {
     const isProdEnv = this.props.appEnv === 'prod'
 
     const link = isProdEnv
-      ? 'https://blockchain.page.link/email_verified'
-      : 'https://blockchainwalletstaging.page.link/email_verified'
+      ? 'https://blockchain.page.link/'
+      : 'https://blockchainwalletstaging.page.link/'
 
-    const isValidContext = VALID_CONTEXTS.indexOf(context) > -1
+    const params = new URLSearchParams()
+    params.set('deep_link_path', PARAM_DEEP_LINK_PATH)
+    params.set('isi', PARAM_ISI)
+    params.set('ibi', PARAM_IBI)
 
-    return isValidContext ? `${link}?context=${context}` : link
+    if (VALID_CONTEXTS.indexOf(context) > -1) {
+      params.set('context', context)
+    }
+
+    const deepLinkComponent = `${window.location.origin}/login?${params}`
+
+    return link + '?link=' + encodeURIComponent(deepLinkComponent)
   }
 
   render () {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmailToken/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmailToken/index.js
@@ -12,6 +12,7 @@ const VALID_CONTEXTS = ['PIT_SIGNUP', 'KYC', 'SETTINGS']
 const PARAM_DEEP_LINK_PATH = 'email_verified'
 const PARAM_ISI = '493253309'
 const PARAM_IBI = 'com.rainydayapps.Blockchain'
+const PARAM_APN = 'piuk.blockchain.android'
 
 class VerifyEmailToken extends React.PureComponent {
   state = {
@@ -37,6 +38,7 @@ class VerifyEmailToken extends React.PureComponent {
     params.set('deep_link_path', PARAM_DEEP_LINK_PATH)
     params.set('isi', PARAM_ISI)
     params.set('ibi', PARAM_IBI)
+    params.set('apn', PARAM_APN)
 
     if (VALID_CONTEXTS.indexOf(context) > -1) {
       params.set('context', context)


### PR DESCRIPTION
## Description
Just adding the param to the deep link directly doesn't seem to work, this creates a longer link but one that should be able to pass on the `context` param.

@bchrisarriola does this seem more like what you need?

## Change Type
- Feature

## Code Checklist
- [x] Code compiles successfully (verified via `yarn start`)
- [x] `README.md` and other documentation is updated as needed

