### PR TITLE
Fix/import labels

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxBchAddresses/selectors.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxBchAddresses/selectors.js
@@ -91,7 +91,12 @@ export const getData = (state, ownProps) => {
           ? assoc('label', prop('addr', addressData), a)
           : assoc('label', prop('label', addressData), a),
       a => assocPath(['value', 'type'], ADDRESS_TYPES.LEGACY, a),
-      a => assoc('balance', path(['info', 'final_balance'], addressData), a),
+      a =>
+        assocPath(
+          ['value', 'balance'],
+          path(['info', 'final_balance'], addressData),
+          a
+        ),
       a => assocPath(['value', 'coin'], coin, a),
       a => assocPath(['value', 'address'], prop('addr', addressData), a),
       a => assoc('value', prop('info', addressData), a)
@@ -122,7 +127,6 @@ export const getData = (state, ownProps) => {
       excludeImported
         ? Remote.of([])
         : lift(formatImportedAddressesData)(relevantAddresses)
-            .map(toDropdown)
             .map(toGroup('Imported Addresses'))
             .map(x =>
               set(

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/ImportBtcAddress/ImportExternalBtcAddress/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/ImportBtcAddress/ImportExternalBtcAddress/index.js
@@ -79,7 +79,6 @@ class ImportExternalBtcAddress extends React.PureComponent {
               <Field
                 name='label'
                 validate={[]}
-                normalize={removeWhitespace}
                 component={TextBox}
                 data-e2e='labelInput'
               />


### PR DESCRIPTION
## Description 
1. now allowing spaces in address labels
2. fixed bch dropdown selector to solve request and transfer issues

## Testing Steps
1. create label with spaces
2. request form with imported address
3. transfer funds to imported address

