### PR TITLE
fix(wdgld): show 8 decimals rather than 2

### DIFF
--- a/packages/blockchain-wallet-v4/src/exchange/index.ts
+++ b/packages/blockchain-wallet-v4/src/exchange/index.ts
@@ -1176,7 +1176,7 @@ const displayWdgldToWdgld = ({
   value: number | string
 }) => {
   return transformWdgldToWdgld({ value, fromUnit, toUnit })
-    .map(x => Currency.coinToString({ ...x, minDigits: 2, maxDigits: 2 }))
+    .map(Currency.coinToString)
     .getOrElse(DefaultDisplay)
 }
 


### PR DESCRIPTION
## Description (optional)
WDGLD displays should use 8 decimal places rather than 2. Adjusted max/min digits and am opening against SDD branch so it can be tested via automation. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

