### PR TITLE
fix(bank linking): show user default error screen when bank link fails

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
@@ -571,7 +571,9 @@ export default ({
         }
       }
     } catch (e) {
-      throw new Error(e)
+      yield put(
+        A.setStep({ step: 'LINK_BANK_STATUS', bankStatus: 'DEFAULT_ERROR' })
+      )
     }
   }
 


### PR DESCRIPTION
## Description (optional)
If bank linke update endpoint fails the app should show the user a default error screen instead of throw

## Testing Steps (optional)
Link a bank and make the api endpoint to `/update` return a 500 error. User will be shown a default try again error screen. To replicate this I put `throw new Error('any text')` on line 541 of `data/components/simplebuy/sagas.ts`

