### PR TITLE
fix(sell): sell for should also stop submit

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
@@ -394,9 +394,7 @@ export default ({
 
       const error = errorHandler(e)
       if (values?.orderType === 'SELL') {
-        return yield put(
-          actions.form.stopSubmit('previewSell', { _error: error })
-        )
+        yield put(actions.form.stopSubmit('previewSell', { _error: error }))
       }
       yield put(actions.form.stopSubmit('simpleBuyCheckout', { _error: error }))
     }


### PR DESCRIPTION
## Description (optional)
Original Issue: If /trades returned an error for sell, the flow would return to Checkout Screen but form would stay in loading state and error message would never show.

Caused by a start submit for the simpleBuyCheckout form on line 391 that was never stopped. Removed the 'return' from line 397 so that saga would go onto 401 and stop the submit.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

