### PR TITLE
fix(swap): resolve saga if xlm payment error and card settings styling

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/swap/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/swap/sagas.ts
@@ -389,26 +389,30 @@ export default ({
     let payment = paymentGetOrElse(BASE.coin, paymentR)
 
     const value = Number(swapAmountValues?.cryptoAmount)
-
-    switch (payment.coin) {
-      case 'BCH':
-      case 'BTC':
-        payment = yield payment.amount(
-          parseInt(convertStandardToBase(BASE.coin, value))
-        )
-        break
-      case 'ETH':
-      case 'PAX':
-      case 'USDT':
-      case 'WDGLD':
-      case 'XLM':
-        payment = yield payment.amount(convertStandardToBase(BASE.coin, value))
-        break
-      default:
-        throw new Error(INVALID_COIN_TYPE)
+    try {
+      switch (payment.coin) {
+        case 'BCH':
+        case 'BTC':
+          payment = yield payment.amount(
+            parseInt(convertStandardToBase(BASE.coin, value))
+          )
+          break
+        case 'ETH':
+        case 'PAX':
+        case 'USDT':
+        case 'WDGLD':
+        case 'XLM':
+          payment = yield payment.amount(
+            convertStandardToBase(BASE.coin, value)
+          )
+          break
+        default:
+          throw new Error(INVALID_COIN_TYPE)
+      }
+      yield put(A.updatePaymentSuccess(payment.value()))
+    } catch (error) {
+      yield put(A.updatePaymentFailure(error))
     }
-
-    yield put(A.updatePaymentSuccess(payment.value()))
   }
 
   const initAmountForm = function * () {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/template.success.tsx
@@ -78,6 +78,10 @@ const Success: React.FC<InjectedFormProps<
 
           if (card.state !== 'ACTIVE') return
 
+          const cardLabel =
+            (card?.card.label && card?.card.label.toLowerCase()) ||
+            card?.card.type
+
           return (
             <CardWrapper
               key={i}
@@ -92,8 +96,9 @@ const Success: React.FC<InjectedFormProps<
                 />
                 <CardDetails>
                   <Text size='16px' color='grey800' weight={600} capitalize>
-                    {(card.card.label && card.card.label.toLowerCase()) ||
-                      card.card.type}
+                    {cardLabel.length > 22
+                      ? `${cardLabel.slice(0, 22)}…`
+                      : cardLabel}
                   </Text>
                   {ccPaymentMethod && (
                     <Text size='14px' color='grey600' weight={500}>


### PR DESCRIPTION
## Description (optional)
Fixes issue with swap where an XLM payment is created by clicking 'Swap Min', but the XLM balance < min. This causes formChange saga to stop and not resolve, breaking most of the app.

Also added styling to card settings, to truncate card label so rows don't shift. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

