### PR TITLE
feat(deposit): show account number no matter of transfer type

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/TransferDetails/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/TransferDetails/template.success.tsx
@@ -313,8 +313,7 @@ const Success: React.FC<Props> = props => {
             </Copy>
           </RowCopy>
         )}
-        {((props.account.currency === 'USD' &&
-          transferType === TransferType.DOMESTIC) ||
+        {(props.account.currency === 'USD' ||
           props.account.currency === 'GBP') &&
           !!props.account.agent.account && (
             <RowCopy>


### PR DESCRIPTION
## Description (optional)
Add a concise explanation of the changes.

## Testing Steps (optional)
Log in to app and go to USD fiat, click on deposit button and then click on international tab
account number should be visible

