### PR TITLE
fix(sb-usdd): coin dropdown and checkout details display name

### DIFF
--- a/packages/blockchain-info-components/src/Buttons/Button.js
+++ b/packages/blockchain-info-components/src/Buttons/Button.js
@@ -86,7 +86,8 @@ const selectColor = (nature, disabled, small) => {
       return {
         color: 'blue600',
         backgroundColor: 'white',
-        borderColor: 'grey100'
+        borderColor: 'grey100',
+        hoverBorderColor: 'blue600'
       }
     }
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
@@ -82,7 +82,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
             weight={600}
             color={props.supportedCoins[props.order.outputCurrency].colorCode}
           >
-            {props.order.outputCurrency}
+            {props.supportedCoins[props.order.outputCurrency].coinTicker}
           </Text>
         </Amount>
       </FlyoutWrapper>
@@ -94,7 +94,8 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           />
         </Title>
         <Value>
-          {displayFiat(props.quote.rate)} / {props.order.outputCurrency}
+          {displayFiat(props.quote.rate)} /{' '}
+          {props.supportedCoins[props.order.outputCurrency].coinTicker}
         </Value>
       </Row>
       <Row>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/CoinSelect/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/CoinSelect/index.tsx
@@ -79,6 +79,7 @@ class CoinSelect extends PureComponent<Props & { name: string }> {
     const fiat = getFiatFromPair(props.value.pair)
     const coinType = this.props.supportedCoins[coin]
     const displayName = coinType.displayName
+    const coinTicker = coinType.coinTicker
     const icon = coinType.icons.circleFilled
     const color = coinType.colorCode
     const isItem = !children
@@ -89,7 +90,7 @@ class CoinSelect extends PureComponent<Props & { name: string }> {
         <Display>
           {children || displayName}
           <Rate>
-            1 {coin} ={' '}
+            1 {coinTicker} ={' '}
             {Currency.fiatToString({
               value: this.props.rates[coin][fiat].last,
               unit: Currencies[fiat].units[fiat]

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CoinIntroduction/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CoinIntroduction/template.js
@@ -41,6 +41,9 @@ const BuyButton = styled(Button)`
   width: auto;
   height: 46px;
   padding: 0 16px;
+  &:hover {
+    background-color: white;
+  }
 `
 
 const Welcome = props => {


### PR DESCRIPTION
## Description (optional)
Checkout and dropdown also had PAX instead of USDD + button hover color for empty tx feed. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

