### PR TITLE
fix(tx-feed): pax to usd digital display

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CustodialTx/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CustodialTx/index.tsx
@@ -1,7 +1,13 @@
+import { connect, ConnectedProps } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
+import { selectors } from 'data'
 import React, { useState } from 'react'
 
-import { CoinTypeEnum, FiatSBAndSwapTransactionType } from 'core/types'
+import {
+  CoinTypeEnum,
+  FiatSBAndSwapTransactionType,
+  SupportedWalletCurrenciesType
+} from 'core/types'
 import { convertBaseToStandard } from 'data/components/exchange/services'
 import { fiatToString } from 'core/exchange/currency'
 import { Text } from 'blockchain-info-components'
@@ -29,6 +35,7 @@ import {
   TransactionType
 } from './model'
 import { Props as OwnProps } from '../TransactionList'
+import { RootState } from 'data/rootReducer'
 
 const CustodialTxListItem: React.FC<Props> = props => {
   const [isToggled, setIsToggled] = useState(false)
@@ -154,8 +161,17 @@ const CustodialTxListItem: React.FC<Props> = props => {
   )
 }
 
-export type Props = OwnProps & {
-  tx: FiatSBAndSwapTransactionType
-}
+const mapStateToProps = (state: RootState) => ({
+  supportedCoins: selectors.core.walletOptions
+    .getSupportedCoins(state)
+    .getOrElse({} as SupportedWalletCurrenciesType)
+})
 
-export default CustodialTxListItem
+const connector = connect(mapStateToProps)
+
+export type Props = OwnProps &
+  ConnectedProps<typeof connector> & {
+    tx: FiatSBAndSwapTransactionType
+  }
+
+export default connector(CustodialTxListItem)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CustodialTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CustodialTx/model.tsx
@@ -152,18 +152,21 @@ export const Origin = (props: Props) => {
     case 'REFUNDED':
     case 'DEPOSIT':
       return props.tx.amount.symbol in CoinTypeEnum ? (
-        <>{props.coinTicker} Wallet</>
+        <>{props.supportedCoins[props.coin].displayName} Wallet</>
       ) : (
         <>Bank Account</>
       )
     case 'SELL':
       return props.tx.extraAttributes?.direction === 'FROM_USERKEY' ? (
-        <>{props.tx.amount.symbol} Wallet</>
+        <>{props.supportedCoins[props.tx.amount.symbol].displayName} Wallet</>
       ) : (
-        <>{props.tx.amount.symbol} Trading Wallet</>
+        <>
+          {props.supportedCoins[props.tx.amount.symbol].displayName} Trading
+          Wallet
+        </>
       )
     case 'WITHDRAWAL':
-      return <>{props.coinTicker} Wallet</>
+      return <>{props.supportedCoins[props.coin].displayName} Wallet</>
     default:
       return <></>
   }
