### PR TITLE
Fix/2fa close

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Settings/ConfirmDisable2FA/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Settings/ConfirmDisable2FA/template.js
@@ -41,7 +41,6 @@ const ConfirmDisable2FA = props => {
   const {
     position,
     total,
-    close,
     handleContinue,
     extraCopy,
     authName,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Settings/ConfirmDisable2FA/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Settings/ConfirmDisable2FA/template.js
@@ -51,7 +51,7 @@ const ConfirmDisable2FA = props => {
 
   return (
     <Modal size='large' position={position} total={total}>
-      <ModalHeader onClose={close}>
+      <ModalHeader onClose={closeAll}>
         <div style={flex('row align/center')}>
           <Icon name='lock' size='20px' style={spacing('pr-5')} />
           <FormattedMessage


### PR DESCRIPTION
## Description (optional)
Fixes FWLT-983. Disable 2FA modal 'x' icon wasn't using correct close function to dismiss the modal. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

