### PR TITLE
Fixing `.prettierrc` config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "semi": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "jsxSingleQuote": true
 }


### PR DESCRIPTION
This is just a rule to make `vscode` and other text editors to comply with `prettier`. It seems that they've created a new rule for `jsx`, and now you have to explicitly add `jsxSingleQuote` as `true`, in order to get single quotes on `tsx` or `jsx`.
