### PR TITLE
fix(v1-login): properly catch v1 payload password error

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/template.tsx
@@ -172,7 +172,9 @@ const Login = (props: InjectedFormProps<{}, Props> & Props) => {
   const guidError =
     loginError && loginError.toLowerCase().includes('unknown wallet id')
   const passwordError =
-    loginError && loginError.toLowerCase().includes('wrong_wallet_password')
+    loginError &&
+    (loginError.toLowerCase().includes('wrong_wallet_password') ||
+      loginError.toLowerCase().includes('wrong_wrapper'))
   const twoFactorError =
     loginError && loginError.toLowerCase().includes('authentication code')
   const accountLocked =

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/template.tsx
@@ -172,9 +172,7 @@ const Login = (props: InjectedFormProps<{}, Props> & Props) => {
   const guidError =
     loginError && loginError.toLowerCase().includes('unknown wallet id')
   const passwordError =
-    loginError &&
-    (loginError.toLowerCase().includes('wrong_wallet_password') ||
-      loginError.toLowerCase().includes('wrong_wrapper'))
+    loginError && loginError.toLowerCase().includes('wrong_wallet_password')
   const twoFactorError =
     loginError && loginError.toLowerCase().includes('authentication code')
   const accountLocked =

--- a/packages/blockchain-wallet-v4/src/types/Wallet.js
+++ b/packages/blockchain-wallet-v4/src/types/Wallet.js
@@ -174,7 +174,9 @@ export const isValidSecondPwd = curry((password, wallet) => {
     if (!is(String, password)) {
       return false
     }
-    let iter = selectIterations(wallet)
+    // 5000 is fallback for v1 wallets that are missing
+    // Pbkdf2 Iterations in the inner wrapper of JSON
+    let iter = selectIterations(wallet) || 5000
     let sk = view(sharedKey, wallet)
     let storedHash = view(dpasswordhash, wallet)
     let computedHash = crypto

--- a/packages/blockchain-wallet-v4/src/walletCrypto/index.ts
+++ b/packages/blockchain-wallet-v4/src/walletCrypto/index.ts
@@ -214,9 +214,8 @@ export const encryptWallet = curry((data, password, iterations, version) =>
 // decryptWalletV1 :: String -> String -> Task Error Object
 export const decryptWalletV1 = (password, data) => {
   let decrypt = (i, o) =>
-    decryptDataWithPassword(data, password, i, o).chain(
-      safeParse,
-      'v1: wrong_wallet_password'
+    decryptDataWithPassword(data, password, i, o).chain(p =>
+      safeParse(p, 'v1: wrong_wallet_password')
     )
   // v1: CBC, ISO10126, 10 iterations
   return (
@@ -264,7 +263,9 @@ export const decryptWalletV2V3 = (password, data) => {
 }
 
 export const decryptWallet = curry((password, data) =>
-  decryptWalletV1(password, data).orElse(() =>
-    decryptWalletV2V3(password, data)
-  )
+  decryptWalletV1(password, data).orElse(result => {
+    return result === 'v1: wrong_wallet_password'
+      ? Task.rejected(result)
+      : decryptWalletV2V3(password, data)
+  })
 )


### PR DESCRIPTION
## Description (optional)
Add error message at login if user tries to log in with v1 wallet/wrong password. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

