### PR TITLE
Fix/ach issues

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -601,7 +601,7 @@ type MessagesType = {
   'modals.brokerage.bank_deposit_description': 'Securely link a bank and send cash to your Blockchain.com Wallet at anytime.'
   'modals.brokerage.deposit_currency': 'Deposit {currency}'
   'modals.brokerage.deposit_success.title': '{amount} Deposited!'
-  'modals.brokerage.deposit_success.wait_description': 'While we wait for your bank to send the cash, here’s early access to {currencySymbol}{amount} in your {currency} Cash Account so you can buy crypto right away.'
+  'modals.brokerage.deposit_success.wait_description': 'While we wait for your bank to send the cash, here’s early access to {amount} in your {currency} Cash Account so you can buy crypto right away.'
   'modals.brokerage.deposit_success.funds_available': 'Your funds will be available to withdraw once the bank transfer is complete in 3-5 business days.'
   'modals.brokerage.funds_will_arrive': 'Funds Will Arrive'
   'modals.brokerage.my_currency_wallet': 'My {currency} Wallet'

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/sagas.ts
@@ -193,6 +193,7 @@ export default ({
           'BANK_DEPOSIT_MODAL'
         )
       )
+      yield put(actions.form.destroy('brokerageTx'))
       yield put(
         actions.components.brokerage.setDWStep({
           dwStep: BankDWStepType.ENTER_AMOUNT

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/sagas.ts
@@ -231,7 +231,13 @@ export default ({
         )
       }
     } catch (e) {
-      // TODO: implement error fallback
+      const error = errorHandler(e)
+      yield put(actions.form.stopSubmit('brokerageTx', { _error: error }))
+      yield put(
+        actions.components.brokerage.setDWStep({
+          dwStep: BankDWStepType.ENTER_AMOUNT
+        })
+      )
     }
   }
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/DepositStatus/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/DepositStatus/template.success.tsx
@@ -119,11 +119,14 @@ const Success = props => {
           <DescriptionText color='grey600' size='14px' weight={600}>
             <FormattedMessage
               id='modals.brokerage.deposit_success.wait_description'
-              defaultMessage='While we wait for your bank to send the cash, here’s early access to {currencySymbol}{amount} in your {currency} Cash Account so you can buy crypto right away.'
+              defaultMessage='While we wait for your bank to send the cash, here’s early access to {amount} in your {currency} Cash Account so you can buy crypto right away.'
               values={{
-                currencySymbol: props.supportedCoins[coin].symbol,
-                amount,
-                currency: props.supportedCoins[coin].currency
+                amount: fiatToString({
+                  value: amount,
+                  unit,
+                  digits: 0
+                }),
+                currency: props.supportedCoins[coin].coinCode
               }}
             />
           </DescriptionText>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/template.success.tsx
@@ -12,6 +12,7 @@ import { AmountTextBox } from 'components/Exchange'
 import { Button, HeartbeatLoader, Icon, Text } from 'blockchain-info-components'
 import { convertBaseToStandard } from 'data/components/exchange/services'
 import { DisplayPaymentIcon } from 'components/SimpleBuy'
+import { ErrorCartridge } from 'components/Cartridge'
 import { fiatToString } from 'core/exchange/currency'
 import { FiatType } from 'core/types'
 import { FlyoutWrapper } from 'components/Flyout'
@@ -267,8 +268,6 @@ const NextButton = ({ invalid, pristine, submitting }) => {
   )
 }
 
-const ErrorMessage = ({ error }) => <div>{error}</div>
-
 const Success = (props: OwnProps) => {
   const isUserEligible =
     props.paymentMethods.methods.length &&
@@ -284,7 +283,19 @@ const Success = (props: OwnProps) => {
             <Amount {...props} />
             <Account {...props} />
             <NextButton {...props} />
-            {props.error && <ErrorMessage {...props} />}
+            {props.error && (
+              <ErrorCartridge
+                style={{ marginTop: '16px' }}
+                data-e2e='checkoutError'
+              >
+                <Icon
+                  name='alert-filled'
+                  color='red600'
+                  style={{ marginRight: '4px' }}
+                />
+                Error: {props.error}
+              </ErrorCartridge>
+            )}
           </Wrapper>
         </CustomForm>
       )}


### PR DESCRIPTION
## Description (optional)
@blockdylanb 

1. Adds error fallback if deposit fails: sends user back to Enter Amount step with error message like this:
<img width="463" alt="Screen Shot 2021-03-04 at 9 20 25 PM" src="https://user-images.githubusercontent.com/14954836/110057941-7aac9e00-7d2f-11eb-8f3d-7455ecfe6125.png">

2. Destroys all values in the brokerageTx form when 'deposit' button is clicked from the transaction feed. This is the best way I found so far to clear form values/errors. If I did it on the `handleClose` or when canceling an order, there would be a brief moment where values would show as NaN while the flyout transitioned from open to close. Not sure if this is the best way, let me know.

3. Adds currency symbol and fiat cash wallet to order success.
<img width="436" alt="Screen Shot 2021-03-04 at 9 38 20 PM" src="https://user-images.githubusercontent.com/14954836/110059347-09bab580-7d32-11eb-963f-676046cdf7fc.png">


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

