### PR TITLE
fix(send): redeemScript to null on tx.sign for segwit send

### DIFF
--- a/packages/blockchain-wallet-v4/src/signer/btc.js
+++ b/packages/blockchain-wallet-v4/src/signer/btc.js
@@ -21,12 +21,6 @@ const getOutputScript = keyPair => {
   const payment = Bitcoin.payments.p2wpkh({ pubkey: pubKey })
   return payment.output
 }
-// TODO SEGWIT: Can likely remove?
-// const getRedeemScript = keyPair => {
-//   const pubKey = keyPair.publicKey
-//   const payment = Bitcoin.payments.p2wpkh({ pubkey: pubKey })
-//   return payment.redeem.output
-// }
 
 export const signSelection = curry((network, selection) => {
   const tx = new Bitcoin.TransactionBuilder(network)

--- a/packages/blockchain-wallet-v4/src/signer/btc.js
+++ b/packages/blockchain-wallet-v4/src/signer/btc.js
@@ -1,7 +1,4 @@
 import * as Bitcoin from 'bitcoinjs-lib'
-import * as Coin from '../coinSelection/coin.js'
-import * as crypto from '../walletCrypto'
-import { addHDWalletWIFS, addLegacyWIFS } from './wifs.js'
 import {
   addIndex,
   compose,
@@ -12,15 +9,26 @@ import {
   over
 } from 'ramda'
 import { mapped } from 'ramda-lens'
-import { privateKeyStringToKey } from '../utils/btc'
 import BitcoinMessage from 'bitcoinjs-message'
 import Btc from '@ledgerhq/hw-app-btc'
+
+import * as Coin from '../coinSelection/coin.js'
+import * as crypto from '../walletCrypto'
+import { addHDWalletWIFS, addLegacyWIFS } from './wifs.js'
+import { privateKeyStringToKey } from '../utils/btc'
 
 const getOutputScript = keyPair => {
   const pubKey = keyPair.publicKey
   const payment = Bitcoin.payments.p2wpkh({ pubkey: pubKey })
   return payment.output
 }
+
+// not currently needed since we only query legacy and bech32 UTXOs
+// const getRedeemScript = keyPair => {
+//   const pubKey = keyPair.publicKey
+//   const payment = Bitcoin.payments.p2wpkh({ pubkey: pubKey })
+//   return payment.redeem.output
+// }
 
 export const signSelection = curry((network, selection) => {
   const tx = new Bitcoin.TransactionBuilder(network)
@@ -29,7 +37,6 @@ export const signSelection = curry((network, selection) => {
     tx.addOutput(defaultTo(coin.address, coin.script), coin.value)
   const addInput = coin => {
     switch (coin.type()) {
-      // TODO: SEGWIT do we need more cases other than just bech32 and legacy?
       case 'P2WPKH':
         return tx.addInput(
           coin.txHash,
@@ -43,7 +50,6 @@ export const signSelection = curry((network, selection) => {
   }
   const sign = (coin, i) => {
     switch (coin.type()) {
-      // TODO: SEGWIT do we need more cases other than just bech32 and legacy?
       case 'P2WPKH':
         return tx.sign(i, coin.priv, null, null, coin.value)
       default:

--- a/packages/blockchain-wallet-v4/src/signer/btc.js
+++ b/packages/blockchain-wallet-v4/src/signer/btc.js
@@ -21,12 +21,12 @@ const getOutputScript = keyPair => {
   const payment = Bitcoin.payments.p2wpkh({ pubkey: pubKey })
   return payment.output
 }
-
-const getRedeemScript = keyPair => {
-  const pubKey = keyPair.publicKey
-  const payment = Bitcoin.payments.p2wpkh({ pubkey: pubKey })
-  return payment.redeem.output
-}
+// TODO SEGWIT: Can likely remove?
+// const getRedeemScript = keyPair => {
+//   const pubKey = keyPair.publicKey
+//   const payment = Bitcoin.payments.p2wpkh({ pubkey: pubKey })
+//   return payment.redeem.output
+// }
 
 export const signSelection = curry((network, selection) => {
   const tx = new Bitcoin.TransactionBuilder(network)
@@ -36,7 +36,7 @@ export const signSelection = curry((network, selection) => {
   const addInput = coin => {
     switch (coin.type()) {
       // TODO: SEGWIT do we need more cases other than just bech32 and legacy?
-      case 'P2SH-P2WPKH':
+      case 'P2WPKH':
         return tx.addInput(
           coin.txHash,
           coin.index,
@@ -50,14 +50,8 @@ export const signSelection = curry((network, selection) => {
   const sign = (coin, i) => {
     switch (coin.type()) {
       // TODO: SEGWIT do we need more cases other than just bech32 and legacy?
-      case 'P2SH-P2WPKH':
-        return tx.sign(
-          i,
-          coin.priv,
-          getRedeemScript(coin.priv),
-          null,
-          coin.value
-        )
+      case 'P2WPKH':
+        return tx.sign(i, coin.priv, null, null, coin.value)
       default:
         return tx.sign(i, coin.priv)
     }


### PR DESCRIPTION
## Description (optional)
Set redeemScript to null in tx.sign for native P2WPKH send. Fixes issue where pushtx wasn't being called for native segwit sends. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

