### PR TITLE
Fix/segwit swap balance

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/coins/btc.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/coins/btc.ts
@@ -2,7 +2,7 @@ import { nth } from 'ramda'
 import { select } from 'redux-saga/effects'
 
 import { CoinType, CurrenciesType, RatesType } from 'core/types'
-import { Exchange } from 'core'
+import { Exchange } from 'blockchain-wallet-v4/src'
 import { PaymentValue } from 'core/redux/payment/types'
 import { selectors } from 'data'
 
@@ -20,8 +20,15 @@ export const getDefaultAccount = function * () {
 // retrieves the next receive address
 export const getNextReceiveAddress = function * (coin, networks) {
   const state = yield select()
-  const defaultAccountIndex = yield select(selectors.core.wallet.getDefaultAccountIndex)
-  const defaultDerivation = yield select(selectors.core.common.btc.getAccountDefaultDerivation(defaultAccountIndex, state))
+  const defaultAccountIndex = yield select(
+    selectors.core.wallet.getDefaultAccountIndex
+  )
+  const defaultDerivation = yield select(
+    selectors.core.common.btc.getAccountDefaultDerivation(
+      defaultAccountIndex,
+      state
+    )
+  )
 
   return selectors.core.common.btc
     .getNextAvailableReceiveAddress(
@@ -34,7 +41,11 @@ export const getNextReceiveAddress = function * (coin, networks) {
 }
 
 // gets or updates a provisional payment
-export const getOrUpdateProvisionalPayment = function * (coreSagas, networks, paymentR) {
+export const getOrUpdateProvisionalPayment = function * (
+  coreSagas,
+  networks,
+  paymentR
+) {
   return yield coreSagas.payment.btc.create({
     payment: paymentR.getOrElse(<PaymentValue>{}),
     network: networks.btc

--- a/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/coins/erc20.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/coins/erc20.ts
@@ -2,12 +2,15 @@ import { head } from 'ramda'
 import { select } from 'redux-saga/effects'
 
 import { CoinType, CurrenciesType, PaymentValue, RatesType } from 'core/types'
+import { Exchange } from 'blockchain-wallet-v4/src'
 import { selectors } from 'data'
-import { Exchange } from 'core'
 
 // retrieves default account/address
 export const getDefaultAccount = function * (coin: CoinType) {
-  const erc20AccountR = yield select(selectors.core.common.eth.getErc20AccountBalances, coin)
+  const erc20AccountR = yield select(
+    selectors.core.common.eth.getErc20AccountBalances,
+    coin
+  )
   return erc20AccountR.map(head)
 }
 
@@ -19,7 +22,11 @@ export const getNextReceiveAddress = function * (coin: CoinType) {
 }
 
 // gets or updates a provisional payment
-export const getOrUpdateProvisionalPayment = function * (coreSagas, networks, paymentR) {
+export const getOrUpdateProvisionalPayment = function * (
+  coreSagas,
+  networks,
+  paymentR
+) {
   return yield coreSagas.payment.eth.create({
     payment: paymentR.getOrElse(<PaymentValue>{}),
     network: networks.eth

--- a/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/coins/eth.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/coins/eth.ts
@@ -1,10 +1,10 @@
 import { head } from 'ramda'
 import { select } from 'redux-saga/effects'
 
-import { selectors } from 'data'
-import { PaymentValue } from 'core/redux/payment/types'
 import { CoinType, CurrenciesType, RatesType } from 'core/types'
-import { Exchange } from 'core'
+import { Exchange } from 'blockchain-wallet-v4/src'
+import { PaymentValue } from 'core/redux/payment/types'
+import { selectors } from 'data'
 
 // retrieves default account/address
 export const getDefaultAccount = function * () {
@@ -20,7 +20,11 @@ export const getNextReceiveAddress = function * () {
 }
 
 // gets or updates a provisional payment
-export const getOrUpdateProvisionalPayment = function * (coreSagas, networks, paymentR) {
+export const getOrUpdateProvisionalPayment = function * (
+  coreSagas,
+  networks,
+  paymentR
+) {
   return yield coreSagas.payment.eth.create({
     payment: paymentR.getOrElse(<PaymentValue>{}),
     network: networks.eth

--- a/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/coins/xlm.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/coins/xlm.ts
@@ -1,16 +1,14 @@
 import { head } from 'ramda'
 import { select } from 'redux-saga/effects'
 
-import { selectors } from 'data'
-import { PaymentValue } from 'core/redux/payment/types'
 import { CoinType, CurrenciesType, RatesType } from 'core/types'
-import { Exchange } from 'core'
+import { Exchange } from 'blockchain-wallet-v4/src'
+import { PaymentValue } from 'core/redux/payment/types'
+import { selectors } from 'data'
 
 // retrieves default account/address
 export const getDefaultAccount = function * () {
-  return (yield select(
-    selectors.core.common.xlm.getAccountBalances
-  )).map(head)
+  return (yield select(selectors.core.common.xlm.getAccountBalances)).map(head)
 }
 
 // retrieves the next receive address
@@ -21,7 +19,11 @@ export const getNextReceiveAddress = function * () {
 }
 
 // gets or updates a provisional payment
-export const getOrUpdateProvisionalPayment = function * (coreSagas, networks, paymentR) {
+export const getOrUpdateProvisionalPayment = function * (
+  coreSagas,
+  networks,
+  paymentR
+) {
   return yield coreSagas.payment.xlm.create({
     payment: paymentR.getOrElse(<PaymentValue>{})
   })
@@ -35,9 +37,9 @@ export const convertFromBaseUnitToFiat = function (
   rates: RatesType
 ): number {
   return Exchange.convertXlmToFiat({
-      value: baseUnitValue,
-      fromUnit: 'STROOP',
-      toCurrency: userCurrency,
-      rates
-    }).value
+    value: baseUnitValue,
+    fromUnit: 'STROOP',
+    toCurrency: userCurrency,
+    rates
+  }).value
 }

--- a/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/coins/sagas/index.ts
@@ -6,7 +6,7 @@ import {
   PaymentValue,
   RatesType,
   RemoteDataType
-} from 'core/types'
+} from 'blockchain-wallet-v4/src/types'
 
 // import * as ALGO from './coins/algo'
 import * as BCH from './coins/bch'
@@ -38,23 +38,36 @@ const coinSagas = {
 
 export default ({ coreSagas, networks }) => {
   // gets the default account/address for requested coin
-  const getDefaultAccountForCoin = function * (coin: CoinType): Generator<string> {
-    const defaultAccountR = yield coinSagas[coin in Erc20CoinsEnum ? 'ERC20' : coin]?.getDefaultAccount(coin)
+  const getDefaultAccountForCoin = function * (
+    coin: CoinType
+  ): Generator<string> {
+    const defaultAccountR = yield coinSagas[
+      coin in Erc20CoinsEnum ? 'ERC20' : coin
+    ]?.getDefaultAccount(coin)
     // @ts-ignore
     return defaultAccountR.getOrFail('Failed to find default account')
   }
 
   // gets the next receive address for requested coin
   // account based currencies will just return the account address
-  const getNextReceiveAddressForCoin = function * (coin: CoinType): Generator<string> {
-    return yield coinSagas[coin in Erc20CoinsEnum ? 'ERC20' : coin]?.getNextReceiveAddress(coin, networks)
+  const getNextReceiveAddressForCoin = function * (
+    coin: CoinType
+  ): Generator<string> {
+    return yield coinSagas[
+      coin in Erc20CoinsEnum ? 'ERC20' : coin
+    ]?.getNextReceiveAddress(coin, networks)
   }
 
   // gets or updates a provisional payment for a coin
   // provisional payments are mutable payment objects used to build a transaction
   // over an extended period of time (e.g. as user goes through interest/swap/sell flows)
-  const getOrUpdateProvisionalPaymentForCoin = function (coin: CoinType, paymentR: RemoteDataType<string | Error, PaymentValue | undefined>): PaymentType {
-    return coinSagas[coin in Erc20CoinsEnum ? 'ERC20' : coin]?.getOrUpdateProvisionalPayment(coreSagas, networks, paymentR)
+  const getOrUpdateProvisionalPaymentForCoin = function (
+    coin: CoinType,
+    paymentR: RemoteDataType<string | Error, PaymentValue | undefined>
+  ): PaymentType {
+    return coinSagas[
+      coin in Erc20CoinsEnum ? 'ERC20' : coin
+    ]?.getOrUpdateProvisionalPayment(coreSagas, networks, paymentR)
   }
 
   // convert from a coins base unit into fiat
@@ -64,12 +77,9 @@ export default ({ coreSagas, networks }) => {
     userCurrency: keyof CurrenciesType,
     rates: RatesType
   ): number => {
-    return coinSagas[coin in Erc20CoinsEnum ? 'ERC20' : coin]?.convertFromBaseUnitToFiat(
-      coin,
-      baseUnitValue,
-      userCurrency,
-      rates
-    )
+    return coinSagas[
+      coin in Erc20CoinsEnum ? 'ERC20' : coin
+    ]?.convertFromBaseUnitToFiat(coin, baseUnitValue, userCurrency, rates)
   }
 
   return {

--- a/packages/blockchain-wallet-v4-frontend/src/data/coins/selectors/coins/btc.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/data/coins/selectors/coins/btc.tsx
@@ -39,7 +39,7 @@ export const getAccounts = createDeepEqualSelector(
       let accounts = []
       // add non-custodial accounts if requested
       if (ownProps?.nonCustodialAccounts) {
-        // each account has a derivations object with legacy address and segwit address
+        // each account has a derivations object with legacy xpub and segwit xpub
         // need to extract each xpub for balance
         const xpubArray = acc =>
           prop('derivations', acc).map(derr => prop('xpub', derr))


### PR DESCRIPTION
## Description (optional)
1. Update imports on some files, I think were added as part of merge from refactors branch. Tests were failing because of this.
2. Some gnarly logic to change how we determine accounts balance for swap. Structure of accounts have changed to include `derivations` key, and we need to get both xPub for each account, and then add the two balances together for total. 
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

