### PR TITLE
fix(payment methods): use new payment method eligibity endpoint

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/custodial/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/custodial/index.ts
@@ -1,4 +1,4 @@
-import { CoinType, FiatType, SBPaymentTypes, WalletFiatType } from 'core/types'
+import { CoinType, SBPaymentTypes, WalletFiatType } from 'core/types'
 
 import {
   BeneficiariesType,
@@ -6,8 +6,6 @@ import {
   CustodialTransferRequestType,
   NabuCustodialProductType,
   PaymentDepositPendingResponseType,
-  PaymentMethod,
-  ProductEligibleResponse,
   WithdrawalFeesProductType,
   WithdrawalLockCheckResponseType,
   WithdrawalLockResponseType,
@@ -96,40 +94,8 @@ export default ({ authorizedGet, authorizedPost, nabuUrl }) => {
       data: request
     })
 
-  const fetchIsProductEligible = (
-    product: NabuCustodialProductType,
-    currency: FiatType
-  ): ProductEligibleResponse =>
-    authorizedGet({
-      url: nabuUrl,
-      endPoint: `/eligible/product/${product}${
-        currency ? `?currency=${currency}` : ''
-      }`
-    })
-
-  const fetchEligiblePaymentMethods = (
-    eligibleOnly: string,
-    currency: string,
-    tier: string
-  ): PaymentMethod[] => {
-    const queryObj = {
-      eligibleOnly,
-      currency,
-      tier
-    }
-    const parameters = new URLSearchParams(queryObj).toString()
-
-    return authorizedGet({
-      url: nabuUrl,
-      ignoreQueryParams: true,
-      endPoint: `/eligible/payment-methods${parameters ? `?${parameters}` : ''}`
-    })
-  }
-
   return {
     checkWithdrawalLocks,
-    fetchIsProductEligible,
-    fetchEligiblePaymentMethods,
     getBeneficiaries,
     getWithdrawalLocks,
     getWithdrawalFees,

--- a/packages/blockchain-wallet-v4/src/network/api/simpleBuy/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/simpleBuy/index.ts
@@ -252,8 +252,8 @@ export default ({
 
   const getSBPaymentMethods = (
     currency: FiatType,
-    checkEligibility?: boolean,
-    tier?: number
+    includeNonEligibleMethods?: boolean,
+    includeTierLimits?: number
   ): SBPaymentMethodsType =>
     authorizedGet({
       url: nabuUrl,
@@ -261,8 +261,8 @@ export default ({
       contentType: 'application/json',
       data: {
         currency,
-        checkEligibility,
-        tier
+        eligibleOnly: includeNonEligibleMethods,
+        tier: includeTierLimits
       }
     })
 

--- a/packages/blockchain-wallet-v4/src/network/api/simpleBuy/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/simpleBuy/types.ts
@@ -134,7 +134,9 @@ export type SBPaymentMethodType = {
   card?: SBCard
   currency: FiatType
   details?: BankDetails
+  eligible?: boolean
   id?: string
+  ineligibleReason?: string
   limits: {
     max: string
     min: string


### PR DESCRIPTION
## Description
- Fix to ensure non-gold users are shown payment methods for Buy/Sell instead of the currency unsupported screen
- Removes duplicate entries of same APIs.  The two removed where not used in the codebase
