### PR TITLE
Feat/Send to Trading: reverted back ability to send to non custodial(trading)

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Bch/SendBch/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Bch/SendBch/FirstStep/template.success.js
@@ -169,9 +169,8 @@ const FirstStep = props => {
                   includeExchangeAddress={!isFromCustody}
                   isCreatable={!isFromCustody}
                   isValidNewOption={() => false}
-                  // hiding send to non-custodial
-                  // includeCustodial={!isFromCustody}
-                  // forceCustodialFirst={!isFromCustody}
+                  includeCustodial={!isFromCustody}
+                  forceCustodialFirst={!isFromCustody}
                   name='to'
                   noOptionsMessage={() => null}
                   openMenuOnClick={!!isFromCustody}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/SendBtc/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/SendBtc/FirstStep/template.success.js
@@ -200,9 +200,8 @@ const FirstStep = props => {
                   includeExchangeAddress={!isFromCustody}
                   isCreatable={!isFromCustody}
                   isValidNewOption={() => false}
-                  // hiding send to non-custodial
-                  // includeCustodial={!isFromCustody}
-                  // forceCustodialFirst={!isFromCustody}
+                  includeCustodial={!isFromCustody}
+                  forceCustodialFirst={!isFromCustody}
                   name='to'
                   openMenuOnClick={!!isFromCustody}
                   noOptionsMessage={() => null}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Eth/SendEth/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Eth/SendEth/FirstStep/template.success.js
@@ -183,9 +183,8 @@ const FirstStep = props => {
               includeExchangeAddress={!isFromCustody}
               isCreatable={!isFromCustody}
               isValidNewOption={() => false}
-              // hiding send to non-custodial
-              // includeCustodial={!isFromCustody}
-              // forceCustodialFirst={!isFromCustody}
+              includeCustodial={!isFromCustody}
+              forceCustodialFirst={!isFromCustody}
               name='to'
               noOptionsMessage={() => null}
               openMenuOnClick={isFromCustody}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Xlm/SendXlm/FirstStep/template.success.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Xlm/SendXlm/FirstStep/template.success.js
@@ -174,9 +174,8 @@ const FirstStep = props => {
                   name='to'
                   noOptionsMessage={() => null}
                   openMenuOnClick={!!isFromCustody}
-                  // hiding send to non-custodial
-                  // includeCustodial={!isFromCustody}
-                  // forceCustodialFirst={!isFromCustody}
+                  includeCustodial={!isFromCustody}
+                  forceCustodialFirst={!isFromCustody}
                   placeholder='Paste, scan, or select destination'
                   validate={
                     isFromCustody ? [required] : [required, validXlmAddress]


### PR DESCRIPTION
## Description (optional)
Next thing to be release id to have ability to send to trading wallets

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

