### PR TITLE
Fix/swap fee

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -383,6 +383,8 @@ type MessagesType = {
   'copy.upgrade': 'Upgrade To Gold'
   'copy.unknown_error': 'An unknown error has occurred.'
   'copy.view': 'View'
+  'copy.view_incoming_tx': 'View Incoming Transaction'
+  'copy.view_outgoing_tx': 'View Outgoing Transaction'
   'dentityverification.verify.resubmit.reason.missing': 'The required photos are missing'
   'exchange-side-nav-tooltip-connected': 'connected'
   'exchangepromo.pairs': 'Access 20+ trading pairs on the Exchange.'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/OrderDetails/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/OrderDetails/index.tsx
@@ -86,46 +86,6 @@ class OrderDetails extends PureComponent<InjectedFormProps<{}, Props> & Props> {
             })}
           </Value>
         </Row>
-        <Row>
-          <Title>
-            <FormattedMessage
-              id='copy.coin_network_fee'
-              defaultMessage='{coin} Network Fee'
-              values={{
-                coin: coins[baseCoin].coinTicker
-              }}
-            />
-          </Title>
-          <Value>
-            {coinToString({
-              unit: { symbol: coins[baseCoin].coinTicker },
-              value: convertBaseToStandard(
-                baseCoin,
-                this.props.order.priceFunnel.networkFee
-              )
-            })}
-          </Value>
-        </Row>
-        <Row>
-          <Title>
-            <FormattedMessage
-              id='copy.coin_network_fee'
-              defaultMessage='{coin} Network Fee'
-              values={{
-                coin: counterCoin
-              }}
-            />
-          </Title>
-          <Value>
-            {coinToString({
-              unit: { symbol: coins[counterCoin].coinTicker },
-              value: convertBaseToStandard(
-                counterCoin,
-                order.priceFunnel.staticFee
-              )
-            })}
-          </Value>
-        </Row>
         {this.props.order.state === 'PENDING_DEPOSIT' && (
           <FlyoutWrapper>
             <Form

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/index.tsx
@@ -1,5 +1,5 @@
 import { bindActionCreators, Dispatch } from 'redux'
-import { Button, Text } from 'blockchain-info-components'
+import { Button, Icon, Link, Text } from 'blockchain-info-components'
 import {
   CoinType,
   ProcessedSwapOrderType,
@@ -35,6 +35,15 @@ const LastCol = styled(Col)`
   display: flex;
   justify-content: flex-end;
 `
+const ViewTxWrapper = styled.div`
+  display: flex;
+  justify-items: center;
+  margin-top: 10px;
+  & > :last-child {
+    display: inline;
+    margin-left: 5px;
+  }
+`
 class SwapOrderTx extends PureComponent<Props, State> {
   state: State = { isToggled: false }
 
@@ -55,9 +64,9 @@ class SwapOrderTx extends PureComponent<Props, State> {
   }
 
   render () {
-    const { order, coin } = this.props
-    const base = getInput(this.props.order)
-    const counter = getOutput(this.props.order)
+    const { order, coin, supportedCoins } = this.props
+    const base = getInput(order)
+    const counter = getOutput(order)
     const { outputMoney } = this.props.order.priceFunnel
     return (
       <TxRowContainer
@@ -149,36 +158,51 @@ class SwapOrderTx extends PureComponent<Props, State> {
                   value: order.priceFunnel.price
                 })}
               </RowValue>
-              <RowHeader>
-                <FormattedMessage
-                  id='copy.outgoing_fee'
-                  defaultMessage='Outgoing Fee'
-                />
-              </RowHeader>
-              <RowValue data-e2e='swapOutFee'>
-                {coinToString({
-                  unit: { symbol: counter },
-                  value: convertBaseToStandard(
-                    counter,
-                    this.props.order.priceFunnel.networkFee
-                  )
-                })}
-              </RowValue>
-              <RowHeader>
-                <FormattedMessage
-                  id='copy.incoming_fee'
-                  defaultMessage='Incoming Fee'
-                />
-              </RowHeader>
-              <RowValue data-e2e='swapInFee'>
-                {coinToString({
-                  unit: { symbol: counter },
-                  value: convertBaseToStandard(
-                    counter,
-                    this.props.order.priceFunnel.staticFee
-                  )
-                })}
-              </RowValue>
+              {order.kind.depositTxHash && (
+                <ViewTxWrapper>
+                  <Text size='14px' weight={500} color='grey600'>
+                    <FormattedMessage
+                      id='copy.view_outgoing_tx'
+                      defaultMessage='View Outgoing Transaction'
+                    />
+                  </Text>
+
+                  <Link
+                    href={`${supportedCoins[base].txExplorerBaseUrl}/${order.kind.depositTxHash}`}
+                    target='_blank'
+                    data-e2e='swapOutgoingTransactionListItemExplorerLink'
+                  >
+                    <Icon
+                      name='open-in-new-tab'
+                      color='marketing-primary'
+                      cursor
+                      size='14px'
+                    />
+                  </Link>
+                </ViewTxWrapper>
+              )}
+              {order.kind.withdrawalTxHash && (
+                <ViewTxWrapper>
+                  <Text size='14px' weight={500} color='grey600'>
+                    <FormattedMessage
+                      id='copy.view_incoming_tx'
+                      defaultMessage='View Incoming Transaction'
+                    />
+                  </Text>
+                  <Link
+                    href={`${supportedCoins[counter].txExplorerBaseUrl}/${order.kind.withdrawalTxHash}`}
+                    target='_blank'
+                    data-e2e='swapOutgoingTransactionListItemExplorerLink'
+                  >
+                    <Icon
+                      name='open-in-new-tab'
+                      color='marketing-primary'
+                      cursor
+                      size='14px'
+                    />
+                  </Link>
+                </ViewTxWrapper>
+              )}
             </DetailsColumn>
             <DetailsColumn />
             <DetailsColumn>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/index.tsx
@@ -166,7 +166,6 @@ class SwapOrderTx extends PureComponent<Props, State> {
                       defaultMessage='View Outgoing Transaction'
                     />
                   </Text>
-
                   <Link
                     href={`${supportedCoins[base].txExplorerBaseUrl}/${order.kind.depositTxHash}`}
                     target='_blank'
@@ -192,7 +191,7 @@ class SwapOrderTx extends PureComponent<Props, State> {
                   <Link
                     href={`${supportedCoins[counter].txExplorerBaseUrl}/${order.kind.withdrawalTxHash}`}
                     target='_blank'
-                    data-e2e='swapOutgoingTransactionListItemExplorerLink'
+                    data-e2e='swapIncomingTransactionListItemExplorerLink'
                   >
                     <Icon
                       name='open-in-new-tab'


### PR DESCRIPTION
## Description (optional)
https://blockchain.atlassian.net/browse/FWLT-864

Originally, swap designs included showing outgoing transaction fees (if on chain) in transaction feed and cancel modals. This is difficult to do, since there's no simple way to get a network fee from a specific transaction, even with the hash. Workaround for this is to link to relevant block explorer for swap transactions applicable (i.e. ON_CHAIN and FROM_USERKEY).

![Uploading Screen Shot 2020-11-23 at 7.55.09 PM.png…]()

Also removes network fee row from cancel flyout. 

