### PR TITLE
Fix/eth check

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -351,6 +351,7 @@ type MessagesType = {
   'copy.new_swap': 'New Swap'
   'copy.no_payment_methods': 'No payment methods available.'
   'copy.now': 'Now'
+  'copy.not_enough_eth': 'ETH is required to send {coin}. You do not have enough ETH in your Ether Wallet to perform a transaction. Note, ETH must be held in "My Ether Wallet" for this transaction, not the Ether Trading Wallet.'
   'copy.not_now': 'Not Now'
   'copy.on_chain_txs': 'On-chain transactions only'
   'copy.outgoing_fee': 'Outgoing Fee'

--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -1239,6 +1239,7 @@ type MessagesType = {
   'modals.simplebuy.checkout.buymax': 'Buy Max'
   'modals.simplebuy.checkout.buymin': 'Buy Min'
   'modals.simplebuy.checkout.payment_method': 'Payment Method'
+  'modals.simplebuy.checkout.receive': 'Recipient Account'
   'modals.simplebuy.checkout.larger_amount.title': 'Want to buy larger amounts?'
   'modals.simplebuy.checkout.larger_amount.info': 'After completing this transaction, upgrade to Gold level to unlock higher transaction limits and more payment methods.'
   'modals.simplebuy.checkoutconfirm': 'Checkout'

--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -1254,7 +1254,7 @@ type MessagesType = {
   'modals.simplebuy.comfirm.price': '{baseCoinTicker} Price'
   'modals.simplebuy.confirm.rate': 'Exchange Rate'
   'modals.simplebuy.confirm.coin_price': '{coin} Price'
-  'modals.simplebuy.doing.work': 'Doing Work...'
+  'modals.simplebuy.processing': 'Processing…'
   'modals.simplebuy.deposit.bank_transfer': 'Bank Transfer'
   'modals.simplebuy.deposit.bank_transfer_only': 'Bank Transfers Only'
   'modals.simplebuy.deposit.bank_transfer_only_description': 'Only send funds from a bank account in your name. If not, your deposit could be delayed or rejected.'

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/CreditCardExpiryBox/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/CreditCardExpiryBox/index.tsx
@@ -25,9 +25,11 @@ export const normalizeCreditCardExpiry = (value, previousValue) => {
   } else {
     if (onlyNumsOrSlash.length === 2) {
       return onlyNumsOrSlash + '/'
-    } else {
-      return onlyNumsOrSlash
     }
+    if (onlyNumsOrSlash.length === 4 && !onlyNumsOrSlash.includes('/')) {
+      return onlyNumsOrSlash.replace(/(?<=^.{2})/, '/')
+    }
+    return onlyNumsOrSlash
   }
 }
 

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
@@ -855,7 +855,6 @@ export default ({
         default:
           throw new Error(INVALID_COIN_TYPE)
       }
-
       yield put(A.updatePaymentSuccess(payment.value()))
     } catch (e) {
       // eslint-disable-next-line

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/InfoAndResidential/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/InfoAndResidential/template.success.tsx
@@ -71,9 +71,6 @@ export const Caption = styled(Text)`
   line-height: 150%;
   color: ${props => props.theme.grey600};
 `
-const SmallFormItem = styled(FormItem)`
-  width: 45%;
-`
 const CustomForm = styled(Form)`
   height: 100%;
   display: flex;
@@ -205,43 +202,43 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
             </ErrorText>
           </ErrorTextContainer>
         )}
+        <FormGroup inline>
+          <FormItem>
+            <Label htmlFor='firstName'>
+              <Text weight={500} size='14px' color='grey900'>
+                <FormattedMessage
+                  id='identityverification.personal.firstnamerequired'
+                  defaultMessage='First Name *'
+                />
+              </Text>
+            </Label>
+            <Field
+              date-e2e='firstName'
+              name='firstName'
+              validate={required}
+              component={TextBox}
+              errorBottom
+            />
+          </FormItem>
+          <FormItem>
+            <Label htmlFor='lastName'>
+              <Text weight={500} size='14px' color='grey900'>
+                <FormattedMessage
+                  id='identityverification.personal.lastnamerequired'
+                  defaultMessage='Last Name *'
+                />
+              </Text>
+            </Label>
+            <Field
+              date-e2e='lastName'
+              name='lastName'
+              validate={required}
+              component={TextBox}
+              errorBottom
+            />
+          </FormItem>
+        </FormGroup>
         <FormGroup>
-          <FullNameContainer>
-            <SmallFormItem>
-              <Label htmlFor='firstName'>
-                <Text weight={500} size='14px' color='grey900'>
-                  <FormattedMessage
-                    id='identityverification.personal.firstnamerequired'
-                    defaultMessage='First Name *'
-                  />
-                </Text>
-              </Label>
-              <Field
-                date-e2e='firstName'
-                name='firstName'
-                validate={required}
-                component={TextBox}
-                errorBottom
-              />
-            </SmallFormItem>
-            <SmallFormItem>
-              <Label htmlFor='lastName'>
-                <Text weight={500} size='14px' color='grey900'>
-                  <FormattedMessage
-                    id='identityverification.personal.lastnamerequired'
-                    defaultMessage='Last Name *'
-                  />
-                </Text>
-              </Label>
-              <Field
-                date-e2e='lastName'
-                name='lastName'
-                validate={required}
-                component={TextBox}
-                errorBottom
-              />
-            </SmallFormItem>
-          </FullNameContainer>
           <Caption>
             <FormattedMessage
               id='modals.simplebuy.info_and_residential.id_or_password'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/AddCard/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/AddCard/template.success.tsx
@@ -284,6 +284,7 @@ const Success: React.FC<InjectedFormProps<{}, Props, ErrorType> &
                   size='14px'
                   color='grey800'
                   lineHeight='150%'
+                  style={{ marginBottom: '16px' }}
                 >
                   <FormattedMessage
                     id='modals.simplebuy.add_card.billing_address'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/ActionButton/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/ActionButton/index.tsx
@@ -5,12 +5,14 @@ import React from 'react'
 
 type Props = {
   invalid: boolean
+  isSufficientEthForErc20: boolean
   submitting: boolean
 } & OwnProps &
   SuccessStateType
 
 const ActionButton: React.FC<Props> = props => {
   const disabled = props.invalid || props.submitting
+  const disableInsufficientEth = props.isSufficientEthForErc20
 
   switch (props.userData.kycState) {
     case 'EXPIRED':
@@ -102,7 +104,7 @@ const ActionButton: React.FC<Props> = props => {
           nature='primary'
           type='submit'
           fullwidth
-          disabled={disabled}
+          disabled={disabled || disableInsufficientEth}
         >
           {props.submitting ? (
             <HeartbeatLoader height='16px' width='16px' color='white' />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/Payment/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/Payment/index.tsx
@@ -17,10 +17,17 @@ import { Props } from '../template.success'
 const Payment: React.FC<Props> = props => (
   <>
     <SectionTitle color='grey900' size='14px' weight={500}>
-      <FormattedMessage
-        id='modals.simplebuy.checkout.payment_method'
-        defaultMessage='Payment Method'
-      />
+      {props.orderType === 'BUY' ? (
+        <FormattedMessage
+          id='modals.simplebuy.checkout.payment_method'
+          defaultMessage='Payment Method'
+        />
+      ) : (
+        <FormattedMessage
+          id='modals.simplebuy.checkout.receive'
+          defaultMessage='Recipient Account'
+        />
+      )}
     </SectionTitle>
     <PaymentContainer
       role='button'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
@@ -104,13 +104,16 @@ const ErrorTextContainer = styled.div`
   display: flex;
   justify-content: center;
   flex-direction: row;
+  margin-left: 40px;
+  margin-right: 40px;
 `
 const ErrorText = styled(Text)`
   display: inline-flex;
+  align-items: center;
   font-weight: 500;
   font-size: 14px;
   padding: 6px 12px;
-  border-radius: 32px;
+  border-radius: 8px;
   background-color: ${props => props.theme.red000};
   color: ${props => props.theme.red800};
   margin-bottom: 16px;
@@ -286,18 +289,18 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
       : amountRowNode.children[amountRowNode.children.length - 1]
     currencyNode.style.fontSize = `${fontSizeNumber * fontRatio}px`
   }
-
   const limit = Number(props.sddLimit.max) / SDD_LIMIT_FACTOR
+  // if user is attempting to send NC ERC20, ensure they have sufficient
+  // ETH balance else warn user and disable trade
   const isErc20 = props.supportedCoins[cryptoCurrency].contractAddress
   const isSufficientEthForErc20 =
     props.payment &&
-    (props.payment.coin === 'PAX' ||
-      props.payment.coin === 'USDT' ||
-      props.payment.coin === 'WDGLD') &&
-    !props.payment.isSufficientEthForErc20 &&
-    isErc20 &&
     props.swapAccount?.type === 'ACCOUNT' &&
-    props.orderType === 'SELL'
+    props.orderType === 'SELL' &&
+    isErc20 &&
+    // @ts-ignore
+    !props.payment.isSufficientEthForErc20
+
   return (
     <CustomForm onSubmit={props.handleSubmit}>
       <FlyoutWrapper style={{ paddingBottom: '0px', borderBottom: 'grey000' }}>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
@@ -288,7 +288,16 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   }
 
   const limit = Number(props.sddLimit.max) / SDD_LIMIT_FACTOR
-
+  const isErc20 = props.supportedCoins[cryptoCurrency].contractAddress
+  const isSufficientEthForErc20 =
+    props.payment &&
+    (props.payment.coin === 'PAX' ||
+      props.payment.coin === 'USDT' ||
+      props.payment.coin === 'WDGLD') &&
+    !props.payment.isSufficientEthForErc20 &&
+    isErc20 &&
+    props.swapAccount?.type === 'ACCOUNT' &&
+    props.orderType === 'SELL'
   return (
     <CustomForm onSubmit={props.handleSubmit}>
       <FlyoutWrapper style={{ paddingBottom: '0px', borderBottom: 'grey000' }}>
@@ -500,10 +509,31 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
             </ErrorText>
           </ErrorTextContainer>
         )}
-        <ActionButton {...props} />
+        <ActionButton
+          {...props}
+          isSufficientEthForErc20={isSufficientEthForErc20 || false}
+        />
       </FlyoutWrapper>
       {props.isSddFlow && props.orderType === 'BUY' && (
         <IncreaseLimits {...props} />
+      )}
+      {isSufficientEthForErc20 && (
+        <ErrorTextContainer>
+          <ErrorText>
+            <Icon
+              name='alert-filled'
+              color='red600'
+              style={{ marginRight: '4px' }}
+            />
+            <FormattedMessage
+              id='copy.not_enough_eth'
+              defaultMessage='ETH is required to send {coin}. You do not have enough ETH in your Ether Wallet to perform a transaction. Note, ETH must be held in "My Ether Wallet" for this transaction, not the Ether Trading Wallet.'
+              values={{
+                coin: props.supportedCoins[cryptoCurrency].coinTicker
+              }}
+            />
+          </ErrorText>
+        </ErrorTextContainer>
       )}
     </CustomForm>
   )

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/ThreeDSHandler/template.loading.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/ThreeDSHandler/template.loading.tsx
@@ -26,8 +26,8 @@ const Loading: React.FC<Props> = ({ order, polling }) => {
       >
         {polling || order ? (
           <FormattedMessage
-            id='modals.simplebuy.doing.work'
-            defaultMessage='Doing Work...'
+            id='modals.simplebuy.processing'
+            defaultMessage='Processing…'
           />
         ) : (
           <FormattedMessage

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/template.loading.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/template.loading.tsx
@@ -21,8 +21,8 @@ const Loading: React.FC<Props> = () => {
       <BlockchainLoader width='80px' height='80px' />
       <Text weight={600} color='grey600' style={{ marginTop: '24px' }}>
         <FormattedMessage
-          id='modals.simplebuy.doing.work'
-          defaultMessage='Doing Work...'
+          id='modals.simplebuy.processing'
+          defaultMessage='Processing…'
         />
       </Text>
     </Wrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
@@ -216,7 +216,15 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   const balanceBelowMinimum = userMax < Number(min)
 
   const isQuoteFailed = Remote.Failure.is(props.quoteR)
-
+  const isErc20 = coins[BASE.coin].contractAddress
+  const isSufficientEthForErc20 =
+    props.payment &&
+    (props.payment.coin === 'PAX' ||
+      props.payment.coin === 'USDT' ||
+      props.payment.coin === 'WDGLD') &&
+    props.payment.isSufficientEthForErc20
+  const disableInsufficientEth =
+    isErc20 && !isSufficientEthForErc20 && BASE.type === 'ACCOUNT'
   return (
     <FlyoutWrapper style={{ paddingTop: '20px' }}>
       <StyledForm onSubmit={handleSubmit}>
@@ -447,7 +455,7 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           jumbo
           fullwidth
           style={{ marginTop: '24px' }}
-          disabled={props.invalid || isQuoteFailed}
+          disabled={props.invalid || isQuoteFailed || disableInsufficientEth}
         >
           <FormattedMessage
             id='buttons.preview_swap'
@@ -463,6 +471,17 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
               Loading: () => null,
               NotAsked: () => null
             })}
+          </ErrorCartridge>
+        )}
+        {disableInsufficientEth && (
+          <ErrorCartridge style={{ marginTop: '16px' }}>
+            <FormattedMessage
+              id='copy.not_enough_eth'
+              defaultMessage='ETH is required to send {coin}. You do not have enough ETH in your Ether Wallet to perform a transaction. Note, ETH must be held in "My Ether Wallet" for this transaction, not the Ether Trading Wallet.'
+              values={{
+                coin: coins[BASE.coin].coinTicker
+              }}
+            />
           </ErrorCartridge>
         )}
       </StyledForm>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
