### PR TITLE
fix(fiat): ensure we always refetch transactions when reset is true

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/data/fiat/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/data/fiat/sagas.ts
@@ -64,10 +64,12 @@ export default ({ api }: { api: APIType }) => {
       // 1) no transactions exist
       // 2) we have a next SB data stored (last tx id and timestamp)
       // 3) we have a next swap page timestamp
+      // 4) reset === true
       if (
         !data?.page.length ||
         (nextSbTxId && nextSbTxTimestamp) ||
-        nextSwapPageTimestamp
+        nextSwapPageTimestamp ||
+        reset
       ) {
         // fetch sb transactions
         sbTransactions = yield call(api.getSBTransactions, {


### PR DESCRIPTION
## Description (optional)
Fixing edge case where user had less than the page size of transactions and entered, exited and then reentered a fiat transaction list, and we never refetched their transactions properly and thus nothing would show.

## Testing Steps (optional)
See above

