### PR TITLE
feat(sdd): prevent verif call if user is not yet created

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
@@ -653,7 +653,11 @@ export default ({
         verified: false
       })
 
-      if (!isSddVerified.verified) {
+      const userIdR = yield select(
+        selectors.core.kvStore.userCredentials.getUserId
+      )
+      const userId = userIdR.getOrElse(null)
+      if (!isSddVerified.verified && userId) {
         yield put(A.fetchSDDVerifiedLoading())
         const sddEligible = yield call(api.fetchSDDVerified)
         yield put(A.fetchSDDVerifiedSuccess(sddEligible))


### PR DESCRIPTION
## Description (optional)
We do prevent calling BE endpoint if user is not ye created

## Testing Steps (optional)
Create a new wallet and then validate email and click on crypto and once when enter amount page is rendered we do call API endpoint /sdd/verified

