### PR TITLE
fix(swap): disable swap if avail balance is less than min swap

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
@@ -122,6 +122,7 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
     userData,
     walletCurrency
   } = props
+
   const [fontRatio, setRatio] = useState(1)
   const amtError = typeof formErrors.amount === 'string' && formErrors.amount
 
@@ -220,8 +221,8 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
       }
     })
   }
-  const userMax = Number(payment ? payment.effectiveBalance : BASE.balance)
-  const balanceBelowMinimum = userMax < Number(min)
+
+  const balanceBelowMinimum = Number(max) < Number(min)
   const isQuoteFailed = Remote.Failure.is(props.quoteR)
   // if user is attempting to send NC ERC20, ensure they have sufficient
   // ETH balance else warn user and disable trade


### PR DESCRIPTION
## Description (optional)
Disable swap if user's wallet balance < swap minimum. Was originally comparing wallet balance in minor units to minimum swap (major units), so the check was always returning false. This change fixes the check to use the correctly converted wallet balance. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

