### PR TITLE
feat(signup): allow .com to link to wallet form opened

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Register/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Register/index.tsx
@@ -3,13 +3,22 @@ import { bindActionCreators, Dispatch } from 'redux'
 import { connect, ConnectedProps } from 'react-redux'
 import { formValueSelector } from 'redux-form'
 import { GoalsType } from 'data/goals/types'
+import { isNil, prop } from 'ramda'
 import { RootState } from 'data/rootReducer'
 import React from 'react'
 import Register from './template'
 
 class RegisterContainer extends React.PureComponent<PropsType, StateType> {
-  state = {
-    showForm: false
+  constructor (props: PropsType) {
+    super(props)
+    let location = prop('location', window)
+    let hash = prop('hash', location)
+    let showWalletFormQuery = !isNil(hash) && hash.includes('showWallet')
+
+    this.state = {
+      showForm: false,
+      showWalletFormQuery
+    }
   }
 
   onSubmit = () => {
@@ -39,6 +48,7 @@ class RegisterContainer extends React.PureComponent<PropsType, StateType> {
         password={password}
         passwordLength={passwordLength}
         showForm={this.state.showForm}
+        showWalletFormQuery={this.state.showWalletFormQuery}
         toggleForm={this.toggleForm}
         {...this.props}
       />
@@ -74,6 +84,7 @@ type LinkStatePropsType = {
 
 type StateType = {
   showForm: boolean
+  showWalletFormQuery: boolean
 }
 
 export type PropsType = ConnectedProps<typeof connector>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Register/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Register/index.tsx
@@ -3,22 +3,13 @@ import { bindActionCreators, Dispatch } from 'redux'
 import { connect, ConnectedProps } from 'react-redux'
 import { formValueSelector } from 'redux-form'
 import { GoalsType } from 'data/goals/types'
-import { isNil, prop } from 'ramda'
 import { RootState } from 'data/rootReducer'
 import React from 'react'
 import Register from './template'
 
 class RegisterContainer extends React.PureComponent<PropsType, StateType> {
-  constructor (props: PropsType) {
-    super(props)
-    let location = prop('location', window)
-    let hash = prop('hash', location)
-    let showWalletFormQuery = !isNil(hash) && hash.includes('showWallet')
-
-    this.state = {
-      showForm: false,
-      showWalletFormQuery
-    }
+  state = {
+    showForm: false
   }
 
   onSubmit = () => {
@@ -31,7 +22,7 @@ class RegisterContainer extends React.PureComponent<PropsType, StateType> {
   }
 
   render () {
-    const { data, password } = this.props
+    const { data, password, search } = this.props
     let busy = data.cata({
       Success: () => false,
       Failure: () => false,
@@ -40,6 +31,7 @@ class RegisterContainer extends React.PureComponent<PropsType, StateType> {
     })
 
     const passwordLength = (password && password.length) || 0
+    const showWalletFormQuery = search.includes('showWallet')
 
     return (
       <Register
@@ -47,8 +39,7 @@ class RegisterContainer extends React.PureComponent<PropsType, StateType> {
         onSubmit={this.onSubmit}
         password={password}
         passwordLength={passwordLength}
-        showForm={this.state.showForm}
-        showWalletFormQuery={this.state.showWalletFormQuery}
+        showForm={this.state.showForm || showWalletFormQuery}
         toggleForm={this.toggleForm}
         {...this.props}
       />
@@ -62,7 +53,8 @@ const mapStateToProps = (state: RootState): LinkStatePropsType => ({
   language: selectors.preferences.getLanguage(state),
   email: formValueSelector('register')(state, 'email'),
   goals: selectors.goals.getGoals(state),
-  password: formValueSelector('register')(state, 'password') || ''
+  password: formValueSelector('register')(state, 'password') || '',
+  search: selectors.router.getSearch(state)
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -80,11 +72,11 @@ type LinkStatePropsType = {
   goals: Array<{ data: any; id: string; name: GoalsType }>
   language: string
   password: string
+  search: string
 }
 
 type StateType = {
   showForm: boolean
-  showWalletFormQuery: boolean
 }
 
 export type PropsType = ConnectedProps<typeof connector>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Register/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Register/template.tsx
@@ -181,6 +181,7 @@ const Register = ({
   password,
   passwordLength,
   showForm,
+  showWalletFormQuery,
   toggleForm
 }: InjectedFormProps<{}, Props> & Props) => {
   const isLinkAccountGoal = find(propEq('name', 'linkAccount'), goals)
@@ -260,7 +261,7 @@ const Register = ({
               </InfoItem>
             </CardInfo>
 
-            {showForm && (
+            {showForm || showWalletFormQuery ? (
               <SignupForm
                 busy={busy}
                 handleSubmit={handleSubmit}
@@ -268,9 +269,7 @@ const Register = ({
                 password={password}
                 passwordLength={passwordLength}
               />
-            )}
-
-            {!showForm && (
+            ) : (
               <Button
                 data-e2e='signupButton'
                 fullwidth
@@ -438,6 +437,7 @@ type Props = {
   password: string
   passwordLength: number
   showForm: boolean
+  showWalletFormQuery: boolean
   toggleForm: any
 }
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Register/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Register/template.tsx
@@ -181,7 +181,6 @@ const Register = ({
   password,
   passwordLength,
   showForm,
-  showWalletFormQuery,
   toggleForm
 }: InjectedFormProps<{}, Props> & Props) => {
   const isLinkAccountGoal = find(propEq('name', 'linkAccount'), goals)
@@ -261,7 +260,7 @@ const Register = ({
               </InfoItem>
             </CardInfo>
 
-            {showForm || showWalletFormQuery ? (
+            {showForm ? (
               <SignupForm
                 busy={busy}
                 handleSubmit={handleSubmit}
@@ -437,7 +436,6 @@ type Props = {
   password: string
   passwordLength: number
   showForm: boolean
-  showWalletFormQuery: boolean
   toggleForm: any
 }
 


### PR DESCRIPTION
## Description (optional)
Add flag in the query to allow .com to link directly into the wallet signup homepage with the form opened

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

