### PR TITLE
fix(simple buy): fixes issue where funds default payment method has no available funds

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
@@ -140,11 +140,13 @@ export const getDefaultPaymentMethod = (state: RootState) => {
               card
             }
           case 'FUNDS':
-            return methodsOfType.find(
-              method =>
+            return methodsOfType.find(method => {
+              return (
                 method.currency === lastOrder.inputCurrency &&
-                method.currency === fiatCurrency
-            )
+                method.currency === fiatCurrency &&
+                sbBalances[method?.currency]?.available > 0
+              )
+            })
           case 'LINK_BANK':
           case 'BANK_TRANSFER':
             if (!method) return


### PR DESCRIPTION
## Description (optional)
If you have fiat funds, and buy crypto with 100% of your fiat wallet, the next time you try to buy crypto, it defaults to previous fiat wallet, but says I don't have enough funds, but you can't change the payment method because there's a form error.

## Testing Steps (optional)
Add fiat funds to your account, buy crypto with 100% of those funds. Try to buy more crypto again.

