### PR TITLE
fix(bank accounts): check for bank_transfer payment method before displaying add bank button on settings page

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/template.success.tsx
@@ -1,3 +1,4 @@
+import { any } from 'ramda'
 import { Button, Image, Text } from 'blockchain-info-components'
 import {
   CardDetails,
@@ -10,12 +11,12 @@ import { FormattedMessage } from 'react-intl'
 import { getBankLogoImageName } from 'services/ImagesService'
 import { InjectedFormProps, reduxForm } from 'redux-form'
 import { Props as OwnProps, SuccessStateType } from '.'
+import { SBPaymentMethodType, WalletFiatEnum } from 'core/types'
 import {
   SettingComponent,
   SettingContainer,
   SettingSummary
 } from 'components/Setting'
-import { WalletFiatEnum } from 'core/types'
 import media from 'services/ResponsiveService'
 import React from 'react'
 import styled from 'styled-components'
@@ -42,6 +43,10 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   const walletBeneficiaries = props.bankAccounts.filter(
     account => account.currency in WalletFiatEnum
   )
+
+  const isEligible = any(
+    (method: SBPaymentMethodType) => method.type === 'BANK_TRANSFER'
+  )(props.paymentMethods.methods)
 
   return (
     <StyledSettingsContainer>
@@ -107,15 +112,20 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           })}
         </div>
       </SettingSummary>
-      <CustomSettingComponent>
-        <Button
-          nature='primary'
-          data-e2e='addCardFromSettings'
-          onClick={() => props.handleBankClick()}
-        >
-          <FormattedMessage id='buttons.add_bank' defaultMessage='Add a Bank' />
-        </Button>
-      </CustomSettingComponent>
+      {isEligible && (
+        <CustomSettingComponent>
+          <Button
+            nature='primary'
+            data-e2e='addCardFromSettings'
+            onClick={() => props.handleBankClick()}
+          >
+            <FormattedMessage
+              id='buttons.add_bank'
+              defaultMessage='Add a Bank'
+            />
+          </Button>
+        </CustomSettingComponent>
+      )}
     </StyledSettingsContainer>
   )
 }


### PR DESCRIPTION
## Description (optional)
Currently users that are not eligible for ACH can still see the "add a bank" button in general settings. They should not be able to.

## Testing Steps (optional)
Create a new user with a NYC address so that they're not eligible, and go to `/settings/general` you should not see an "add a bank" button anymore.