@@ -214,17 +214,17 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   }
   const userMax = Number(payment ? payment.effectiveBalance : BASE.balance)
   const balanceBelowMinimum = userMax < Number(min)
-
   const isQuoteFailed = Remote.Failure.is(props.quoteR)
+  // if user is attempting to send NC ERC20, ensure they have sufficient
+  // ETH balance else warn user and disable trade
   const isErc20 = coins[BASE.coin].contractAddress
-  const isSufficientEthForErc20 =
-    props.payment &&
-    (props.payment.coin === 'PAX' ||
-      props.payment.coin === 'USDT' ||
-      props.payment.coin === 'WDGLD') &&
-    props.payment.isSufficientEthForErc20
   const disableInsufficientEth =
-    isErc20 && !isSufficientEthForErc20 && BASE.type === 'ACCOUNT'
+    props.payment &&
+    BASE.type === 'ACCOUNT' &&
+    isErc20 &&
+    // @ts-ignore
+    props.payment.isSufficientEthForErc20
+
   return (
     <FlyoutWrapper style={{ paddingTop: '20px' }}>
       <StyledForm onSubmit={handleSubmit}>


### PR DESCRIPTION
## Description (optional)
Sell and Swap 2.0: User would be able to proceed with non-custodial sends for ERC20 tokens even if their wallet didn't have enough eth for the tx. This disables at button the checkout screen for both with an error explaining why. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

