### PR TITLE
fix(simple buy): fixes error on first-time user credit card form validation

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/AddCard/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/AddCard/index.tsx
@@ -15,8 +15,9 @@ import Success from './template.success'
 
 class AddCard extends PureComponent<Props> {
   componentDidMount () {
+    this.props.simpleBuyActions.fetchSBPaymentMethods(this.props.fiatCurrency)
+
     if (!Remote.Success.is(this.props.data)) {
-      this.props.simpleBuyActions.fetchSBPaymentMethods(this.props.fiatCurrency)
       this.props.identityVerificationActions.fetchSupportedCountries()
     }
   }

--- a/packages/blockchain-wallet-v4-frontend/src/services/ImagesService/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/ImagesService/index.ts
@@ -2,6 +2,7 @@ export const getBankLogoImageName = bankName => {
   switch (bankName) {
     case 'Acorns':
       return 'bank-logo-acorns'
+    case 'Ally Bank':
     case 'Ally':
       return 'bank-logo-ally'
     case 'Bank Of America':


### PR DESCRIPTION
## Description (optional)
When a user first signs up and proceeds to go through the simple buy flow, we get the payment methods eligibility from the api _before_ the user has entered any address/kyc info. So it shows them as ineligible unless they hard refresh and log in again. This change makes the payments method fetch each time the CC form is loaded so we always have the latest eligibility. 

## Testing Steps (optional)
1. Sign up for a new wallet (DO NOT HARD REFRESH)
2. Go through simple buy flow
3. CC form should no longer show the `Card type not supported` input error when you put in a CC#

