### PR TITLE
Fix/swap refund

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/swap/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/swap/sagas.ts
@@ -175,6 +175,9 @@ export default ({
       )
 
       const quote = S.getQuote(yield select()).getOrFail('NO_SWAP_QUOTE')
+      const refundAddr = onChain
+        ? yield call(selectReceiveAddress, BASE, networks)
+        : undefined
       const destinationAddr = toChain
         ? yield call(selectReceiveAddress, COUNTER, networks)
         : undefined
@@ -184,7 +187,8 @@ export default ({
         quote.quote.id,
         amount,
         ccy,
-        destinationAddr
+        destinationAddr,
+        refundAddr
       )
       const paymentR = S.getPayment(yield select())
       let payment = paymentGetOrElse(BASE.coin, paymentR)

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
@@ -207,7 +207,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
                         value.quote.networkFee
                       ),
                       unit: {
-                        symbol: coins[COUNTER.coin].coinTicker
+                        symbol: coins[COUNTER.baseCoin].coinTicker
                       }
                     })}
                   </>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
@@ -203,7 +203,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
                   <>
                     {coinToString({
                       value: convertBaseToStandard(
-                        COUNTER.coin,
+                        COUNTER.baseCoin,
                         value.quote.networkFee
                       ),
                       unit: {

--- a/packages/blockchain-wallet-v4/src/network/api/swap/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/swap/index.ts
@@ -31,7 +31,8 @@ export default ({ authorizedGet, authorizedPost, nabuUrl }) => {
     quoteId: string,
     volume: string,
     ccy: FiatType,
-    destinationAddress?: string
+    destinationAddress?: string,
+    refundAddress?: string
   ): SwapOrderType =>
     authorizedPost({
       url: nabuUrl,
@@ -43,7 +44,8 @@ export default ({ authorizedGet, authorizedPost, nabuUrl }) => {
         direction,
         quoteId,
         volume,
-        destinationAddress
+        destinationAddress,
+        refundAddress
       }
     })
 

--- a/packages/blockchain-wallet-v4/src/network/api/swap/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/swap/types.ts
@@ -13,7 +13,8 @@ export type SwapOrderType = {
     // Optional fields depending on direction
     depositAddress: string
     depositTxHash: string
-    direction: SwapOrderDirectionType
+    direction: SwapOrderDirectionType,
+    refundAddress: string,
     withdrawalAddress: string
     withdrawalTxHash: string
   }


### PR DESCRIPTION
## Description (optional)


1) Adds a refund address to swap order creation so user ops/compliance can easily find address in case they need to issue a refund to swap. https://blockchain.atlassian.net/browse/FWLT-859

2) Shows erc20 network fees in ETH always. https://blockchain.atlassian.net/browse/FWLT-876

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

