### PR TITLE
fix(swap): selectReceiveAddress function fix

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/utils/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/utils/sagas.ts
@@ -35,10 +35,22 @@ export const selectReceiveAddress = function * (source, networks) {
   if (equals('BTC', coin)) {
     let btcReceiveAddress
     if (type === ADDRESS_TYPES.LOCKBOX) {
-      btcReceiveAddress = yield select(selectors.core.common.btc.getNextAvailableReceiveAddressLockbox(networks.btc, address, appState))
+      btcReceiveAddress = selectors.core.common.btc.getNextAvailableReceiveAddressLockbox(
+        networks.btc,
+        address,
+        appState
+      )
     } else {
-      const defaultDerivation = yield select(selectors.core.common.btc.getAccountDefaultDerivation(address, appState))
-      btcReceiveAddress = yield select(selectors.core.common.btc.getNextAvailableReceiveAddress(networks.btc, address, defaultDerivation, appState))
+      const defaultDerivation = selectors.core.common.btc.getAccountDefaultDerivation(
+        address,
+        appState
+      )
+      btcReceiveAddress = selectors.core.common.btc.getNextAvailableReceiveAddress(
+        networks.btc,
+        address,
+        defaultDerivation,
+        appState
+      )
     }
     if (isEmpty(btcReceiveAddress.getOrElse(''))) {
       throw new Error('Could not generate return bitcoin receive address')


### PR DESCRIPTION
## Description (optional)
Fixes 1070, issue where creating a swap order wasn't working correctly.

Not sure why `const defaultDerivation = yield select(selectors.core.common.btc.getAccountDefaultDerivation(address, appState))` wasn't working, but that returned undefined. If I removed the `yield select`, the value was correctly resolved. 


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

