### PR TITLE
feat(simplebuy): fixed check withdrawal lock to pass over fiat currency

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/send/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/send/sagas.ts
@@ -11,7 +11,8 @@ import {
   PaymentValue,
   RemoteDataType,
   SBOrderType,
-  SBPaymentTypes
+  SBPaymentTypes,
+  WalletFiatType
 } from 'core/types'
 import { INVALID_COIN_TYPE } from 'blockchain-wallet-v4/src/model'
 import { promptForSecondPassword } from 'services/SagaService'
@@ -157,6 +158,17 @@ export default ({
       const payment: SBOrderType = yield select(
         selectors.components.simpleBuy.getSBOrder
       )
+
+      const fiatCurrency: WalletFiatType = yield select(
+        selectors.components.simpleBuy.getFiatCurrency
+      )
+      const state = yield select()
+      const settingsCurrency: WalletFiatType = selectors.core.settings
+        .getCurrency(state)
+        .getOrElse('USD')
+
+      const currency = fiatCurrency || settingsCurrency
+
       // Lock rule can only be called with BANK_TRANSFER and PAYMENT_CARD
       // Adding check here to only pass those too, else pass BANK_TRANSFER
       const withdrawalCheckPayment: SBPaymentTypes =
@@ -167,7 +179,8 @@ export default ({
 
       const withdrawalLockCheckResponse = yield call(
         api.checkWithdrawalLocks,
-        withdrawalCheckPayment
+        withdrawalCheckPayment,
+        currency
       )
       yield put(A.getLockRuleSuccess(withdrawalLockCheckResponse))
     } catch (e) {

--- a/packages/blockchain-wallet-v4/src/network/api/custodial/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/custodial/index.ts
@@ -75,14 +75,16 @@ export default ({ authorizedGet, authorizedPost, nabuUrl }) => {
     })
 
   const checkWithdrawalLocks = (
-    paymentMethod: SBPaymentTypes
+    paymentMethod: SBPaymentTypes,
+    currency: WalletFiatType
   ): WithdrawalLockCheckResponseType =>
     authorizedPost({
       url: nabuUrl,
       endPoint: '/payments/withdrawals/locks/check',
       contentType: 'application/json',
       data: {
-        paymentMethod
+        paymentMethod,
+        currency
       }
     })
 


### PR DESCRIPTION
## Description (optional)
Due to recent changes on API side we have to pass along fiatCurrency in check call

## Testing Steps (optional)
To test this log in to wallet and go ove simple buy flow, make sure that there is no errors show once when user do select crypto currency

