### PR TITLE
fix(credit cards): remove click event from cards in general settings

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/template.success.tsx
@@ -83,13 +83,7 @@ const Success: React.FC<InjectedFormProps<
             card?.card.type
 
           return (
-            <CardWrapper
-              key={i}
-              onClick={() => {
-                if (props.submitting) return
-                props.handleCreditCardClick()
-              }}
-            >
+            <CardWrapper key={i}>
               <Child>
                 <CardImg
                   src={cardType ? cardType.logo : DEFAULT_CARD_SVG_LOGO}


### PR DESCRIPTION
## Description (optional)
There's a click event on all cards in general settings that just opens the simple buy flyout. This should not be there.

## Testing Steps (optional)
Add CC to an account or use existing CC account, go to General settings, click on the save CC (not the remove button) and it should now do nothing.

