### PR TITLE
Fix/interest rate response

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/reducers.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/reducers.ts
@@ -117,7 +117,7 @@ export function interestReducer (
     case AT.FETCH_INTEREST_RATE_SUCCESS:
       return {
         ...state,
-        interestRate: Remote.Success(action.payload.interestRate)
+        interestRate: Remote.Success(action.payload.interestRate.rates)
       }
     case AT.FETCH_INTEREST_TRANSACTIONS_FAILURE:
       return {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/types.ts
@@ -54,7 +54,7 @@ export interface InterestState {
   interestEligible: RemoteDataType<string, InterestEligibleType>
   interestInstruments: RemoteDataType<string, InterestInstrumentsType>
   interestLimits: RemoteDataType<string, InterestLimitsType>
-  interestRate: RemoteDataType<string, InterestRateType>
+  interestRate: RemoteDataType<string, InterestRateType['rates']>
   interestTransactions: RemoteDataType<string, InterestTransactionResponseType>
   limits: InterestMinMaxType
   payment: RemoteDataType<string, PaymentValue>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/AccountSummary/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/AccountSummary/template.success.tsx
@@ -43,7 +43,7 @@ const AccountSummary: React.FC<Props> = props => {
     supportedCoins
   } = props
   const displayName = supportedCoins[coin].displayName
-  const account = accountBalances[coin]
+  const account = accountBalances && accountBalances[coin]
 
   return (
     <Wrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Interest/SummaryCard/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Interest/SummaryCard/template.success.tsx
@@ -80,7 +80,6 @@ function SummaryCard (props: OwnProps & SuccessStateType): ReactElement {
   }).value
   const totalInterest =
     interestAccountBalance.BTC && interestAccountBalance.BTC.totalInterest
-
   return (
     <DepositBox showInterestInfoBox={showInterestInfoBox}>
       <Row>

--- a/packages/blockchain-wallet-v4/src/network/api/interest/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/interest/types.ts
@@ -31,7 +31,10 @@ export type InterestAccountType = {
 }
 
 export type InterestRateType = {
-  BTC: number
+  rates: {
+    BTC: number
+    ETH: number
+  }
 }
 
 export type InterestTransactionType = {


### PR DESCRIPTION
## Description (optional)
1. Interest rate response format went from {coin:rate} to {rates: {coin:rate}}, updated type to handle correctly
2. Added check for accountBalance, flyout was blowing up because accountBalance was returning 204 if there is no balance. 
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

