### PR TITLE
fix(credit cards): fixes safari bug where safari cannot use a certain…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/CreditCardExpiryBox/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/CreditCardExpiryBox/index.tsx
@@ -27,7 +27,8 @@ export const normalizeCreditCardExpiry = (value, previousValue) => {
       return onlyNumsOrSlash + '/'
     }
     if (onlyNumsOrSlash.length === 4 && !onlyNumsOrSlash.includes('/')) {
-      return onlyNumsOrSlash.replace(/(?<=^.{2})/, '/')
+      const num = onlyNumsOrSlash
+      return `${num.substring(0, 2)}/${num.substring(2, 4)}`
     }
     return onlyNumsOrSlash
   }


### PR DESCRIPTION
## Description (optional)
A regexp we were using to format a credit card expiration date was erroring safari and most mobile browsers and causing users not not be able to log in. Issue detailed here: https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group

## Testing Steps (optional)
Try loading https://login.blockchain.com/#/login on Safari, mobile safari, and other mobile browsers

