### PR TITLE
feat(sdd): show minimum buy when user type lower amount

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
@@ -76,6 +76,10 @@ const Amounts = styled.div`
   display: flex;
   justify-content: center;
 `
+
+const QuoteActionContainer = styled.div`
+  height: 32px;
+`
 const ErrorAmountContainer = styled.div`
   margin: 0;
   display: flex;
@@ -390,9 +394,10 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           )}
         </AmountRow>
 
-        {props.isSddFlow &&
+        <QuoteActionContainer>
+          {props.isSddFlow &&
           props.orderType === 'BUY' &&
-          amtError === 'BELOW_MIN' && (
+          amtError === 'BELOW_MIN' ? (
             <ErrorAmountContainer onClick={handleMinMaxClick}>
               <CustomErrorCartridge role='button' data-e2e='sbEnterAmountMin'>
                 <FormattedMessage
@@ -405,37 +410,42 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
                 />
               </CustomErrorCartridge>
             </ErrorAmountContainer>
+          ) : (
+            <QuoteRow>
+              <div />
+              <Text
+                color='grey600'
+                size='14px'
+                weight={500}
+                data-e2e='sbQuoteAmount'
+              >
+                {formatQuote(
+                  quoteAmt,
+                  props.pair.pair,
+                  fix,
+                  props.supportedCoins
+                )}
+              </Text>
+              <Icon
+                color='blue600'
+                cursor
+                name='up-down-chevron'
+                onClick={() =>
+                  props.simpleBuyActions.switchFix(
+                    quoteAmt,
+                    props.orderType,
+                    props.preferences[props.orderType].fix === 'CRYPTO'
+                      ? 'FIAT'
+                      : 'CRYPTO'
+                  )
+                }
+                role='button'
+                size='24px'
+                data-e2e='sbSwitchIcon'
+              />
+            </QuoteRow>
           )}
-
-        <QuoteRow>
-          <div />
-          <Text
-            color='grey600'
-            size='14px'
-            weight={500}
-            data-e2e='sbQuoteAmount'
-          >
-            {formatQuote(quoteAmt, props.pair.pair, fix, props.supportedCoins)}
-          </Text>
-          <Icon
-            color='blue600'
-            cursor
-            name='up-down-chevron'
-            onClick={() =>
-              props.simpleBuyActions.switchFix(
-                quoteAmt,
-                props.orderType,
-                props.preferences[props.orderType].fix === 'CRYPTO'
-                  ? 'FIAT'
-                  : 'CRYPTO'
-              )
-            }
-            role='button'
-            size='24px'
-            data-e2e='sbSwitchIcon'
-          />
-        </QuoteRow>
-
+        </QuoteActionContainer>
         {(!props.isSddFlow || props.orderType === 'SELL') &&
           props.pair &&
           Number(min) <= Number(max) && (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
@@ -76,6 +76,11 @@ const Amounts = styled.div`
   display: flex;
   justify-content: center;
 `
+const ErrorAmountContainer = styled.div`
+  margin: 0;
+  display: flex;
+  justify-content: center;
+`
 const QuoteRow = styled.div`
   display: flex;
   align-items: center;
@@ -384,6 +389,23 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
             </Text>
           )}
         </AmountRow>
+
+        {props.isSddFlow &&
+          props.orderType === 'BUY' &&
+          amtError === 'BELOW_MIN' && (
+            <ErrorAmountContainer onClick={handleMinMaxClick}>
+              <CustomErrorCartridge role='button' data-e2e='sbEnterAmountMin'>
+                <FormattedMessage
+                  id='modals.simplebuy.checkout.belowmin'
+                  defaultMessage='{value} Minimum {orderType}'
+                  values={{
+                    value: getValue(min),
+                    orderType: 'Buy'
+                  }}
+                />
+              </CustomErrorCartridge>
+            </ErrorAmountContainer>
+          )}
 
         <QuoteRow>
           <div />


### PR DESCRIPTION
## Description (optional)
with this PR we show min buy for SDD users once when user start entering smaller amount than it's limited.

## Testing Steps (optional)
Login to wallet with SDD wallet, tier3 go to simple buy flow chose BTC and enter small amount like $1 button with min should be visible 
![image](https://user-images.githubusercontent.com/67264242/107497457-e6697400-6b92-11eb-8ae1-39faa45e20b1.png)


