### PR TITLE
 Fix: BTC Request QR Code Bip21

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/template.shareLink.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/template.shareLink.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { FormattedMessage } from 'react-intl'
+import bip21 from 'bip21'
 
 import { Button, Text, TextGroup } from 'blockchain-info-components'
 import CopyClipboard from 'components/CopyClipboard'
@@ -54,6 +55,10 @@ const ShareRequestLink = props => {
   const link = `https://blockchain.com/btc/payment_request?address=${receiveAddress}&amount=${
     requestAmount.coin
   }&message=${requestMessage}`
+  const requestBip21 = bip21.encode(receiveAddress, {
+    amount: requestAmount.coin,
+    label: requestMessage
+  })
 
   return (
     <React.Fragment>
@@ -66,7 +71,7 @@ const ShareRequestLink = props => {
       <Details>
         <QrCodeColumn>
           <QRCodeWrapper
-            value={receiveAddress}
+            value={requestBip21}
             size={150}
             data-e2e='requestBtcAddressQrCode'
           />


### PR DESCRIPTION
## Description 
- Simply changed the qr code in `template.shareLink.js` to render a bip21 encoded message containing address, amount, and label.

## Testing Steps (optional)
1. Fill out a btc request form and click `create sharable link`.
2. Scan the QR code with the mobile app to check that address and amount have been auto-filled.
