### PR TITLE
fix(sell): use payment to calculate max avail

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/selectors.ts
@@ -12,6 +12,7 @@ export const getData = (state: RootState, ownProps: OwnProps) => {
   )
   // used for sell only now, eventually buy as well
   // TODO: use swap2 quote for buy AND sell
+  const paymentR = selectors.components.simpleBuy.getPayment(state)
   const quoteR =
     ownProps.orderType === 'BUY'
       ? selectors.components.simpleBuy.getSBQuote(state)
@@ -23,6 +24,7 @@ export const getData = (state: RootState, ownProps: OwnProps) => {
   return lift(
     (
       quote: ExtractSuccess<typeof quoteR>,
+      payment: ExtractSuccess<typeof paymentR>,
       rates: ExtractSuccess<typeof ratesR>,
       sbBalances: ExtractSuccess<typeof sbBalancesR>,
       userData: ExtractSuccess<typeof userDataR>,
@@ -32,9 +34,10 @@ export const getData = (state: RootState, ownProps: OwnProps) => {
       supportedCoins,
       formErrors,
       quote,
+      payment,
       rates,
       sbBalances,
       userData
     })
-  )(quoteR, ratesR, sbBalancesR, userDataR, supportedCoinsR)
+  )(quoteR, paymentR, ratesR, sbBalancesR, userDataR, supportedCoinsR)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
@@ -163,6 +163,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
     props.orderType,
     props.quote,
     props.pair,
+    props.payment,
     props.formValues,
     method,
     props.swapAccount
@@ -173,6 +174,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
     props.orderType,
     props.quote,
     props.pair,
+    props.payment,
     props.formValues,
     method,
     props.swapAccount
@@ -186,6 +188,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
       props.orderType,
       props.quote,
       props.pair,
+      props.payment,
       props.formValues,
       method,
       props.swapAccount

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
@@ -76,7 +76,7 @@ export const getMaxMin = (
   orderType: SBOrderActionType,
   QUOTE: SBQuoteType | { quote: SwapQuoteType; rate: number },
   pair: SBPairType,
-  payment: undefined | PaymentValue,
+  payment?: PaymentValue,
   allValues?: SBCheckoutFormValuesType,
   method?: SBPaymentMethodType,
   account?: SwapAccountType
@@ -158,7 +158,7 @@ export const getMaxMinSell = (
   orderType: SBOrderActionType,
   quote: { quote: SwapQuoteType; rate: number },
   pair: SBPairType,
-  payment: undefined | PaymentValue,
+  payment?: PaymentValue,
   allValues?: SBCheckoutFormValuesType,
   method?: SBPaymentMethodType,
   account?: SwapAccountType

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
@@ -9,8 +9,8 @@ import {
   getCoinFromPair,
   getFiatFromPair
 } from 'data/components/simpleBuy/model'
-import { Props } from './template.success'
 import {
+  PaymentValue,
   SBBalancesType,
   SBOrderActionType,
   SBPairType,
@@ -19,6 +19,7 @@ import {
   SupportedWalletCurrenciesType,
   SwapQuoteType
 } from 'core/types'
+import { Props } from './template.success'
 import {
   SBCheckoutFormValuesType,
   SBFixType,
@@ -75,6 +76,7 @@ export const getMaxMin = (
   orderType: SBOrderActionType,
   QUOTE: SBQuoteType | { quote: SwapQuoteType; rate: number },
   pair: SBPairType,
+  payment: undefined | PaymentValue,
   allValues?: SBCheckoutFormValuesType,
   method?: SBPaymentMethodType,
   account?: SwapAccountType
@@ -140,6 +142,7 @@ export const getMaxMin = (
         orderType,
         quote,
         pair,
+        payment,
         allValues,
         method,
         account
@@ -155,6 +158,7 @@ export const getMaxMinSell = (
   orderType: SBOrderActionType,
   quote: { quote: SwapQuoteType; rate: number },
   pair: SBPairType,
+  payment: undefined | PaymentValue,
   allValues?: SBCheckoutFormValuesType,
   method?: SBPaymentMethodType,
   account?: SwapAccountType
@@ -173,12 +177,14 @@ export const getMaxMinSell = (
             : sbBalances[coin]?.available || '0'
 
           const maxSell = new BigNumber(pair.sellMax)
-
             .dividedBy(rate)
             .toFixed(Currencies[coin].units[coin].decimal_digits)
 
+          const userMax = Number(
+            payment ? payment.effectiveBalance : maxAvailable
+          )
           const maxCrypto = Math.min(
-            Number(convertBaseToStandard(coin, maxAvailable)),
+            Number(convertBaseToStandard(coin, userMax)),
             Number(maxSell)
           ).toString()
           const maxFiat = getQuote(pair.pair, rate, 'CRYPTO', maxCrypto)
@@ -216,6 +222,7 @@ export const maximumAmount = (
     method: selectedMethod,
     orderType,
     pair,
+    payment,
     quote,
     sbBalances,
     swapAccount
@@ -231,6 +238,7 @@ export const maximumAmount = (
         orderType,
         quote,
         pair,
+        payment,
         allValues,
         method,
         swapAccount
@@ -252,6 +260,7 @@ export const minimumAmount = (
     method: selectedMethod,
     orderType,
     pair,
+    payment,
     quote,
     sbBalances,
     swapAccount
@@ -267,6 +276,7 @@ export const minimumAmount = (
         orderType,
         quote,
         pair,
+        payment,
         allValues,
         method,
         swapAccount


### PR DESCRIPTION
## Description (optional)
Maximum sell amount validation in the checkout form was not accounting for network fees. This checks if a payment is created (will only happen from non-custodial accounts) and uses that effective balance as a max rather than account's full balance.
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

