### PR TITLE
Fix/bugs

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/LinkedPaymentAccounts/Accounts/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/LinkedPaymentAccounts/Accounts/index.tsx
@@ -231,8 +231,8 @@ class Accounts extends PureComponent<InjectedFormProps<{}, Props> & Props> {
         type: 'USER_CARD',
         currency: card.currency,
         limits: {
-          min: cardMethod?.value.limits.min,
-          max: cardMethod?.value.limits.max
+          min: cardMethod?.value.limits.min || '10000',
+          max: cardMethod?.value.limits.max || '50000'
         }
       } as SBPaymentMethodType
     }))

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/LinkedPaymentAccounts/Accounts/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/LinkedPaymentAccounts/Accounts/index.tsx
@@ -214,6 +214,11 @@ class Accounts extends PureComponent<InjectedFormProps<{}, Props> & Props> {
           ) > 0)
     )
 
+    // use this to get min/max for card buys from eligible/payment-methods
+    // limits aren't available on availableCards
+    const cardMethod = defaultMethods.find(
+      method => method.value.type === 'PAYMENT_CARD'
+    )
     const cardMethods = availableCards.map(card => ({
       text: card.card
         ? card.card.label
@@ -225,7 +230,10 @@ class Accounts extends PureComponent<InjectedFormProps<{}, Props> & Props> {
         card: card.card,
         type: 'USER_CARD',
         currency: card.currency,
-        limits: { min: '1000', max: '500000' }
+        limits: {
+          min: cardMethod?.value.limits.min,
+          max: cardMethod?.value.limits.max
+        }
       } as SBPaymentMethodType
     }))
 
@@ -247,7 +255,6 @@ class Accounts extends PureComponent<InjectedFormProps<{}, Props> & Props> {
 
     const availableMethods =
       funds.length || cardMethods.length || bankMethods.length
-
     return (
       <Wrapper>
         <Form>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/CoinSelection/CryptoAccountOption/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/CoinSelection/CryptoAccountOption/index.tsx
@@ -34,7 +34,7 @@ const CryptoAccountOption: React.FC<Props> = props => {
           style={{ marginRight: '12px' }}
         />
         <div>
-          <OptionTitle>{account.label}</OptionTitle>
+          <OptionTitle data-e2e={account.label}>{account.label}</OptionTitle>
           <OptionValue>
             <BalanceRow>
               <CoinBalance account={account} walletCurrency={walletCurrency} />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/InitSwapForm/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/InitSwapForm/index.tsx
@@ -115,7 +115,9 @@ class InitSwapForm extends PureComponent<InjectedFormProps<{}, Props> & Props> {
                           defaultMessage='Swap from'
                         />
                       </Text>
-                      <OptionTitle>{values.BASE.label}</OptionTitle>
+                      <OptionTitle data-e2e='swapFromWallet'>
+                        {values.BASE.label}
+                      </OptionTitle>
                       <OptionValue>
                         <BalanceRow>
                           <CoinBalance
@@ -180,7 +182,7 @@ class InitSwapForm extends PureComponent<InjectedFormProps<{}, Props> & Props> {
                           defaultMessage='Receive to'
                         />
                       </OptionValue>
-                      <OptionTitle color='grey900'>
+                      <OptionTitle data-e2e='swapToWallet' color='grey900'>
                         {values.COUNTER.label}
                       </OptionTitle>
                       <OptionValue>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
@@ -85,7 +85,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
           <Title>
             <FormattedMessage id='copy.swap' defaultMessage='Swap' />
           </Title>
-          <Value>
+          <Value data-e2e='swapOutgoingValue'>
             {coinToString({
               value: this.props.swapAmountFormValues?.cryptoAmount,
               unit: { symbol: baseCoinTicker }
@@ -96,7 +96,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
           <Title>
             <FormattedMessage id='buttons.receive' defaultMessage='Receive' />
           </Title>
-          <Value>
+          <Value data-e2e='swapIncomingValue'>
             {this.props.incomingAmountR.cata({
               Success: value => (
                 <>
@@ -119,7 +119,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
               defaultMessage='Exchange Rate'
             />
           </Title>
-          <Value>
+          <Value data-e2e='swapExchangeRate'>
             {this.props.quoteR.cata({
               Success: val => (
                 <>
@@ -144,13 +144,13 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
           <Title>
             <FormattedMessage id='copy.from' defaultMessage='From' />
           </Title>
-          <Value>{BASE.label}</Value>
+          <Value data-e2e='swapOutgoingWallet'>{BASE.label}</Value>
         </Row>
         <Row>
           <Title>
             <FormattedMessage id='copy.to' defaultMessage='To' />
           </Title>
-          <Value>{COUNTER.label}</Value>
+          <Value data-e2e='swapIncomingWallet'>{COUNTER.label}</Value>
         </Row>
         <Row>
           <Title>
@@ -160,7 +160,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
               values={{ coin: coins[BASE.coin].coinTicker }}
             />
           </Title>
-          <Value>
+          <Value data-e2e='swapOutgoingFee'>
             {BASE.type === 'CUSTODIAL' ? (
               <FreeCartridge>
                 <FormattedMessage id='copy.free' defaultMessage='FREE' />
@@ -193,7 +193,7 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props> {
               values={{ coin: counterCoinTicker }}
             />
           </Title>
-          <Value>
+          <Value data-e2e='swapIncomingFee'>
             {COUNTER.type === 'CUSTODIAL' ? (
               <FreeCartridge>
                 <FormattedMessage id='copy.free' defaultMessage='FREE' />


### PR DESCRIPTION
## Description (optional)
Adds data e2e for automation and fixes issue where credit card limit was hard coded to 5k when selecting a credit card from the payment method screen. Now, we fetch the correct credit card limit from `eligible/payment-methods`.
FWLT-799 and FWLT-1006

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

