### PR TITLE
fix(export-history): include erc20 feed in eth transaction history

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/data/eth/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/data/eth/sagas.ts
@@ -194,7 +194,6 @@ export default ({ api }) => {
         fullTxList = fullTxList.concat(prop('transactions', txPage))
         currentPage++
       }
-
       // process txs further for report
       const processedTxList = yield call(
         __processReportTxs,
@@ -540,7 +539,7 @@ export default ({ api }) => {
     // remove txs that dont match coin type and are not within date range
     let prunedTxList = filter(tx => {
       // @ts-ignore
-      return !tx.erc20 && moment.unix(tx.time).isBetween(startDate, endDate)
+      return moment.unix(tx.time).isBetween(startDate, endDate)
     }, fullTxList)
 
     // return empty list if no tx found in filter set


### PR DESCRIPTION
## Description (optional)
Fixes issue where ERC20 fees weren't include in the ETH transaction history csv. The !tx.erc20 check isn't needed, since erc20 transactions are not included in the rawTxList returned from eth transaction endpoint.  
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

