### PR TITLE
feat(sdd-flow): implemented new open payment screen

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -1344,6 +1344,8 @@ type MessagesType = {
   'modals.simplebuy.summary.created': 'Created'
   'modals.simplebuy.summary.paymentmethod': 'Payment Method'
   'modals.simplebuy.summary.purchased': '{amount} {coin} Purchased'
+  'modals.simplebuy.summary.pending_buy': 'Pending Buy'
+  'modals.simplebuy.summary.pending_buy_description': 'Once you finalize your credit card information, your buy order will complete.'
   'modals.simplebuy.summary.disclaimer': 'You will not be able to Send or Withdraw these funds from your Wallet for the next 1 day.'
   'modals.simplebuy.summary.disclaimer_plural': 'You will not be able to Send or Withdraw these funds from your Wallet for the next {days} days.'
   'modals.simplebuy.summary.purchasing': 'Purchasing'


### PR DESCRIPTION
If a user quits out of the process when attempting to verify the 3ds, the payment will go into pending state in BO, and will show that the payment was successful in the wallet. After that the user is unable to start a new payment until the pending one fails/expires.

Expected Behavior:
The payment should display a correct status or let the user cancel it manually.