### PR TITLE
fix(settings): update card style to match designs

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -2254,6 +2254,7 @@ type MessagesType = {
   'scenes.settings.general.walletid.warning': 'Do not share your Wallet ID with others.'
   'scenes.settings.linked_banks': 'Linked Banks'
   'scenes.settings.linked_banks.daily_limit': '{amount} Daily Limit'
+  'scenes.settings.card_ending_in': 'Card Ending in {cardNumber}'
   'scenes.settings.no_linked_banks': 'No Linked Banks'
   'scenes.settings.no_credit_cards': 'No Credit Cards'
   'scenes.settings.no_linked_wire_banks': 'No Linked Wire Banks'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/template.success.tsx
@@ -10,8 +10,6 @@ import {
   CustomSettingHeader,
   RemoveButton
 } from '../styles'
-import { convertBaseToStandard } from 'data/components/exchange/services'
-import { fiatToString } from 'core/exchange/currency'
 import { FiatType } from 'core/types'
 import { FormattedMessage } from 'react-intl'
 import { InjectedFormProps, reduxForm } from 'redux-form'
@@ -96,27 +94,16 @@ const Success: React.FC<InjectedFormProps<
                   </Text>
                   {ccPaymentMethod && (
                     <Text size='14px' color='grey600' weight={500}>
-                      {fiatToString({
-                        value: convertBaseToStandard(
-                          'FIAT',
-                          ccPaymentMethod.limits.max
-                        ),
-                        unit: props.fiatCurrency || 'USD'
-                      })}{' '}
-                      {props.fiatCurrency} Limit
+                      <FormattedMessage
+                        id='scenes.settings.card_ending_in'
+                        defaultMessage='Card Ending in {cardNumber}'
+                        values={{ cardNumber: card.card.number }}
+                      />
                     </Text>
                   )}
                 </CardDetails>
               </Child>
               <Child>
-                <CardDetails right>
-                  <Text size='16px' color='grey800' weight={600}>
-                    ····{card.card.number}
-                  </Text>
-                  <Text size='14px' color='grey600' weight={500}>
-                    Exp: {card.card.expireMonth}/{card.card.expireYear}
-                  </Text>
-                </CardDetails>
                 <RemoveButton
                   data-e2e='removeCard'
                   nature='light-red'


### PR DESCRIPTION
## Description (optional)
Matches design for linked cards displayed in Settings. We originally had exp date and limits in the card, but I've removed to match design, which just has 'Card Ending in {cardNumber}' as the detail.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

