### PR TITLE
fix(LinkContext): Remove double-uri encoding

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmailToken/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmailToken/index.js
@@ -44,7 +44,7 @@ class VerifyEmailToken extends React.PureComponent {
     const deepLink = `${window.location.origin}/login?${deepLinkParams}`
 
     const params = new URLSearchParams()
-    params.set('link', encodeURIComponent(deepLink))
+    params.set('link', deepLink)
     params.set('isi', PARAM_ISI)
     params.set('ibi', PARAM_IBI)
     params.set('apn', PARAM_APN)


### PR DESCRIPTION
## Description
Before, the deep link was getting double-URI encoded, because I didn't realize that `URLSearchParams` actually does the encoding for you. This removes the first layer of URI-encoding.