### PR TITLE
fix(swap): fee

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
@@ -203,11 +203,11 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
                   <>
                     {coinToString({
                       value: convertBaseToStandard(
-                        COUNTER.baseCoin,
+                        COUNTER.coin,
                         value.quote.networkFee
                       ),
                       unit: {
-                        symbol: coins[COUNTER.baseCoin].coinTicker
+                        symbol: coins[COUNTER.coin].coinTicker
                       }
                     })}
                   </>


### PR DESCRIPTION

Undos this [commit](https://github.com/blockchain/blockchain-wallet-v4-frontend/commit/3bb150a0ab7007b63a1182b3fc92c8bfb792bfc6), backend doesn't return fee in ETH. Need to add more conversion, didn't want this to break with next release. 

