### PR TITLE
fix(tx-feed): use coinTicker instead of displayName for swaps in tx feed

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SwapOrderTx/model.tsx
@@ -11,10 +11,10 @@ import {
 import { Text } from 'blockchain-info-components'
 
 const getOutputCoinDisplayName = (props: Props) => {
-  return path([getOutput(props.order), 'displayName'], props.supportedCoins)
+  return path([getOutput(props.order), 'coinTicker'], props.supportedCoins)
 }
 const getInputCoinDisplayName = (props: Props) => {
-  return path([getInput(props.order), 'displayName'], props.supportedCoins)
+  return path([getInput(props.order), 'coinTicker'], props.supportedCoins)
 }
 export const IconTx = (props: Props) => {
   return <SharedIconTx type='SWAP' coin={props.coin} />


### PR DESCRIPTION
## Description (optional)
Fixes FWLT-1030, uses abbreviated wallet name in tx feed for swaps, to match what we display in wallet selection for swap.  

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

