### PR TITLE
fix(buy): payment getOrElse undefined so it doesn't load forever

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/selectors.ts
@@ -24,7 +24,6 @@ export const getData = (state: RootState, ownProps: OwnProps) => {
   return lift(
     (
       quote: ExtractSuccess<typeof quoteR>,
-      payment: ExtractSuccess<typeof paymentR>,
       rates: ExtractSuccess<typeof ratesR>,
       sbBalances: ExtractSuccess<typeof sbBalancesR>,
       userData: ExtractSuccess<typeof userDataR>,
@@ -34,10 +33,10 @@ export const getData = (state: RootState, ownProps: OwnProps) => {
       supportedCoins,
       formErrors,
       quote,
-      payment,
+      payment: paymentR.getOrElse(undefined),
       rates,
       sbBalances,
       userData
     })
-  )(quoteR, paymentR, ratesR, sbBalancesR, userDataR, supportedCoinsR)
+  )(quoteR, ratesR, sbBalancesR, userDataR, supportedCoinsR)
 }


### PR DESCRIPTION
## Description (optional)
Added `paymentR` to get limits for sell with fees, but this broke buy because payment never loads. Changed it to 'getOrElse undefined' which allows everything to load, there just is a slight delay in getting limits when on the sell checkout screen, i.e. the UI updates in real time once the right limits load.
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

