### PR TITLE
fix(sdd): once when we know that user is verified we set this flag in state

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
@@ -418,7 +418,12 @@ export default ({ api, coreSagas, networks }) => {
             break
           }
           sddVerified = yield call(api.fetchSDDVerified)
-          if (sddVerified?.taskComplete) break
+          if (sddVerified?.taskComplete) {
+            yield put(
+              actions.components.simpleBuy.fetchSDDVerifiedSuccess(sddVerified)
+            )
+            break
+          }
           yield delay(POLL_SDD_DELAY)
         }
 

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
@@ -752,9 +752,15 @@ export default ({
   }
   const fetchSDDVerified = function * () {
     try {
-      yield put(A.fetchSDDVerifiedLoading())
-      const sddEligible = yield call(api.fetchSDDVerified)
-      yield put(A.fetchSDDVerifiedSuccess(sddEligible))
+      const isSddVerified = S.getSddVerified(yield select()).getOrElse({
+        verified: false
+      })
+
+      if (!isSddVerified.verified) {
+        yield put(A.fetchSDDVerifiedLoading())
+        const sddEligible = yield call(api.fetchSDDVerified)
+        yield put(A.fetchSDDVerifiedSuccess(sddEligible))
+      }
     } catch (e) {
       const error = errorHandler(e)
       yield put(A.fetchSDDVerifiedFailure(error))


### PR DESCRIPTION
## Description (optional)
This PR fix a multiple calls to /nabu-gateway/sdd/verified in case that user is already verified we do not need to again call BE anymore since user can't lost verification

## Testing Steps (optional)
- create a fresh wallet
- go over SDD
- after you enter dob/address make sure that in network tab we do not call more calls to /nabu-gateway/sdd/verified after BE return that user is verified

