### PR TITLE
fix(swap): coinTicker in swap error messages

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
@@ -218,7 +218,7 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           />
           {fix === 'CRYPTO' && (
             <Text size={'56px'} color='textBlack' weight={500}>
-              {BASE.coin}
+              {coins[BASE.coin].coinTicker}
             </Text>
           )}
         </AmountRow>
@@ -263,7 +263,7 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
                     value:
                       fix === 'FIAT'
                         ? fiatToString({ value: fiatMin, unit: walletCurrency })
-                        : `${min} ${BASE.coin}`
+                        : `${min} ${coins[BASE.coin].coinTicker}`
                   }}
                 />
               </CustomErrorCartridge>
@@ -328,7 +328,7 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
                     value:
                       fix === 'FIAT'
                         ? fiatToString({ value: fiatMax, unit: walletCurrency })
-                        : `${max} ${BASE.coin}`
+                        : `${max} ${coins[BASE.coin].coinTicker}`
                   }}
                 />
               </CustomErrorCartridge>


### PR DESCRIPTION
## Description (optional)
https://blockchain.atlassian.net/browse/FWLT-849

Uses coinTicker for swap error messages and in checkout form, so currency will say USD-D instead of PAX. 

