### PR TITLE
fix(send): :switch linkcontiner to connect container in exchange promo

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Send/ExchangePromo/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Send/ExchangePromo/index.tsx
@@ -2,7 +2,6 @@ import { bindActionCreators, Dispatch } from 'redux'
 import { concat, equals, prop } from 'ramda'
 import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
-import { LinkContainer } from 'react-router-bootstrap'
 import React, { PureComponent } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -138,7 +137,7 @@ class ExchangePromo extends PureComponent<Props> {
             </ConnectContainer>
           )
         ) : (
-          <LinkContainer
+          <ConnectContainer
             data-e2e='goSettingsProfile'
             onClick={() => {
               this.props.analyticsActions.logEvent([
@@ -164,7 +163,7 @@ class ExchangePromo extends PureComponent<Props> {
                 weight={500}
               />
             </GetStartedContainer>
-          </LinkContainer>
+          </ConnectContainer>
         )}
       </Wrapper>
     )


### PR DESCRIPTION
## Description (optional)
Fixes issue with send blowing up when first opening the modal, similar to the fix in segwit branch.

I'm not sure why LinkContainer was causing the issue, but it seems like using a different component visually looks the same and as far as I can tell, functions the same as well.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

