### PR TITLE
feat(swap): prevent caching of old swap amount after success swap

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/swap/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/swap/sagas.ts
@@ -222,6 +222,7 @@ export default ({
       }
       yield put(actions.form.stopSubmit('previewSwap'))
       yield put(actions.components.refresh.refreshClicked())
+      yield put(actions.form.destroy('swapAmount'))
       yield put(
         A.setStep({
           step: 'SUCCESSFUL_SWAP',


### PR DESCRIPTION
## Description (optional)
This PR prevents caching of swap initial value, after success swap we now do clear previously entered amount

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

