### PR TITLE
fix(recover): show email used in recovery for verify email page at re…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -397,6 +397,7 @@ export default ({ api, coreSagas }) => {
   const restore = function * (action) {
     try {
       yield put(actions.auth.restoreLoading())
+      yield put(actions.auth.setRegisterEmail(action.payload.email))
       yield put(actions.alerts.displayInfo(C.RESTORE_WALLET_INFO))
       yield call(coreSagas.wallet.restoreWalletSaga, action.payload)
       yield put(actions.alerts.displaySuccess(C.RESTORE_SUCCESS))


### PR DESCRIPTION
…covery

## Description (optional)
After wallet recovery, sets the registerEmail from the form so email field isn't empty.
![image-2021-03-03-11-02-25-830](https://user-images.githubusercontent.com/14954836/109829807-ded64180-7c0b-11eb-9ea1-8ddf20d8873e.png)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

