### PR TITLE
Fix XLM Socket

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -93,7 +93,6 @@ export default ({ api, coreSagas }) => {
     yield put(actions.middleware.webSocket.bch.startSocket())
     yield put(actions.middleware.webSocket.btc.startSocket())
     yield put(actions.middleware.webSocket.eth.startSocket())
-    yield put(actions.middleware.webSocket.xlm.startStreams())
   }
 
   const authNabu = function * () {
@@ -123,6 +122,7 @@ export default ({ api, coreSagas }) => {
         coreSagas.kvStore.eth.fetchMetadataEth,
         askSecondPasswordEnhancer
       )
+      yield put(actions.middleware.webSocket.xlm.startStreams())
       yield call(
         coreSagas.kvStore.xlm.fetchMetadataXlm,
         askSecondPasswordEnhancer

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.spec.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.spec.js
@@ -385,6 +385,10 @@ describe('authSagas', () => {
         .call(coreSagas.kvStore.eth.fetchMetadataEth, askSecondPasswordEnhancer)
     })
 
+    it('should start xlm socket', () => {
+      saga.next().put(actions.middleware.webSocket.xlm.startStreams())
+    })
+
     it('should fetch xlm metadata', () => {
       saga
         .next()


### PR DESCRIPTION
## Description 
1. Moved `actions.middleware.webSocket.xlm.startStreams()` to execute before `coreSagas.kvStore.xlm.fetchMetadataXlm` in order to avoid race condition with setting `onMessage` and `onError` attributes of the `HorizonStreamingService`.
2. Added test for `startStreams()`.

## Testing Steps
1. Open up two wallet sessions in different tabs. 
2. Send xlm from once account to the other.
3. Check to make sure alert popup fires, and balance updates without refreshing.