@@ -173,12 +176,12 @@ export const Destination = (props: Props) => {
   switch (props.tx.type) {
     case 'REFUNDED':
     case 'DEPOSIT':
-      return <>{props.coinTicker} Wallet</>
+      return <>{props.supportedCoins[props.coin].displayName} Wallet</>
     case 'SELL':
-      return <>{props.coinTicker} Wallet</>
+      return <>{props.supportedCoins[props.coin].displayName} Wallett</>
     case 'WITHDRAWAL':
       return props.tx.amount.symbol in CoinTypeEnum ? (
-        <>{props.tx.amount.symbol} Wallet</>
+        <>{props.supportedCoins[props.tx.amount.symbol].displayName} Wallet</>
       ) : (
         <>Bank Account</>
       )

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CustodialTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CustodialTx/model.tsx
@@ -18,14 +18,11 @@ const Icon = styled(BCIcon)`
   font-weight: 600;
 `
 const getSymbolDisplayName = (props: Props) => {
-  return path(
-    [`${props.tx.amount.symbol}`, 'displayName'],
-    props.supportedCoins
-  )
+  return path([props.tx.amount.symbol, 'displayName'], props.supportedCoins)
 }
 
 const getCoinDisplayName = (props: Props) => {
-  return path([`${props.coin}`, 'displayName'], props.supportedCoins)
+  return path([props.coin, 'displayName'], props.supportedCoins)
 }
 export const IconTx = (props: Props) => {
   switch (props.tx.state) {
@@ -174,9 +171,7 @@ export const Origin = (props: Props) => {
       )
     case 'WITHDRAWAL':
       return (
-        <>
-          {path([`${props.coin}`, 'displayName'], props.supportedCoins)} Wallet
-        </>
+        <>{path([props.coin, 'displayName'], props.supportedCoins)} Wallet</>
       )
     default:
       return <></>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CustodialTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CustodialTx/model.tsx
@@ -1,5 +1,6 @@
 import { Icon as BCIcon, Text } from 'blockchain-info-components'
 import { FormattedMessage } from 'react-intl'
+import { path } from 'ramda'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -16,7 +17,16 @@ const Icon = styled(BCIcon)`
   size: 18px;
   font-weight: 600;
 `
+const getSymbolDisplayName = (props: Props) => {
+  return path(
+    [`${props.tx.amount.symbol}`, 'displayName'],
+    props.supportedCoins
+  )
+}
 
+const getCoinDisplayName = (props: Props) => {
+  return path([`${props.coin}`, 'displayName'], props.supportedCoins)
+}
 export const IconTx = (props: Props) => {
   switch (props.tx.state) {
     case 'FINISHED':
@@ -152,21 +162,22 @@ export const Origin = (props: Props) => {
     case 'REFUNDED':
     case 'DEPOSIT':
       return props.tx.amount.symbol in CoinTypeEnum ? (
-        <>{props.supportedCoins[props.coin].displayName} Wallet</>
+        <>{getCoinDisplayName(props)} Wallet</>
       ) : (
         <>Bank Account</>
       )
     case 'SELL':
       return props.tx.extraAttributes?.direction === 'FROM_USERKEY' ? (
-        <>{props.supportedCoins[props.tx.amount.symbol].displayName} Wallet</>
+        <> {getSymbolDisplayName(props)} Wallet</>
       ) : (
-        <>
-          {props.supportedCoins[props.tx.amount.symbol].displayName} Trading
-          Wallet
-        </>
+        <>{getSymbolDisplayName(props)} Trading Wallet</>
       )
     case 'WITHDRAWAL':
-      return <>{props.supportedCoins[props.coin].displayName} Wallet</>
+      return (
+        <>
+          {path([`${props.coin}`, 'displayName'], props.supportedCoins)} Wallet
+        </>
+      )
     default:
       return <></>
   }
@@ -176,12 +187,12 @@ export const Destination = (props: Props) => {
   switch (props.tx.type) {
     case 'REFUNDED':
     case 'DEPOSIT':
-      return <>{props.supportedCoins[props.coin].displayName} Wallet</>
+      return <>{getCoinDisplayName(props)} Wallet</>
     case 'SELL':
-      return <>{props.supportedCoins[props.coin].displayName} Wallett</>
+      return <>{getCoinDisplayName(props)} Wallet</>
     case 'WITHDRAWAL':
       return props.tx.amount.symbol in CoinTypeEnum ? (
-        <>{props.supportedCoins[props.tx.amount.symbol].displayName} Wallet</>
+        <>{getSymbolDisplayName(props)} Wallet</>
       ) : (
         <>Bank Account</>
       )

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/index.tsx
@@ -77,7 +77,7 @@ class SimpleBuyListItem extends PureComponent<Props, State> {
     const bankAccounts = data.getOrElse([] as Array<BankTransferAccountType>)
     const coin = getCoinFromPair(order.pair)
     const coinDisplayName = path(
-      [`${this.props.order.outputCurrency}`, 'coinTicker'],
+      [this.props.order.outputCurrency, 'coinTicker'],
       this.props.supportedCoins
     )
     const orderType = getOrderType(order)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/index.tsx
@@ -112,7 +112,15 @@ class SimpleBuyListItem extends PureComponent<Props, State> {
           <Col width='50%' data-e2e='orderToAndFrom'>
             <Addresses
               from={<>{getOrigin(this.props, bankAccounts)}</>}
-              to={<>{this.props.order.outputCurrency} Trading Wallet</>}
+              to={
+                <>
+                  {
+                    this.props.supportedCoins[this.props.order.outputCurrency]
+                      .coinTicker
+                  }{' '}
+                  Trading Wallet
+                </>
+              }
             />
           </Col>
           {order.state === 'PENDING_CONFIRMATION' ||

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/index.tsx
@@ -2,6 +2,7 @@ import { bindActionCreators, Dispatch } from 'redux'
 import { Button, Text } from 'blockchain-info-components'
 import { connect, ConnectedProps } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
+import { path } from 'ramda'
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 
@@ -75,6 +76,10 @@ class SimpleBuyListItem extends PureComponent<Props, State> {
     const { data, order, supportedCoins } = this.props
     const bankAccounts = data.getOrElse([] as Array<BankTransferAccountType>)
     const coin = getCoinFromPair(order.pair)
+    const coinDisplayName = path(
+      [`${this.props.order.outputCurrency}`, 'coinTicker'],
+      this.props.supportedCoins
+    )
     const orderType = getOrderType(order)
     const baseAmount = getBaseAmount(order)
     const baseCurrency = getBaseCurrency(order, supportedCoins)
@@ -112,15 +117,7 @@ class SimpleBuyListItem extends PureComponent<Props, State> {
           <Col width='50%' data-e2e='orderToAndFrom'>
             <Addresses
               from={<>{getOrigin(this.props, bankAccounts)}</>}
-              to={
-                <>
-                  {
-                    this.props.supportedCoins[this.props.order.outputCurrency]
-                      .coinTicker
-                  }{' '}
-                  Trading Wallet
-                </>
-              }
+              to={<>{coinDisplayName} Trading Wallet</>}
             />
           </Col>
           {order.state === 'PENDING_CONFIRMATION' ||

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/model.tsx
@@ -17,10 +17,15 @@ export const getDestination = (props: Props) => {
   switch (props.order.kind.direction) {
     case 'TO_USERKEY':
     case 'ON_CHAIN':
-      return getOutput(props.order) + ' Wallet'
+      return (
+        props.supportedCoins[getOutput(props.order)].displayName + ' Wallet'
+      )
     case 'FROM_USERKEY':
     case 'INTERNAL':
-      return getOutput(props.order) + ' Trading Wallet'
+      return (
+        props.supportedCoins[getOutput(props.order)].displayName +
+        ' Trading Wallet'
+      )
     default:
       return ''
   }
@@ -30,10 +35,13 @@ export const getOrigin = (props: Props) => {
   switch (props.order.kind.direction) {
     case 'FROM_USERKEY':
     case 'ON_CHAIN':
-      return getInput(props.order) + ' Wallet'
+      return props.supportedCoins[getInput(props.order)].displayName + ' Wallet'
     case 'TO_USERKEY':
     case 'INTERNAL':
-      return getInput(props.order) + ' Trading Wallet'
+      return (
+        props.supportedCoins[getInput(props.order)].displayName +
+        ' Trading Wallet'
+      )
     default:
       return ''
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/model.tsx
@@ -1,5 +1,6 @@
 import { FormattedMessage } from 'react-intl'
 import { getInput, getOutput } from 'data/components/swap/model'
+import { path } from 'ramda'
 import React from 'react'
 
 import { Props } from '.'
@@ -9,6 +10,15 @@ import {
 } from '../components'
 import { Text } from 'blockchain-info-components'
 
+const getOutputCoinDisplayName = (props: Props) => {
+  return path(
+    [`${getOutput(props.order)}`, 'displayName'],
+    props.supportedCoins
+  )
+}
+const getInputCoinDisplayName = (props: Props) => {
+  return path([`${getInput(props.order)}`, 'displayName'], props.supportedCoins)
+}
 export const IconTx = (props: Props) => {
   return <SharedIconTx type='SWAP' coin={props.coin} />
 }
@@ -17,15 +27,10 @@ export const getDestination = (props: Props) => {
   switch (props.order.kind.direction) {
     case 'TO_USERKEY':
     case 'ON_CHAIN':
-      return (
-        props.supportedCoins[getOutput(props.order)].displayName + ' Wallet'
-      )
+      return `${getOutputCoinDisplayName(props)} Wallet`
     case 'FROM_USERKEY':
     case 'INTERNAL':
-      return (
-        props.supportedCoins[getOutput(props.order)].displayName +
-        ' Trading Wallet'
-      )
+      return `${getOutputCoinDisplayName(props)} Trading Wallet`
     default:
       return ''
   }
@@ -35,13 +40,10 @@ export const getOrigin = (props: Props) => {
   switch (props.order.kind.direction) {
     case 'FROM_USERKEY':
     case 'ON_CHAIN':
-      return props.supportedCoins[getInput(props.order)].displayName + ' Wallet'
+      return `${getInputCoinDisplayName(props)} Wallet`
     case 'TO_USERKEY':
     case 'INTERNAL':
-      return (
-        props.supportedCoins[getInput(props.order)].displayName +
-        ' Trading Wallet'
-      )
+      return `${getInputCoinDisplayName(props)} Trading Wallet`
     default:
       return ''
   }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/model.tsx
@@ -11,13 +11,10 @@ import {
 import { Text } from 'blockchain-info-components'
 
 const getOutputCoinDisplayName = (props: Props) => {
-  return path(
-    [`${getOutput(props.order)}`, 'displayName'],
-    props.supportedCoins
-  )
+  return path([getOutput(props.order), 'displayName'], props.supportedCoins)
 }
 const getInputCoinDisplayName = (props: Props) => {
-  return path([`${getInput(props.order)}`, 'displayName'], props.supportedCoins)
+  return path([getInput(props.order), 'displayName'], props.supportedCoins)
 }
 export const IconTx = (props: Props) => {
   return <SharedIconTx type='SWAP' coin={props.coin} />


### PR DESCRIPTION
## Description (optional)
Fixed 985, where swap/buy/sell transactions displayed PAX in the feed rather than usd-d. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

