### PR TITLE
RFC: Fix/lift typings

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/index.tsx
@@ -1,14 +1,6 @@
 import { actions, selectors } from 'data'
 import { bindActionCreators, Dispatch } from 'redux'
 import { connect, ConnectedProps } from 'react-redux'
-import {
-  FiatEligibleType,
-  FiatType,
-  RemoteDataType,
-  SBCardType,
-  SBPairType,
-  SBPaymentMethodsType
-} from 'core/types'
 import { getData } from './selectors'
 import { RootState } from 'data/rootReducer'
 import Failure from './template.failure'
@@ -36,7 +28,7 @@ class EnterAmount extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state: RootState): LinkStatePropsType => ({
+const mapStateToProps = (state: RootState) => ({
   data: getData(state),
   fiatCurrency: selectors.components.simpleBuy.getFiatCurrency(state)
 })
@@ -51,16 +43,6 @@ const connector = connect(mapStateToProps, mapDispatchToProps)
 
 export type OwnProps = {
   handleClose: () => void
-}
-export type SuccessStateType = {
-  cards: Array<SBCardType>
-  eligibility: FiatEligibleType
-  pairs: Array<SBPairType>
-  paymentMethods: SBPaymentMethodsType
-}
-export type LinkStatePropsType = {
-  data: RemoteDataType<string, SuccessStateType>
-  fiatCurrency: undefined | FiatType
 }
 export type LinkDispatchPropsType = ReturnType<typeof mapDispatchToProps>
 export type Props = OwnProps & ConnectedProps<typeof connector>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/selectors.ts
@@ -1,3 +1,4 @@
+import { ExtractSuccess } from 'core/types'
 import { lift } from 'ramda'
 import { selectors } from 'data'
 
@@ -9,10 +10,17 @@ export const getData = state => {
     state
   )
 
-  return lift((cards, eligibility, pairs, paymentMethods) => ({
-    cards,
-    eligibility,
-    pairs,
-    paymentMethods
-  }))(cardsR, eligibilityR, pairsR, paymentMethodsR)
+  return lift(
+    (
+      cards: ExtractSuccess<typeof cardsR>,
+      eligibility: ExtractSuccess<typeof eligibilityR>,
+      pairs: ExtractSuccess<typeof pairsR>,
+      paymentMethods: ExtractSuccess<typeof paymentMethodsR>
+    ) => ({
+      cards,
+      eligibility,
+      pairs,
+      paymentMethods
+    })
+  )(cardsR, eligibilityR, pairsR, paymentMethodsR)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/index.tsx
@@ -4,7 +4,7 @@ import { connect, ConnectedProps } from 'react-redux'
 import { getData } from './selectors'
 import { Remote } from 'core'
 import { RootState } from 'data/rootReducer'
-import { SBCardType, SBOrderType } from 'core/types'
+import { SBOrderType } from 'core/types'
 import DataError from 'components/DataError'
 import Loading from '../AddCard/template.loading'
 import React, { PureComponent } from 'react'
@@ -56,9 +56,6 @@ const connector = connect(mapStateToProps, mapDispatchToProps)
 export type OwnProps = {
   handleClose: () => void
   order: SBOrderType
-}
-export type SuccessStateType = {
-  cards: Array<SBCardType>
 }
 export type Props = OwnProps & ConnectedProps<typeof connector>
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/index.tsx
@@ -3,13 +3,8 @@ import { bindActionCreators, Dispatch } from 'redux'
 import { connect, ConnectedProps } from 'react-redux'
 import { getData } from './selectors'
 import { Remote } from 'core'
-import {
-  RemoteDataType,
-  SBCardType,
-  SBOrderType,
-  SupportedCoinsType
-} from 'core/types'
 import { RootState } from 'data/rootReducer'
+import { SBCardType, SBOrderType } from 'core/types'
 import DataError from 'components/DataError'
 import Loading from '../AddCard/template.loading'
 import React, { PureComponent } from 'react'
@@ -38,7 +33,7 @@ class OrderSummary extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state: RootState): LinkStatePropsType => ({
+const mapStateToProps = (state: RootState) => ({
   data: getData(state),
   supportedCoins: selectors.core.walletOptions
     .getSupportedCoins(state)
@@ -64,10 +59,6 @@ export type OwnProps = {
 }
 export type SuccessStateType = {
   cards: Array<SBCardType>
-}
-type LinkStatePropsType = {
-  data: RemoteDataType<string, SuccessStateType>
-  supportedCoins: SupportedCoinsType
 }
 export type Props = OwnProps & ConnectedProps<typeof connector>
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/selectors.ts
@@ -1,9 +1,15 @@
 import { lift } from 'ramda'
+import { RemoteDataType, SBCardType } from 'core/types'
 import { RootState } from 'data/rootReducer'
 import { selectors } from 'data'
 
 export const getData = (state: RootState) => {
   const cardsR = selectors.components.simpleBuy.getSBCards(state)
 
-  return lift(cards => ({ cards }))(cardsR)
+  const transform = (cards: Array<SBCardType>) => ({ cards })
+
+  return lift(transform)(cardsR) as RemoteDataType<
+    string,
+    ReturnType<typeof transform>
+  >
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/selectors.ts
@@ -1,4 +1,4 @@
-import { ExtractSuccess, RemoteDataType } from 'core/types'
+import { ExtractSuccess } from 'core/types'
 import { lift } from 'ramda'
 import { RootState } from 'data/rootReducer'
 import { selectors } from 'data'
@@ -6,8 +6,7 @@ import { selectors } from 'data'
 export const getData = (state: RootState) => {
   const cardsR = selectors.components.simpleBuy.getSBCards(state)
   const transform = (cards: ExtractSuccess<typeof cardsR>) => ({ cards })
-  return lift(transform)(cardsR) as RemoteDataType<
-    string,
-    ReturnType<typeof transform>
-  >
+
+  const x = lift(transform)(cardsR)
+  return x
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/selectors.ts
@@ -1,13 +1,11 @@
+import { ExtractSuccess, RemoteDataType } from 'core/types'
 import { lift } from 'ramda'
-import { RemoteDataType, SBCardType } from 'core/types'
 import { RootState } from 'data/rootReducer'
 import { selectors } from 'data'
 
 export const getData = (state: RootState) => {
   const cardsR = selectors.components.simpleBuy.getSBCards(state)
-
-  const transform = (cards: Array<SBCardType>) => ({ cards })
-
+  const transform = (cards: ExtractSuccess<typeof cardsR>) => ({ cards })
   return lift(transform)(cardsR) as RemoteDataType<
     string,
     ReturnType<typeof transform>

--- a/packages/blockchain-wallet-v4/src/remote/types.ts
+++ b/packages/blockchain-wallet-v4/src/remote/types.ts
@@ -75,6 +75,16 @@ const map = function<E, A> (this: RemoteDataType<E, A>, f: Function) {
 }
 
 export type ExtractSuccess<T> = T extends RemoteSuccess<infer A> ? A : never
+export type ExtractFailure<T> = T extends RemoteFailure<infer E> ? E : never
+export type ExtractRemoteArray<T> = T extends Array<RemoteSuccess<infer A>>
+  ? Array<RemoteSuccess<A>>
+  : T extends Array<RemoteFailure<infer E>>
+  ? Array<RemoteFailure<E>>
+  : T extends Array<RemoteNotAsked>
+  ? Array<RemoteNotAsked>
+  : T extends Array<RemoteLoading>
+  ? Array<RemoteLoading>
+  : T
 
 export type RemoteType = {
   cata: typeof cata

--- a/packages/blockchain-wallet-v4/src/remote/types.ts
+++ b/packages/blockchain-wallet-v4/src/remote/types.ts
@@ -74,6 +74,8 @@ const map = function<E, A> (this: RemoteDataType<E, A>, f: Function) {
   })
 }
 
+export type ExtractSuccess<T> = T extends RemoteSuccess<infer A> ? A : never
+
 export type RemoteType = {
   cata: typeof cata
   getOrElse: typeof getOrElse

--- a/packages/blockchain-wallet-v4/src/remote/types.ts
+++ b/packages/blockchain-wallet-v4/src/remote/types.ts
@@ -90,12 +90,3 @@ export type RemoteDataType<E, A> =
 
 export type ExtractSuccess<T> = T extends RemoteSuccess<infer A> ? A : never
 export type ExtractFailure<T> = T extends RemoteFailure<infer E> ? E : never
-export type ExtractRemote<T> = T extends RemoteSuccess<infer A>
-  ? RemoteSuccess<A>
-  : T extends RemoteFailure<infer E>
-  ? RemoteFailure<E>
-  : T extends RemoteNotAsked
-  ? RemoteNotAsked
-  : T extends RemoteLoading
-  ? RemoteLoading
-  : T

--- a/packages/blockchain-wallet-v4/src/remote/types.ts
+++ b/packages/blockchain-wallet-v4/src/remote/types.ts
@@ -27,64 +27,28 @@ const cata = function<E, A> (
 
 const getOrElse = function<A, DV> (
   this: RemoteDataType<any, A>,
-  defaultValue: DV
+  defaultValue: DV extends A ? DV : A
 ): DV | A {
-  switch (this['@@tag']) {
-    case 'RemoteNotAsked': {
-      return defaultValue
-    }
-    case 'RemoteLoading': {
-      return defaultValue
-    }
-    case 'RemoteFailure': {
-      return defaultValue
-    }
-    case 'RemoteSuccess': {
-      return this.data
-    }
-  }
+  return this.data || defaultValue
 }
 
 const getOrFail = function<A, EV> (
   this: RemoteDataType<any, A>,
   errorValue: EV
 ): A {
-  switch (this['@@tag']) {
-    case 'RemoteNotAsked': {
-      throw errorValue
-    }
-    case 'RemoteLoading': {
-      throw errorValue
-    }
-    case 'RemoteFailure': {
-      throw errorValue
-    }
-    case 'RemoteSuccess': {
-      return this.data
-    }
+  if (!this.data) {
+    throw errorValue
+  } else {
+    return this.data
   }
 }
 
-const map = function<E, A> (this: RemoteDataType<E, A>, f: Function) {
-  return this.cata({
-    Success: (x: A) => Remote.Success(f(x)),
-    Failure: () => this,
-    Loading: () => this,
-    NotAsked: () => this
-  })
+const map = function<E, A, T> (
+  this: RemoteDataType<E, A>,
+  f: (x: A) => T
+): RemoteSuccess<ReturnType<typeof f>> {
+  return Remote.Success(f(this.data))
 }
-
-export type ExtractSuccess<T> = T extends RemoteSuccess<infer A> ? A : never
-export type ExtractFailure<T> = T extends RemoteFailure<infer E> ? E : never
-export type ExtractRemoteArray<T> = T extends Array<RemoteSuccess<infer A>>
-  ? Array<RemoteSuccess<A>>
-  : T extends Array<RemoteFailure<infer E>>
-  ? Array<RemoteFailure<E>>
-  : T extends Array<RemoteNotAsked>
-  ? Array<RemoteNotAsked>
-  : T extends Array<RemoteLoading>
-  ? Array<RemoteLoading>
-  : T
 
 export type RemoteType = {
   cata: typeof cata
@@ -96,16 +60,19 @@ export type RemoteType = {
 export type RemoteNotAsked = RemoteType & {
   readonly '@@tag': 'RemoteNotAsked'
   readonly '@@values': []
+  readonly data: never
 }
 
 export type RemoteLoading = RemoteType & {
   readonly '@@tag': 'RemoteLoading'
   readonly '@@values': []
+  readonly data: never
 }
 
 export type RemoteFailure<E> = RemoteType & {
   readonly '@@tag': 'RemoteFailure'
   readonly '@@values': [E]
+  readonly data: never
   readonly error: E
 }
 
@@ -120,3 +87,15 @@ export type RemoteDataType<E, A> =
   | RemoteLoading
   | RemoteFailure<E>
   | RemoteSuccess<A>
+
+export type ExtractSuccess<T> = T extends RemoteSuccess<infer A> ? A : never
+export type ExtractFailure<T> = T extends RemoteFailure<infer E> ? E : never
+export type ExtractRemote<T> = T extends RemoteSuccess<infer A>
+  ? RemoteSuccess<A>
+  : T extends RemoteFailure<infer E>
+  ? RemoteFailure<E>
+  : T extends RemoteNotAsked
+  ? RemoteNotAsked
+  : T extends RemoteLoading
+  ? RemoteLoading
+  : T

--- a/typings/ramda.d.ts
+++ b/typings/ramda.d.ts
@@ -1,11 +1,15 @@
-// declare module 'ramda' {
-// import { RemoteDataType, RemoteSuccess } from 'core/types'
-
 /* eslint-disable */
-// export function lift<E, A>(
-//   f: (arg) => A
-//   // @ts-ignore
-// ): (Fx: RemoteDataType<E, A>) => ExtractSuccess<RemoteDataType<E, A>> {
-//   return Fx => f(Fx)
-// }
-// }
+import * as ramda from 'ramda'
+import { ExtractFailure, ExtractRemoteArray, RemoteDataType } from 'core/types'
+
+declare module 'ramda' {
+  export function lift<T>(
+    f: (...args: any[]) => T
+  ): <A>(
+    ...Fx: ExtractRemoteArray<A[]>
+  ) => // @ts-ignore
+  RemoteDataType<ExtractFailure<A>, T> {
+    // @ts-ignore
+    return Fx => Fx.map(f)
+  }
+}

--- a/typings/ramda.d.ts
+++ b/typings/ramda.d.ts
@@ -1,0 +1,11 @@
+// declare module 'ramda' {
+// import { RemoteDataType, RemoteSuccess } from 'core/types'
+
+/* eslint-disable */
+// export function lift<E, A>(
+//   f: (arg) => A
+//   // @ts-ignore
+// ): (Fx: RemoteDataType<E, A>) => ExtractSuccess<RemoteDataType<E, A>> {
+//   return Fx => f(Fx)
+// }
+// }

--- a/typings/ramda.d.ts
+++ b/typings/ramda.d.ts
@@ -1,15 +1,11 @@
 /* eslint-disable */
 import * as ramda from 'ramda'
-import { ExtractFailure, ExtractRemoteArray, RemoteDataType } from 'core/types'
+import { RemoteDataType } from 'core/types'
 
 declare module 'ramda' {
   export function lift<T>(
     f: (...args: any[]) => T
-  ): <A>(
-    ...Fx: ExtractRemoteArray<A[]>
-  ) => // @ts-ignore
-  RemoteDataType<ExtractFailure<A>, T> {
-    // @ts-ignore
+  ): (...Fx) => RemoteDataType<any, ReturnType<typeof f>> {
     return Fx => Fx.map(f)
   }
 }


### PR DESCRIPTION
## Description (optional)
As described on slack, there are some limitations to typing ramda's `lift` function. This is what I have so far, it still requires you to give the "`transform`ation" function some information about your Remote types, but some of the heavy lifting is now done by using Typescript's `extend`  and `infer` to get the `SuccessStateType`.

**Note:** This PR breaks getOrElse, getOrFail, and mapped, which was previously incorrectly typed.

### What improved?
I was able to get rid of `SuccessStateType` and `LinkStatePropsType`:

<img width="506" alt="Screen Shot 2020-07-11 at 12 56 51 PM" src="https://user-images.githubusercontent.com/5640772/87222676-05422680-c376-11ea-9fbf-fb96ce27261a.png">

These are now moved to the selectors.ts file, but we still need to use the new `ExtractSuccess` when defining the types of the params for the "`transform`ation" function.

<img width="520" alt="Screen Shot 2020-07-11 at 1 12 03 PM" src="https://user-images.githubusercontent.com/5640772/87222891-2c99f300-c378-11ea-965d-6dd571da68a5.png">

Now getData knows the return type of our `lift` w/o needing to explicitly set the `SuccessStateType`'s

<img width="872" alt="Screen Shot 2020-07-11 at 1 13 55 PM" src="https://user-images.githubusercontent.com/5640772/87222960-b8138400-c378-11ea-8c07-7e9c9be9aad9.png">

### What can be improved more?
My biggest frustration is that I can not figure out how to get the Remote's `Success` type inside the "`transform`ation" function without defining it explicitly. As you can see [here](https://github.com/blockchain/blockchain-wallet-v4-frontend/compare/fix/lift-typings?expand=1#diff-dfdd32de94cc282e5b0a19d9627f83bbR7) I had to use `any[]` for `args`. In an ideal world `any[]` would be `Array<ExtractSuccess[A]>`, but A is not defined until the next function below...

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

