### PR TITLE
Fix/block-bc1

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/importBtcAddress/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/importBtcAddress/sagas.js
@@ -36,7 +36,11 @@ export default ({ api, coreSagas, networks }) => {
     }
 
     // address handling (watch-only)
-    if (value && utils.btc.isValidBtcAddress(value, networks.btc)) {
+    if (
+      value &&
+      utils.btc.isValidBtcAddress(value, networks.btc) &&
+      !utils.btc.isSegwitAddress(value)
+    ) {
       yield call(importLegacyAddress, value, null, null, null, null)
     }
   }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/ImportBtcAddress/ImportExternalBtcAddress/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/ImportBtcAddress/ImportExternalBtcAddress/index.js
@@ -7,8 +7,12 @@ import {
   SelectBoxBtcAddresses,
   TextBox
 } from 'components/Form'
+import {
+  isSegwitAddress,
+  required,
+  validBtcAddressOrPrivateKey
+} from 'services/FormHelper'
 import { removeWhitespace } from 'services/FormHelper/normalizers'
-import { required, validBtcAddressOrPrivateKey } from 'services/FormHelper'
 import { spacing } from 'services/StyleService'
 import QRCodeCapture from 'components/QRCodeCapture'
 import React from 'react'
@@ -49,7 +53,11 @@ class ImportExternalBtcAddress extends React.PureComponent {
             <Row>
               <Field
                 name='addrOrPriv'
-                validate={[validBtcAddressOrPrivateKey, required]}
+                validate={[
+                  validBtcAddressOrPrivateKey,
+                  required,
+                  isSegwitAddress
+                ]}
                 normalize={removeWhitespace}
                 component={TextBox}
                 data-e2e='addressOrPrKeyInput'

--- a/packages/blockchain-wallet-v4-frontend/src/services/FormHelper/validationMessages.js
+++ b/packages/blockchain-wallet-v4-frontend/src/services/FormHelper/validationMessages.js
@@ -39,7 +39,7 @@ export const InvalidBtcAddressAndPrivateKeyMessage = () => (
 export const SegwitAddressMessage = () => (
   <FormattedMessage
     id='formhelper.segwitaddress'
-    defaultMessage='Segwit addresses are not supported.'
+    defaultMessage='Segwit addresses are not supported'
   />
 )
 export const InvalidEmailCodeMessage = () => (

--- a/packages/blockchain-wallet-v4-frontend/src/services/FormHelper/validationMessages.js
+++ b/packages/blockchain-wallet-v4-frontend/src/services/FormHelper/validationMessages.js
@@ -36,6 +36,12 @@ export const InvalidBtcAddressAndPrivateKeyMessage = () => (
     defaultMessage='Not a valid bitcoin address or private key'
   />
 )
+export const SegwitAddressMessage = () => (
+  <FormattedMessage
+    id='formhelper.segwitaddress'
+    defaultMessage='Segwit addresses are not supported.'
+  />
+)
 export const InvalidEmailCodeMessage = () => (
   <FormattedMessage
     id='formhelper.invalidemailcode'

--- a/packages/blockchain-wallet-v4-frontend/src/services/FormHelper/validators.js
+++ b/packages/blockchain-wallet-v4-frontend/src/services/FormHelper/validators.js
@@ -172,6 +172,9 @@ export const validBtcAddressOrPrivateKey = (value, allValues, props) =>
     <M.InvalidBtcAddressAndPrivateKeyMessage />
   )
 
+export const isSegwitAddress = value =>
+  utils.btc.isSegwitAddress(value) ? <M.SegwitAddressMessage /> : undefined
+
 export const validIban = value =>
   isValidIBAN(value) ? undefined : 'Invalid IBAN'
 

--- a/packages/blockchain-wallet-v4/src/utils/btc.js
+++ b/packages/blockchain-wallet-v4/src/utils/btc.js
@@ -23,11 +23,9 @@ export const isValidBtcAddress = (value, network) => {
   } catch (e) {
     try {
       const decoded = decode(value)
-
       if (decoded.prefix !== 'bc') {
         return false
       }
-
       // We only validate version 0 scripts
       // TODO Should we fail other scripts? This would make upgrading harder in the future
       if (decoded.words[0] === 0) {
@@ -40,6 +38,15 @@ export const isValidBtcAddress = (value, network) => {
     } catch (e1) {
       return false
     }
+  }
+}
+
+export const isSegwitAddress = value => {
+  try {
+    const decoded = decode(value)
+    return decoded.prefix === 'bc'
+  } catch (e) {
+    return false
   }
 }
 


### PR DESCRIPTION
## Description 
Block external bc prefixed segwit addresses from being imported

## Testing Steps 
1. Generate segwit address here: https://xcubicle.github.io/memorypaperwallet/
(bc1qng92vjwx57p4nz2esaff2zy0w3yfutpjul7hu4)
2. Setting->Wallets/Addresses->Import Address->External Address
3. Notice validation error message `Segwit addresses are not supported`

