### PR TITLE
fix(simple buy): filter out non-active cards from sb default payment

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
@@ -19,7 +19,7 @@ import {
 } from '../exchange/services'
 import { getInputFromPair, getOutputFromPair } from '../swap/model'
 import { getRate } from '../swap/utils'
-import { SBCheckoutFormValuesType } from './types'
+import { SBCardStateEnum, SBCheckoutFormValuesType } from './types'
 
 const SDD_LIMIT = { min: '500', max: '10000' } as SDDLimits
 
@@ -123,8 +123,11 @@ export const getDefaultPaymentMethod = (state: RootState) => {
           case 'USER_CARD':
           case 'PAYMENT_CARD':
             if (!method) return
+            const active = SBCardStateEnum.ACTIVE
             const sbCard = sbCards.find(
-              value => value.id === lastOrder.paymentMethodId
+              value =>
+                value.id === lastOrder.paymentMethodId &&
+                value.state === SBCardStateEnum[active]
             )
             const card = sbCard?.card || undefined
 

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/types.ts
@@ -119,6 +119,14 @@ export type BankStatusType =
   | 'BANK_TRANSFER_ACCOUNT_NAME_MISMATCH'
   | 'DEFAULT_ERROR'
 
+export enum SBCardStateEnum {
+  PENDING,
+  CREATED,
+  ACTIVE,
+  BLOCKED,
+  FRAUD_REVIEW
+}
+
 // State
 export type SimpleBuyState = {
   account: RemoteDataType<string, SBAccountType>


### PR DESCRIPTION
## Description (optional)
This filters the default card payment method by 'ACTIVE' state. Currently if you remove a CC and it was the last used card, it will still be set as the default payment method.
![image](https://user-images.githubusercontent.com/57680122/105561226-0102a880-5ccb-11eb-9e1e-967a45432adf.png)

## Testing Steps (optional)
- add a card or use an existing one
- make a simple buy with it
- remove that card
- open simple buy form

