### PR TITLE
fix/legacy-eth-dust

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -10,7 +10,8 @@ import {
   promptForSecondPassword,
   forceSyncWallet
 } from 'services/SagaService'
-import { Remote } from 'blockchain-wallet-v4/src'
+import { Remote, utils } from 'blockchain-wallet-v4/src'
+
 import { checkForVulnerableAddressError } from 'services/ErrorCheckService'
 
 export const logLocation = 'auth/sagas'
@@ -66,11 +67,17 @@ export default ({ api, coreSagas }) => {
     )
     const legacyAccount = legacyAccountR.getOrElse(null)
     const { addr, correct } = legacyAccount || {}
+    const fees = yield call(api.getEthFees)
+    const feeAmount = yield call(
+      utils.eth.calculateFee,
+      fees.regular,
+      fees.gasLimit
+    )
     // If needed, get the eth legacy account balance and prompt sweep
     if (!correct && addr) {
       const balances = yield call(api.getEthBalances, addr)
       const balance = path([addr, 'balance'], balances)
-      if (balance > 0) {
+      if (balance > feeAmount) {
         yield put(actions.modals.showModal('TransferEth', { balance, addr }))
         yield put(actions.analytics.logEvent(LOGIN_EVENTS.TRANSFER_ETH_LEGACY))
       }


### PR DESCRIPTION
WEB4-2683

## Description 
Adding fee lookup and calculation before prompting the legacy transfer.
If current balance is less than regular transaction fee times 21000 gas limit for a transfer,
do not prompt transfer

## Testing Steps 
1. Login with wallet that has a legacy eth address (5f0a9223-d295-4b5a-81da-9f23e435ed4a). Notice how transfer modal does not pop up on signup since transaction fee is greater than balance.
3. Send funds to address in excess of transaction fee. Notice the modal will now show on login.
