### PR TITLE
fix(swap): btc fee amount displayed in preview swap screen

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
@@ -30,9 +30,11 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
   }
 
   networkFee = value => {
-    return value.coin === 'BTC' || value.coin === 'BCH'
-      ? value.selection.fee
-      : value.fee
+    return value
+      ? value.coin === 'BTC' || value.coin === 'BCH'
+        ? value.selection.fee
+        : value.fee
+      : 0
   }
 
   render () {
@@ -174,7 +176,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
                     {coinToString({
                       value: convertBaseToStandard(
                         BASE.baseCoin,
-                        value ? this.networkFee(value) : 0
+                        this.networkFee(value)
                       ),
                       unit: { symbol: coins[BASE.baseCoin].coinTicker }
                     })}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
@@ -29,6 +29,12 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
     this.props.swapActions.createOrder()
   }
 
+  networkFee = value => {
+    return value.coin === 'BTC' || value.coin === 'BCH'
+      ? value.selection.fee
+      : value.fee
+  }
+
   render () {
     if (
       !this.props.initSwapFormValues?.BASE ||
@@ -168,7 +174,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
                     {coinToString({
                       value: convertBaseToStandard(
                         BASE.baseCoin,
-                        value ? value.fee : 0
+                        value ? this.networkFee(value) : 0
                       ),
                       unit: { symbol: coins[BASE.baseCoin].coinTicker }
                     })}


### PR DESCRIPTION
For btc/bch outgoing swaps, we display the network fee as the sat/b value rather than what the network fee actually is. BTC/BCH payment has a network fee under payment.selection.fee, while other coins have a static fee in just payment.fee. 

![500A0774-39F3-4D84-843D-1D7CA7DE8403](https://user-images.githubusercontent.com/14954836/99598138-56ae9200-29b6-11eb-9839-4bb465806bb4.jpeg)


This should be released to production ASAP but https://github.com/blockchain/blockchain-wallet-v4-frontend/commit/f470e9538dbba591a03769716da99f89327b483d should be cherry picked out of development before release since it breaks swap. 
