### PR TITLE
Feat/segwit fixes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Security issues can be reported to us in the following ways:
+
+Email: security@blockchain.com
+Bug Bounty: https://hackerone.com/blockchain

--- a/packages/blockchain-wallet-v4-frontend/src/components/Balances/wallet/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Balances/wallet/selectors.ts
@@ -1,4 +1,4 @@
-import { add, curry, lift, pathOr, reduce } from 'ramda'
+import { add, curry, flatten, lift, pathOr, reduce } from 'ramda'
 import {
   ExtractSuccess,
   InterestAccountBalanceType,
@@ -40,7 +40,7 @@ export const getBtcBalance = createDeepEqualSelector(
       interestAccountBalance: InterestAccountBalanceType,
       sbBalances: SBBalancesType
     ): Array<number> => {
-      const walletBalances: Array<number> = context.map(a =>
+      const walletBalances: Array<number> = flatten(context).map(a =>
         pathOr(0, [a, 'final_balance'], balances)
       )
       const interestBalance = interestAccountBalance.BTC

--- a/packages/blockchain-wallet-v4-frontend/src/components/Send/ExchangePromo/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Send/ExchangePromo/index.tsx
@@ -2,7 +2,6 @@ import { bindActionCreators, Dispatch } from 'redux'
 import { concat, equals, prop } from 'ramda'
 import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
-import { LinkContainer } from 'react-router-bootstrap'
 import React, { PureComponent } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -138,7 +137,7 @@ class ExchangePromo extends PureComponent<Props> {
             </ConnectContainer>
           )
         ) : (
-          <LinkContainer
+          <ConnectContainer
             data-e2e='goSettingsProfile'
             onClick={() => {
               this.props.analyticsActions.logEvent([
@@ -164,7 +163,7 @@ class ExchangePromo extends PureComponent<Props> {
                 weight={500}
               />
             </GetStartedContainer>
-          </LinkContainer>
+          </ConnectContainer>
         )}
       </Wrapper>
     )

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
@@ -76,6 +76,15 @@ const Amounts = styled.div`
   display: flex;
   justify-content: center;
 `
+
+const QuoteActionContainer = styled.div`
+  height: 32px;
+`
+const ErrorAmountContainer = styled.div`
+  margin: 0;
+  display: flex;
+  justify-content: center;
+`
 const QuoteRow = styled.div`
   display: flex;
   align-items: center;
@@ -385,35 +394,58 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           )}
         </AmountRow>
 
-        <QuoteRow>
-          <div />
-          <Text
-            color='grey600'
-            size='14px'
-            weight={500}
-            data-e2e='sbQuoteAmount'
-          >
-            {formatQuote(quoteAmt, props.pair.pair, fix, props.supportedCoins)}
-          </Text>
-          <Icon
-            color='blue600'
-            cursor
-            name='up-down-chevron'
-            onClick={() =>
-              props.simpleBuyActions.switchFix(
-                quoteAmt,
-                props.orderType,
-                props.preferences[props.orderType].fix === 'CRYPTO'
-                  ? 'FIAT'
-                  : 'CRYPTO'
-              )
-            }
-            role='button'
-            size='24px'
-            data-e2e='sbSwitchIcon'
-          />
-        </QuoteRow>
-
+        <QuoteActionContainer>
+          {props.isSddFlow &&
+          props.orderType === 'BUY' &&
+          amtError === 'BELOW_MIN' ? (
+            <ErrorAmountContainer onClick={handleMinMaxClick}>
+              <CustomErrorCartridge role='button' data-e2e='sbEnterAmountMin'>
+                <FormattedMessage
+                  id='modals.simplebuy.checkout.belowmin'
+                  defaultMessage='{value} Minimum {orderType}'
+                  values={{
+                    value: getValue(min),
+                    orderType: 'Buy'
+                  }}
+                />
+              </CustomErrorCartridge>
+            </ErrorAmountContainer>
+          ) : (
+            <QuoteRow>
+              <div />
+              <Text
+                color='grey600'
+                size='14px'
+                weight={500}
+                data-e2e='sbQuoteAmount'
+              >
+                {formatQuote(
+                  quoteAmt,
+                  props.pair.pair,
+                  fix,
+                  props.supportedCoins
+                )}
+              </Text>
+              <Icon
+                color='blue600'
+                cursor
+                name='up-down-chevron'
+                onClick={() =>
+                  props.simpleBuyActions.switchFix(
+                    quoteAmt,
+                    props.orderType,
+                    props.preferences[props.orderType].fix === 'CRYPTO'
+                      ? 'FIAT'
+                      : 'CRYPTO'
+                  )
+                }
+                role='button'
+                size='24px'
+                data-e2e='sbSwitchIcon'
+              />
+            </QuoteRow>
+          )}
+        </QuoteActionContainer>
         {(!props.isSddFlow || props.orderType === 'SELL') &&
           props.pair &&
           Number(min) <= Number(max) && (


### PR DESCRIPTION
## Description (optional)
1. merged latest dev into branch to make sure bugs weren't related to not being up to date

2. `LinkContainer` in ExchangePromo was causing send to blow up when opening the modal. It's the upgrade to gold promo we put on the send modal:
<img width="453" alt="Screen Shot 2021-02-11 at 1 33 42 PM" src="https://user-images.githubusercontent.com/14954836/107695517-f1450700-6c6d-11eb-8c95-dc13da644bdb.png">
Changing it to just `ConnectContainer` vs. `LinkContainer` worked and visually looks the same, though I couldn't figure out why pathname was undefined. 
<img width="686" alt="Screen Shot 2021-02-11 at 10 04 33 AM" src="https://user-images.githubusercontent.com/14954836/107695311-a6c38a80-6c6d-11eb-931f-1bf2c50976d9.png">

3. The `getSpendableContext` selector now returns nested arrays (2 xpubs for each HD account), so needed to flatten the array to properly map over balances. Now the BTC balance shows correctly in the Dashboard, top left menu, and tx feed. 
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

