### PR TITLE
fix(swap): remove 0 if no fee, only show fee tag

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
@@ -161,14 +161,9 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
           </Title>
           <Value>
             {BASE.type === 'CUSTODIAL' ? (
-              <>
-                <>0 {BASE.baseCoin}</>
-                <div>
-                  <FreeCartridge>
-                    <FormattedMessage id='copy.free' defaultMessage='FREE' />
-                  </FreeCartridge>
-                </div>
-              </>
+              <FreeCartridge>
+                <FormattedMessage id='copy.free' defaultMessage='FREE' />
+              </FreeCartridge>
             ) : (
               this.props.paymentR.cata({
                 Success: value => (
@@ -198,34 +193,30 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
             />
           </Title>
           <Value>
-            {this.props.quoteR.cata({
-              Success: value => (
-                <>
-                  {coinToString({
-                    value: convertBaseToStandard(
-                      COUNTER.coin,
-                      value.quote.networkFee
-                    ),
-                    unit: {
-                      symbol: coins[COUNTER.coin].coinTicker
-                    }
-                  })}
-                  {COUNTER.type === 'CUSTODIAL' && (
-                    <div>
-                      <FreeCartridge>
-                        <FormattedMessage
-                          id='copy.free'
-                          defaultMessage='FREE'
-                        />
-                      </FreeCartridge>
-                    </div>
-                  )}
-                </>
-              ),
-              Failure: e => e,
-              Loading: () => <SkeletonRectangle height='18px' width='70px' />,
-              NotAsked: () => <SkeletonRectangle height='18px' width='70px' />
-            })}
+            {COUNTER.type === 'CUSTODIAL' ? (
+              <FreeCartridge>
+                <FormattedMessage id='copy.free' defaultMessage='FREE' />
+              </FreeCartridge>
+            ) : (
+              this.props.quoteR.cata({
+                Success: value => (
+                  <>
+                    {coinToString({
+                      value: convertBaseToStandard(
+                        COUNTER.coin,
+                        value.quote.networkFee
+                      ),
+                      unit: {
+                        symbol: coins[COUNTER.coin].coinTicker
+                      }
+                    })}
+                  </>
+                ),
+                Failure: e => e,
+                Loading: () => <SkeletonRectangle height='18px' width='70px' />,
+                NotAsked: () => <SkeletonRectangle height='18px' width='70px' />
+              })
+            )}
           </Value>
         </Row>
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/index.tsx
@@ -59,7 +59,6 @@ class SwapOrderTx extends PureComponent<Props, State> {
     const base = getInput(this.props.order)
     const counter = getOutput(this.props.order)
     const { outputMoney } = this.props.order.priceFunnel
-
     return (
       <TxRowContainer
         className={this.state.isToggled ? 'active' : ''}


### PR DESCRIPTION
## Description (optional)
https://blockchain.atlassian.net/browse/FWLT-854

## Testing Steps (optional)
Swap:

Rather than show both '0' and 'Free' tag  or network fee if wallet is custodial, only show free tag. 
<img width="473" alt="Screen Shot 2020-11-20 at 11 44 17 AM" src="https://user-images.githubusercontent.com/14954836/99838062-c727f100-2b25-11eb-91ca-fa5be5486495.png">


