### PR TITLE
fix(ACH): Payment methods defaults and order history

### DIFF
--- a/packages/blockchain-info-components/src/Colors/DarkMode.ts
+++ b/packages/blockchain-info-components/src/Colors/DarkMode.ts
@@ -27,7 +27,7 @@ const DarkTheme: DefaultTheme = {
   grey600: '#677185',
   grey700: lighten(0.1, '#50596B'),
   grey800: lighten(0.1, '#B1B8C7'),
-  grey900: '#121D33',
+  grey900: lighten(0.15, '#121D33'),
   blue000: '#ECF5FE',
   blue100: '#D8EBFD',
   blue200: '#BBDBFC',

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
@@ -5,6 +5,7 @@ import {
   ExtractSuccess,
   FiatTypeEnum,
   SBPaymentMethodType,
+  SBPaymentTypes,
   SDDLimits
 } from 'blockchain-wallet-v4/src/types'
 import { FiatType } from 'core/types'
@@ -69,8 +70,10 @@ export const getDefaultPaymentMethod = (state: RootState) => {
   const sbMethodsR = getSBPaymentMethods(state)
   const actionType = getOrderType(state)
   const sbBalancesR = getSBBalances(state)
+  const bankAccountsR = getBankTransferAccounts(state)
 
   const transform = (
+    bankAccounts: ExtractSuccess<typeof bankAccountsR>,
     sbCards: ExtractSuccess<typeof sbCardsR>,
     sbMethods: ExtractSuccess<typeof sbMethodsR>,
     sbBalances: ExtractSuccess<typeof sbBalancesR>
@@ -110,15 +113,17 @@ export const getDefaultPaymentMethod = (state: RootState) => {
             method.type === 'FUNDS' && method.currency === fiatCurrencyToUse
         )
       default:
+        // TODO: need to search for payment types instead of return
         if (!lastOrder) return undefined
 
         const methodsOfType = sbMethods.methods.filter(
           method => method.type === lastOrder.paymentType
         )
+        const method = head(methodsOfType)
 
         switch (lastOrder.paymentType) {
+          case 'USER_CARD':
           case 'PAYMENT_CARD':
-            const method = head(methodsOfType)
             if (!method) return
             const sbCard = sbCards.find(
               value => value.id === lastOrder.paymentMethodId
@@ -139,10 +144,22 @@ export const getDefaultPaymentMethod = (state: RootState) => {
                 method.currency === lastOrder.inputCurrency &&
                 method.currency === fiatCurrency
             )
-          case 'BANK_ACCOUNT':
-          case 'BANK_TRANSFER':
           case 'LINK_BANK':
-          case 'USER_CARD':
+          case 'BANK_TRANSFER':
+            if (!method) return
+            const bankAccount = bankAccounts.find(
+              acct => acct.id === lastOrder.paymentMethodId
+            )
+            if (bankAccount && bankAccount.state === 'ACTIVE') {
+              return {
+                ...method,
+                ...bankAccount,
+                state: 'ACTIVE',
+                type: lastOrder.paymentType as SBPaymentTypes
+              }
+            }
+            return undefined
+          case 'BANK_ACCOUNT':
           case undefined:
             return undefined
           default:
@@ -151,7 +168,7 @@ export const getDefaultPaymentMethod = (state: RootState) => {
     }
   }
 
-  return lift(transform)(sbCardsR, sbMethodsR, sbBalancesR)
+  return lift(transform)(bankAccountsR, sbCardsR, sbMethodsR, sbBalancesR)
 }
 
 export const hasFiatBalances = (state: RootState) => {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
@@ -113,7 +113,6 @@ export const getDefaultPaymentMethod = (state: RootState) => {
             method.type === 'FUNDS' && method.currency === fiatCurrencyToUse
         )
       default:
-        // TODO: need to search for payment types instead of return
         if (!lastOrder) return undefined
 
         const methodsOfType = sbMethods.methods.filter(

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/index.tsx
@@ -2,25 +2,17 @@ import { bindActionCreators, Dispatch } from 'redux'
 import { Button, Text } from 'blockchain-info-components'
 import { connect, ConnectedProps } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
-import { SBOrderType, SupportedWalletCurrenciesType } from 'core/types'
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 
 import { actions, selectors } from 'data'
 import {
-  Addresses,
-  Col,
-  DetailsColumn,
-  DetailsRow,
-  Row,
-  RowHeader,
-  RowValue,
-  StatusAndType,
-  StyledCoinDisplay,
-  StyledFiatDisplay,
-  TxRow,
-  TxRowContainer
-} from '../components'
+  BankTransferAccountType,
+  ExtractSuccess,
+  RemoteDataType,
+  SBOrderType,
+  SupportedWalletCurrenciesType
+} from 'core/types'
 import {
   BuyOrSell,
   displayFiat
@@ -35,8 +27,24 @@ import {
   getCounterCurrency,
   getOrderType
 } from 'data/components/simpleBuy/model'
-import { getOrigin, IconTx, Status, Timestamp } from './model'
 import { RootState } from 'data/rootReducer'
+
+import {
+  Addresses,
+  Col,
+  DetailsColumn,
+  DetailsRow,
+  Row,
+  RowHeader,
+  RowValue,
+  StatusAndType,
+  StyledCoinDisplay,
+  StyledFiatDisplay,
+  TxRow,
+  TxRowContainer
+} from '../components'
+import { getData } from './selectors'
+import { getOrigin, IconTx, Status, Timestamp } from './model'
 
 const LastCol = styled(Col)`
   display: flex;
@@ -63,7 +71,8 @@ class SimpleBuyListItem extends PureComponent<Props, State> {
   }
 
   render () {
-    const { order, supportedCoins } = this.props
+    const { data, order, supportedCoins } = this.props
+    const bankAccounts = data.getOrElse([] as Array<BankTransferAccountType>)
     const coin = getCoinFromPair(order.pair)
     const orderType = getOrderType(order)
     const baseAmount = getBaseAmount(order)
@@ -97,7 +106,7 @@ class SimpleBuyListItem extends PureComponent<Props, State> {
           </Row>
           <Col width='50%' data-e2e='orderToAndFrom'>
             <Addresses
-              from={<>{getOrigin(this.props)}</>}
+              from={<>{getOrigin(this.props, bankAccounts)}</>}
               to={<>{this.props.order.outputCurrency} Trading Wallet</>}
             />
           </Col>
@@ -220,7 +229,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   simpleBuyActions: bindActionCreators(actions.components.simpleBuy, dispatch)
 })
 
-const mapStateToProps = (state: RootState) => ({
+const mapStateToProps = (state: RootState): LinkStatePropsType => ({
+  data: getData(state),
   supportedCoins: selectors.core.walletOptions
     .getSupportedCoins(state)
     .getOrElse({} as SupportedWalletCurrenciesType)
@@ -230,6 +240,11 @@ const connector = connect(mapStateToProps, mapDispatchToProps)
 
 type OwnProps = {
   order: SBOrderType
+}
+export type SuccessStateType = ExtractSuccess<ReturnType<typeof getData>>
+type LinkStatePropsType = {
+  data: RemoteDataType<string, SuccessStateType>
+  supportedCoins: SupportedWalletCurrenciesType
 }
 export type Props = OwnProps & ConnectedProps<typeof connector>
 type State = { isToggled: boolean }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/model.tsx
@@ -1,13 +1,15 @@
 import { FormattedMessage } from 'react-intl'
-import { getCoinFromPair, getOrderType } from 'data/components/simpleBuy/model'
 import React from 'react'
+
+import { BankTransferAccountType } from 'core/network/api/simpleBuy/types'
+import { getCoinFromPair, getOrderType } from 'data/components/simpleBuy/model'
+import { Text } from 'blockchain-info-components'
 
 import { Props } from '.'
 import {
   IconTx as SharedIconTx,
   Timestamp as SharedTimestamp
 } from '../components'
-import { Text } from 'blockchain-info-components'
 
 export const IconTx = (props: Props) => {
   const orderType = getOrderType(props.order)
@@ -15,7 +17,10 @@ export const IconTx = (props: Props) => {
   return <SharedIconTx type={orderType} coin={coin} />
 }
 
-export const getOrigin = (props: Props) => {
+export const getOrigin = (
+  props: Props,
+  bankAccounts: Array<BankTransferAccountType>
+) => {
   switch (props.order.paymentType) {
     case 'FUNDS':
       return props.order.inputCurrency + ' Wallet'
@@ -25,8 +30,19 @@ export const getOrigin = (props: Props) => {
     case 'BANK_ACCOUNT':
       return 'Bank Transfer'
     case 'LINK_BANK':
-    case 'BANK_TRANSFER': // LOL this is so bad
-      return 'Bank Account'
+    case 'BANK_TRANSFER':
+      // should always be a bank account but user may have removed the account
+      try {
+        const accounts = bankAccounts.filter(
+          acct => acct.id === props.order.paymentMethodId
+        )
+        const { details } = accounts[0]
+        return `${details.bankName} ${details.bankAccountType.toLowerCase()} ${
+          details.accountNumber
+        }`
+      } catch {
+        return 'Bank Account'
+      }
     case undefined:
       return 'Unknown Payment Type'
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/model.tsx
@@ -31,18 +31,16 @@ export const getOrigin = (
       return 'Bank Transfer'
     case 'LINK_BANK':
     case 'BANK_TRANSFER':
-      // should always be a bank account but user may have removed the account
-      try {
-        const accounts = bankAccounts.filter(
-          acct => acct.id === props.order.paymentMethodId
-        )
-        const { details } = accounts[0]
+      const bankAccount = bankAccounts.find(
+        acct => acct.id === props.order.paymentMethodId
+      )
+      if (bankAccount) {
+        const { details } = bankAccount
         return `${details.bankName} ${details.bankAccountType.toLowerCase()} ${
           details.accountNumber
         }`
-      } catch {
-        return 'Bank Account'
       }
+      return 'Bank Account'
     case undefined:
       return 'Unknown Payment Type'
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/selectors.ts
@@ -1,0 +1,14 @@
+import { ExtractSuccess } from 'core/types'
+import { lift } from 'ramda'
+import { RootState } from 'data/rootReducer'
+
+import { selectors } from 'data'
+
+export const getData = (state: RootState) => {
+  const bankAccountsR = selectors.components.simpleBuy.getBankTransferAccounts(
+    state
+  )
+  return lift(
+    (bankAccounts: ExtractSuccess<typeof bankAccountsR>) => bankAccounts
+  )(bankAccountsR)
+}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/index.tsx
@@ -96,6 +96,7 @@ class TransactionsContainer extends React.PureComponent<Props> {
       this.props.currency,
       'week'
     )
+    this.props.simpleBuyActions.fetchBankTransferAccounts()
   }
 
   componentDidUpdate (prevProps) {


### PR DESCRIPTION
## Description (optional)
- Show correct bank account information on transaction list instead of "Bank Account"
- By default select last bank account used for Buy
- Fix Dark mode grey900 text

