### PR TITLE
add linkcontainer back to balance dropdown

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Balances/TopMenu.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Balances/TopMenu.js
@@ -1,3 +1,5 @@
+import { LinkContainer } from 'react-router-bootstrap'
+import { toLower } from 'ramda'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -60,19 +62,21 @@ export const CoinBalanceWrapper = props => {
       </FiatDisplay>
     </CoinBalanceMain>
   ) : (
-    <CoinBalanceSwitchable>
-      <Text size='12px' weight={400}>
-        {props.coinTicker ? props.coinTicker : props.coin}
-      </Text>
-      <SwitchableDisplay
-        size='12px'
-        weight={500}
-        coin={props.coin}
-        hideCoinTicker
-      >
-        {props.balance}
-      </SwitchableDisplay>
-    </CoinBalanceSwitchable>
+    <LinkContainer to={`/${toLower(props.coin)}/transactions`}>
+      <CoinBalanceSwitchable>
+        <Text size='12px' weight={400}>
+          {props.coinTicker ? props.coinTicker : props.coin}
+        </Text>
+        <SwitchableDisplay
+          size='12px'
+          weight={500}
+          coin={props.coin}
+          hideCoinTicker
+        >
+          {props.balance}
+        </SwitchableDisplay>
+      </CoinBalanceSwitchable>
+    </LinkContainer>
   )
 }
 

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/WalletBalance/Balance/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/WalletBalance/Balance/template.success.js
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { LinkContainer } from 'react-router-bootstrap'
-import { toLower } from 'ramda'
 
 import { CoinBalanceWrapper } from 'components/Balances'
 
@@ -9,16 +7,14 @@ const Success = props => {
   const { balance, coin, coinTicker, large } = props
 
   return (
-     <LinkContainer to={`/${toLower(coin)}/transactions`}>
-        <div data-e2e={`balanceDropdown-wallet-${coin}`}>
-          <CoinBalanceWrapper
-          coin={coin}
-          balance={balance}
-          large={large}
-          coinTicker={coinTicker}
-          />
-        </div>
-    </LinkContainer>
+    <div data-e2e={`balanceDropdown-wallet-${coin}`}>
+      <CoinBalanceWrapper
+        coin={coin}
+        balance={balance}
+        large={large}
+        coinTicker={coinTicker}
+      />
+    </div>
   )
 }
 

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/WalletBalance/Balance/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuTop/Balance/WalletBalance/Balance/template.success.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { LinkContainer } from 'react-router-bootstrap'
+import { toLower } from 'ramda'
 
 import { CoinBalanceWrapper } from 'components/Balances'
 
@@ -7,14 +9,16 @@ const Success = props => {
   const { balance, coin, coinTicker, large } = props
 
   return (
-    <div data-e2e={`balanceDropdown-wallet-${coin}`}>
-      <CoinBalanceWrapper
-        coin={coin}
-        balance={balance}
-        large={large}
-        coinTicker={coinTicker}
-      />
-    </div>
+     <LinkContainer to={`/${toLower(coin)}/transactions`}>
+        <div data-e2e={`balanceDropdown-wallet-${coin}`}>
+          <CoinBalanceWrapper
+          coin={coin}
+          balance={balance}
+          large={large}
+          coinTicker={coinTicker}
+          />
+        </div>
+    </LinkContainer>
   )
 }
 


### PR DESCRIPTION
## Description (optional)

Fixes issue 113. This undoes https://github.com/blockchain/blockchain-wallet-v4-frontend/commit/0dc7d92d66f1e01349f367d981538f2f59c7068e#diff-1e74d3892617b0624c51881e58bc2c26. 

@jjBlockchain was there a reason LinkContainer was removed? I don't see any issues when adding back it. 


