### PR TITLE
chore: removed optional text from text area

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/RequestBtc/template.success.js
@@ -155,7 +155,7 @@ const FirstStep = props => {
                 name='message'
                 component={TextArea}
                 validate={[required]}
-                placeholder="What's this transaction for? (optional)"
+                placeholder="What's this transaction for?"
                 data-e2e='requestBtcDescription'
               />
             </FormItem>


### PR DESCRIPTION
## Description (optional)
We removed text label option from text area

## Testing Steps (optional)
- login to wallet 
- click on request
- click on last item in modal `Create Shareable Request Link`
- make sure that description text area do not have wording (optional)

