### PR TITLE
fix(brokerage): adds a fiat eligibility check when opening up the dep…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -595,6 +595,7 @@ type MessagesType = {
   'modals.brokerage.daily_limit': 'Daily Limit'
   'modals.brokerage.deposit_methods': 'Select a Deposit Method'
   'modals.brokerage.deposit_fiat': 'Deposit {fiat}'
+  'modals.brokerage.ineligible_error': 'You are not eligible to make deposits and withdrawals with this currency.'
   'modals.brokerage.withdraw_fiat': 'Withdraw {fiat}'
   'modals.brokerage.confirm_deposit': 'Confirm Deposit'
   'modals.brokerage.bank_deposit': 'Bank Deposit'

--- a/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/index.tsx
@@ -13,14 +13,18 @@ const AddNewButton = styled(Button)`
   border-color: ${props => props.theme.grey100};
 `
 
+const StyledText = styled(Text)`
+  width: 300px;
+`
+
 const BROKERAGE_INELIGIBLE = 'BROKERAGE_INELIGIBLE'
 const IneligibleErrorMessage = () => (
-  <Text size='16px' weight={400}>
+  <StyledText size='16px' weight={400}>
     <FormattedMessage
       id='modals.brokerage.ineligible_error'
       defaultMessage='You are not eligible to make deposits and withdrawals with this currency.'
     />
-  </Text>
+  </StyledText>
 )
 
 export { AddNewButton, BROKERAGE_INELIGIBLE, IneligibleErrorMessage }

--- a/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/index.tsx
@@ -1,4 +1,6 @@
-import { Button } from 'blockchain-info-components'
+import { Button, Text } from 'blockchain-info-components'
+import { FormattedMessage } from 'react-intl'
+import React from 'react'
 import styled from 'styled-components'
 
 const AddNewButton = styled(Button)`
@@ -11,4 +13,14 @@ const AddNewButton = styled(Button)`
   border-color: ${props => props.theme.grey100};
 `
 
-export { AddNewButton }
+const BROKERAGE_INELIGIBLE = 'BROKERAGE_INELIGIBLE'
+const IneligibleErrorMessage = () => (
+  <Text size='16px' weight={400}>
+    <FormattedMessage
+      id='modals.brokerage.ineligible_error'
+      defaultMessage='You are not eligible to make deposits and withdrawals with this currency.'
+    />
+  </Text>
+)
+
+export { AddNewButton, BROKERAGE_INELIGIBLE, IneligibleErrorMessage }

--- a/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/index.tsx
@@ -1,30 +1,12 @@
-import { Button, Text } from 'blockchain-info-components'
-import { FormattedMessage } from 'react-intl'
-import React from 'react'
+import { Button } from 'blockchain-info-components'
 import styled from 'styled-components'
 
 const AddNewButton = styled(Button)`
   padding: 8px 16px;
-  margin: 0 auto;
-  margin-top: 40px;
-  margin-bottom: 40px;
+  margin: 40px auto;
   width: 83%;
   color: ${props => props.theme.blue600};
   border-color: ${props => props.theme.grey100};
 `
 
-const StyledText = styled(Text)`
-  width: 300px;
-`
-
-const BROKERAGE_INELIGIBLE = 'BROKERAGE_INELIGIBLE'
-const IneligibleErrorMessage = () => (
-  <StyledText size='16px' weight={400}>
-    <FormattedMessage
-      id='modals.brokerage.ineligible_error'
-      defaultMessage='You are not eligible to make deposits and withdrawals with this currency.'
-    />
-  </StyledText>
-)
-
-export { AddNewButton, BROKERAGE_INELIGIBLE, IneligibleErrorMessage }
+export { AddNewButton }

--- a/packages/blockchain-wallet-v4-frontend/src/components/DataError/ErrorHandler.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/DataError/ErrorHandler.js
@@ -1,3 +1,7 @@
+import {
+  BROKERAGE_INELIGIBLE,
+  IneligibleErrorMessage
+} from 'components/Brokerage'
 import { Button, Link, Text, TextGroup } from 'blockchain-info-components'
 import { checkForVulnerableAddressError } from 'services/ErrorCheckService'
 import { FETCH_FEES_FAILURE } from 'blockchain-wallet-v4/src/redux/payment/model'
@@ -33,6 +37,8 @@ const ErrorHandler = props => {
         </Button>
       </React.Fragment>
     )
+  } else if (errorMessage === BROKERAGE_INELIGIBLE) {
+    return <IneligibleErrorMessage />
   } else if (errorMessage === FETCH_FEES_FAILURE) {
     return (
       <Text size='16px' weight={400}>

--- a/packages/blockchain-wallet-v4-frontend/src/components/DataError/ErrorHandler.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/DataError/ErrorHandler.js
@@ -1,7 +1,7 @@
 import {
   BROKERAGE_INELIGIBLE,
   IneligibleErrorMessage
-} from 'components/Brokerage'
+} from '../../modals/Brokerage/components'
 import { Button, Link, Text, TextGroup } from 'blockchain-info-components'
 import { checkForVulnerableAddressError } from 'services/ErrorCheckService'
 import { FETCH_FEES_FAILURE } from 'blockchain-wallet-v4/src/redux/payment/model'

--- a/packages/blockchain-wallet-v4-frontend/src/components/DataError/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/DataError/index.tsx
@@ -10,6 +10,7 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
+  height: 100%;
 `
 const Empty = styled.div`
   display: flex;

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/sagas.ts
@@ -177,7 +177,31 @@ export default ({
     }
   }
 
-  const handleDepositFiatClick = function * () {
+  const handleDepositFiatClick = function * ({
+    payload
+  }: ReturnType<typeof A.handleDepositFiatClick>) {
+    yield put(
+      actions.components.brokerage.showModal(
+        BrokerageModalOriginType.DEPOSIT_BUTTON,
+        'BANK_DEPOSIT_MODAL'
+      )
+    )
+    yield put(
+      actions.components.brokerage.setDWStep({
+        dwStep: BankDWStepType.LOADING
+      })
+    )
+    try {
+      // If user is not eligible for the requested fiat the route will 400
+      // and this code will throw so no need to check the response body
+      yield call(api.getSBPaymentAccount, payload.fiatCurrency)
+    } catch (e) {
+      return yield put(
+        actions.components.brokerage.setDWStep({
+          dwStep: BankDWStepType.INELIGIBLE
+        })
+      )
+    }
     const bankTransferAccounts = yield select(
       selectors.components.brokerage.getBankTransferAccounts
     )

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/types.ts
@@ -28,6 +28,8 @@ export enum BankDWStepType {
   DEPOSIT_METHODS = 'DEPOSIT_METHODS',
   DEPOSIT_STATUS = 'DEPOSIT_STATUS',
   ENTER_AMOUNT = 'ENTER_AMOUNT',
+  INELIGIBLE = 'INELIGIBLE',
+  LOADING = 'LOADING',
   WIRE_INSTRUCTIONS = 'WIRE_INSTRUCTIONS'
 }
 
@@ -38,6 +40,8 @@ export type BrokerageDWStepPayload =
         | BankDWStepType.WIRE_INSTRUCTIONS
         | BankDWStepType.DEPOSIT_STATUS
         | BankDWStepType.BANK_LIST
+        | BankDWStepType.INELIGIBLE
+        | BankDWStepType.LOADING
     }
   | {
       addNew?: boolean

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/withdraw/reducers.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/withdraw/reducers.ts
@@ -1,12 +1,12 @@
 import * as AT from './actionTypes'
-import { WithdrawActionTypes, WithdrawState } from './types'
+import { WithdrawActionTypes, WithdrawState, WithdrawStepEnum } from './types'
 import Remote from 'blockchain-wallet-v4/src/remote/remote'
 
 const INITIAL_STATE: WithdrawState = {
   amount: undefined,
   beneficiary: undefined,
   fiatCurrency: 'EUR',
-  step: 'ENTER_AMOUNT',
+  step: WithdrawStepEnum.ENTER_AMOUNT,
   withdrawal: undefined,
   feesAndMinAmount: Remote.NotAsked,
   withdrawLocks: Remote.NotAsked
@@ -19,21 +19,21 @@ export function withdrawReducer (
   switch (action.type) {
     case AT.SET_STEP:
       switch (action.payload.step) {
-        case 'ENTER_AMOUNT':
+        case WithdrawStepEnum.ENTER_AMOUNT:
           return {
             ...state,
             beneficiary: action.payload.beneficiary,
             fiatCurrency: action.payload.fiatCurrency,
             step: action.payload.step
           }
-        case 'WITHDRAWAL_METHODS':
-        case 'BANK_PICKER':
+        case WithdrawStepEnum.WITHDRAWAL_METHODS:
+        case WithdrawStepEnum.BANK_PICKER:
           return {
             ...state,
             fiatCurrency: action.payload.fiatCurrency,
             step: action.payload.step
           }
-        case 'CONFIRM_WITHDRAW': {
+        case WithdrawStepEnum.CONFIRM_WITHDRAW: {
           return {
             ...state,
             amount: action.payload.amount,
@@ -41,15 +41,19 @@ export function withdrawReducer (
             step: action.payload.step
           }
         }
-        case 'WITHDRAWAL_DETAILS': {
+        case WithdrawStepEnum.WITHDRAWAL_DETAILS: {
           return {
             ...state,
             step: action.payload.step,
             withdrawal: action.payload.withdrawal
           }
         }
+        default:
+          return {
+            ...state,
+            step: action.payload.step
+          }
       }
-      break
     case AT.FETCH_WITHDRAWAL_FEES_LOADING: {
       return {
         ...state,

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/withdraw/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/withdraw/types.ts
@@ -16,37 +16,40 @@ export type WithdrawCheckoutFormValuesType = {
 }
 
 export enum WithdrawStepEnum {
-  'ENTER_AMOUNT',
-  'BANK_PICKER',
-  'CONFIRM_WITHDRAW',
-  'WITHDRAWAL_DETAILS',
-  'WITHDRAWAL_METHODS'
+  BANK_PICKER = 'BANK_PICKER',
+  CONFIRM_WITHDRAW = 'CONFIRM_WITHDRAW',
+  ENTER_AMOUNT = 'ENTER_AMOUNT',
+  INELIGIBLE = 'INELIGIBLE',
+  LOADING = 'LOADING',
+  WITHDRAWAL_DETAILS = 'WITHDRAWAL_DETAILS',
+  WITHDRAWAL_METHODS = 'WITHDRAWAL_METHODS'
 }
 
 export type WithdrawStepActionsPayload =
+  | { step: WithdrawStepEnum.LOADING | WithdrawStepEnum.INELIGIBLE }
   | {
       beneficiary?: BeneficiaryType
       fiatCurrency: WalletFiatType
-      step: 'ENTER_AMOUNT'
+      step: WithdrawStepEnum.ENTER_AMOUNT
       transferAccount?: BankTransferAccountType
     }
   | {
       fiatCurrency: WalletFiatType
-      step: 'BANK_PICKER'
+      step: WithdrawStepEnum.BANK_PICKER
     }
   | {
       amount: string
       beneficiary?: BeneficiaryType
       defaultMethod?: BankTransferAccountType
-      step: 'CONFIRM_WITHDRAW'
+      step: WithdrawStepEnum.CONFIRM_WITHDRAW
     }
   | {
-      step: 'WITHDRAWAL_DETAILS'
+      step: WithdrawStepEnum.WITHDRAWAL_DETAILS
       withdrawal: WithdrawResponseType
     }
   | {
       fiatCurrency: WalletFiatType
-      step: 'WITHDRAWAL_METHODS'
+      step: WithdrawStepEnum.WITHDRAWAL_METHODS
     }
 
 // state
@@ -55,7 +58,7 @@ export type WithdrawState = {
   beneficiary?: BeneficiaryType
   feesAndMinAmount: RemoteDataType<string, WithdrawalMinsAndFeesResponse>
   fiatCurrency: WalletFiatType
-  step: keyof typeof WithdrawStepEnum
+  step: WithdrawStepEnum
   withdrawLocks: RemoteDataType<string, WithdrawalLockResponseType>
   withdrawal?: WithdrawResponseType
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/index.tsx
@@ -54,10 +54,6 @@ class Deposit extends PureComponent<Props> {
         data-e2e='bankDepositModal'
       >
         {this.props.step === BankDWStepType.LOADING && (
-          /*
-           * loads deposit payment methods ui
-           * bank_transfer or loads wire transfer screen
-           */
           <FlyoutChild>
             <Loading {...this.props} />
           </FlyoutChild>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/index.tsx
@@ -5,7 +5,9 @@ import React, { PureComponent } from 'react'
 
 import { actions, selectors } from 'data'
 import { BankDWStepType } from 'data/types'
+import { BROKERAGE_INELIGIBLE } from 'components/Brokerage'
 import { FiatType, WalletFiatType } from 'core/types'
+import DataError from 'components/DataError'
 import Flyout, { duration, FlyoutChild } from 'components/Flyout'
 import ModalEnhancer from 'providers/ModalEnhancer'
 
@@ -15,8 +17,8 @@ import Confirm from './Confirm'
 import DepositMethods from './DepositMethods'
 import DepositStatus from './DepositStatus'
 import EnterAmount from './EnterAmount'
+import Loading from './DepositMethods/template.loading'
 import WireInstructions from './WireInstructions'
-
 class Deposit extends PureComponent<Props> {
   state: State = { show: false, direction: 'left' }
 
@@ -51,6 +53,15 @@ class Deposit extends PureComponent<Props> {
         direction={this.state.direction}
         data-e2e='bankDepositModal'
       >
+        {this.props.step === BankDWStepType.LOADING && (
+          /*
+           * loads deposit payment methods ui
+           * bank_transfer or loads wire transfer screen
+           */
+          <FlyoutChild>
+            <Loading {...this.props} />
+          </FlyoutChild>
+        )}
         {this.props.step === BankDWStepType.DEPOSIT_METHODS && (
           /*
            * loads deposit payment methods ui
@@ -104,6 +115,11 @@ class Deposit extends PureComponent<Props> {
         {this.props.step === BankDWStepType.WIRE_INSTRUCTIONS && (
           <FlyoutChild>
             <WireInstructions {...this.props} handleClose={this.handleClose} />
+          </FlyoutChild>
+        )}
+        {this.props.step === BankDWStepType.INELIGIBLE && (
+          <FlyoutChild>
+            <DataError message={{ message: BROKERAGE_INELIGIBLE }} />
           </FlyoutChild>
         )}
       </Flyout>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/index.tsx
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react'
 
 import { actions, selectors } from 'data'
 import { BankDWStepType } from 'data/types'
-import { BROKERAGE_INELIGIBLE } from 'components/Brokerage'
+import { BROKERAGE_INELIGIBLE } from '../../components'
 import { FiatType, WalletFiatType } from 'core/types'
 import DataError from 'components/DataError'
 import Flyout, { duration, FlyoutChild } from 'components/Flyout'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/BankPicker/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/BankPicker/template.success.tsx
@@ -13,6 +13,7 @@ import {
 } from 'components/SimpleBuy'
 import { getBankLogoImageName } from 'services/ImagesService'
 import { Props as OwnProps, SuccessStateType } from '.'
+import { WithdrawStepEnum } from 'data/types'
 import Bank from '../../Deposit/BankList/Accounts/Bank'
 
 const Top = styled.div`
@@ -39,7 +40,7 @@ const Success: React.FC<Props> = props => {
             style={{ marginRight: '8px' }}
             onClick={() =>
               props.withdrawActions.setStep({
-                step: 'ENTER_AMOUNT',
+                step: WithdrawStepEnum.ENTER_AMOUNT,
                 fiatCurrency: props.fiatCurrency
               })
             }
@@ -65,7 +66,7 @@ const Success: React.FC<Props> = props => {
               props.withdrawActions.setStep({
                 beneficiary: undefined,
                 fiatCurrency: props.fiatCurrency,
-                step: 'ENTER_AMOUNT'
+                step: WithdrawStepEnum.ENTER_AMOUNT
               })
             }}
           />
@@ -79,7 +80,7 @@ const Success: React.FC<Props> = props => {
               props.withdrawActions.setStep({
                 beneficiary,
                 fiatCurrency: props.fiatCurrency,
-                step: 'ENTER_AMOUNT'
+                step: WithdrawStepEnum.ENTER_AMOUNT
               })
             }}
           >
@@ -104,7 +105,7 @@ const Success: React.FC<Props> = props => {
         onClick={() => {
           props.withdrawActions.setStep({
             fiatCurrency: props.fiatCurrency,
-            step: 'WITHDRAWAL_METHODS'
+            step: WithdrawStepEnum.WITHDRAWAL_METHODS
           })
         }}
       >

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/ConfirmWithdraw/template.failure.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/ConfirmWithdraw/template.failure.tsx
@@ -4,6 +4,8 @@ import { Props } from '.'
 import React from 'react'
 import styled from 'styled-components'
 
+import { WithdrawStepEnum } from 'data/types'
+
 const Wrapper = styled.div`
   height: 100%;
   width: 100%;
@@ -42,7 +44,7 @@ const Failure: React.FC<Props> = props => {
           size='16px'
           onClick={() =>
             props.withdrawActions.setStep({
-              step: 'ENTER_AMOUNT',
+              step: WithdrawStepEnum.ENTER_AMOUNT,
               fiatCurrency: props.fiatCurrency,
               beneficiary: props.beneficiary
             })

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/ConfirmWithdraw/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/ConfirmWithdraw/template.success.tsx
@@ -11,7 +11,7 @@ import { Form } from 'components/Form'
 import { FormattedMessage } from 'react-intl'
 import { InjectedFormProps, reduxForm } from 'redux-form'
 import { Props as OwnProps, SuccessStateType } from '.'
-import { WithdrawCheckoutFormValuesType } from 'data/types'
+import { WithdrawCheckoutFormValuesType, WithdrawStepEnum } from 'data/types'
 
 import CoinDisplay from 'components/Display/CoinDisplay'
 
@@ -61,7 +61,7 @@ const Success: React.FC<InjectedFormProps<
               props.withdrawActions.setStep({
                 beneficiary: props.beneficiary,
                 fiatCurrency: props.fiatCurrency,
-                step: 'ENTER_AMOUNT'
+                step: WithdrawStepEnum.ENTER_AMOUNT
               })
             }
           />
@@ -155,7 +155,7 @@ const Success: React.FC<InjectedFormProps<
             props.withdrawActions.setStep({
               beneficiary: props.beneficiary,
               fiatCurrency: props.fiatCurrency,
-              step: 'ENTER_AMOUNT'
+              step: WithdrawStepEnum.ENTER_AMOUNT
             })
           }
           data-e2e='cancelWithdrawCustody'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/EnterAmount/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/EnterAmount/index.tsx
@@ -12,7 +12,11 @@ import {
 } from 'core/types'
 import { Remote } from 'blockchain-wallet-v4/src'
 import { SBPaymentTypes } from 'core/network/api/settingsComponent/types'
-import { UserDataType, WithdrawCheckoutFormValuesType } from 'data/types'
+import {
+  UserDataType,
+  WithdrawCheckoutFormValuesType,
+  WithdrawStepEnum
+} from 'data/types'
 
 import { getData } from './selectors'
 import Failure from './template.failure'
@@ -51,13 +55,13 @@ class EnterAmount extends PureComponent<Props> {
 
     if (defaultMethod) {
       this.props.withdrawActions.setStep({
-        step: 'CONFIRM_WITHDRAW',
+        step: WithdrawStepEnum.CONFIRM_WITHDRAW,
         amount: this.props.formValues.amount,
         defaultMethod
       })
     } else if (defaultBeneficiary || this.props.beneficiary) {
       this.props.withdrawActions.setStep({
-        step: 'CONFIRM_WITHDRAW',
+        step: WithdrawStepEnum.CONFIRM_WITHDRAW,
         amount: this.props.formValues.amount,
         beneficiary
       })
@@ -85,7 +89,7 @@ class EnterAmount extends PureComponent<Props> {
     }
 
     this.props.withdrawActions.setStep({
-      step: 'BANK_PICKER',
+      step: WithdrawStepEnum.BANK_PICKER,
       fiatCurrency: this.props.fiatCurrency
     })
   }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/WithdrawalMethods/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/WithdrawalMethods/template.success.tsx
@@ -5,7 +5,8 @@ import styled from 'styled-components'
 import {
   AddBankStepType,
   BankDWStepType,
-  BrokerageModalOriginType
+  BrokerageModalOriginType,
+  WithdrawStepEnum
 } from 'data/types'
 import { FlyoutWrapper } from 'components/Flyout'
 import { Icon, Image, Text } from 'blockchain-info-components'
@@ -138,7 +139,7 @@ const Success = ({
               })
               withdrawActions.setStep({
                 fiatCurrency,
-                step: 'ENTER_AMOUNT'
+                step: WithdrawStepEnum.ENTER_AMOUNT
               })
             }}
             text={getType(bankTransfer)}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/index.tsx
@@ -7,7 +7,7 @@ import {
   WalletFiatType,
   WithdrawResponseType
 } from 'core/types'
-import { BROKERAGE_INELIGIBLE } from 'components/Brokerage'
+import { BROKERAGE_INELIGIBLE } from '../../components'
 import { RootState } from 'data/rootReducer'
 import { selectors } from 'data'
 import { WithdrawStepEnum } from 'data/types'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/index.tsx
@@ -7,9 +7,11 @@ import {
   WalletFiatType,
   WithdrawResponseType
 } from 'core/types'
+import { BROKERAGE_INELIGIBLE } from 'components/Brokerage'
 import { RootState } from 'data/rootReducer'
 import { selectors } from 'data'
 import { WithdrawStepEnum } from 'data/types'
+import DataError from 'components/DataError'
 import Flyout, { duration, FlyoutChild } from 'components/Flyout'
 import ModalEnhancer from 'providers/ModalEnhancer'
 
@@ -17,6 +19,7 @@ import { ModalPropsType } from '../../../types'
 import BankPicker from './BankPicker'
 import ConfirmWithdraw from './ConfirmWithdraw'
 import EnterAmount from './EnterAmount'
+import Loading from './ConfirmWithdraw/template.loading'
 import WithdrawalDetails from './WithdrawalDetails'
 import WithdrawalMethods from './WithdrawalMethods'
 
@@ -56,29 +59,39 @@ class Withdraw extends PureComponent<Props> {
         direction={this.state.direction}
         data-e2e='custodyWithdrawModal'
       >
-        {this.props.step === 'ENTER_AMOUNT' && (
+        {this.props.step === WithdrawStepEnum.LOADING && (
+          <FlyoutChild>
+            <Loading {...this.props} />
+          </FlyoutChild>
+        )}
+        {this.props.step === WithdrawStepEnum.ENTER_AMOUNT && (
           <FlyoutChild>
             <EnterAmount {...this.props} handleClose={this.handleClose} />
           </FlyoutChild>
         )}
-        {this.props.step === 'WITHDRAWAL_METHODS' && (
+        {this.props.step === WithdrawStepEnum.WITHDRAWAL_METHODS && (
           <FlyoutChild>
             <WithdrawalMethods {...this.props} handleClose={this.handleClose} />
           </FlyoutChild>
         )}
-        {this.props.step === 'BANK_PICKER' && (
+        {this.props.step === WithdrawStepEnum.BANK_PICKER && (
           <FlyoutChild>
             <BankPicker {...this.props} handleClose={this.handleClose} />
           </FlyoutChild>
         )}
-        {this.props.step === 'CONFIRM_WITHDRAW' && (
+        {this.props.step === WithdrawStepEnum.CONFIRM_WITHDRAW && (
           <FlyoutChild>
             <ConfirmWithdraw {...this.props} handleClose={this.handleClose} />
           </FlyoutChild>
         )}
-        {this.props.step === 'WITHDRAWAL_DETAILS' && (
+        {this.props.step === WithdrawStepEnum.WITHDRAWAL_DETAILS && (
           <FlyoutChild>
             <WithdrawalDetails {...this.props} handleClose={this.handleClose} />
+          </FlyoutChild>
+        )}
+        {this.props.step === WithdrawStepEnum.INELIGIBLE && (
+          <FlyoutChild>
+            <DataError message={{ message: BROKERAGE_INELIGIBLE }} />
           </FlyoutChild>
         )}
       </Flyout>
@@ -105,27 +118,30 @@ const enhance = compose(
 type OwnProps = ModalPropsType
 type LinkStatePropsType =
   | {
+      step: WithdrawStepEnum.LOADING | WithdrawStepEnum.INELIGIBLE
+    }
+  | {
       beneficiary?: BeneficiaryType
       fiatCurrency: WalletFiatType
-      step: 'ENTER_AMOUNT'
+      step: WithdrawStepEnum.ENTER_AMOUNT
     }
   | {
       fiatCurrency: WalletFiatType
-      step: 'BANK_PICKER'
+      step: WithdrawStepEnum.BANK_PICKER
     }
   | {
       amount: string
       beneficiary: BeneficiaryType
       fiatCurrency: WalletFiatType
-      step: 'CONFIRM_WITHDRAW'
+      step: WithdrawStepEnum.CONFIRM_WITHDRAW
     }
   | {
-      step: 'WITHDRAWAL_DETAILS'
+      step: WithdrawStepEnum.WITHDRAWAL_DETAILS
       withdrawal: WithdrawResponseType
     }
   | {
       fiatCurrency: WalletFiatType
-      step: 'WITHDRAWAL_METHODS'
+      step: WithdrawStepEnum.WITHDRAWAL_METHODS
     }
 // export type SuccessStateType = ExtractSuccess<ReturnType<typeof getData>>
 export type Props = OwnProps &

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/components/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/components/index.tsx
@@ -1,0 +1,21 @@
+import { FormattedMessage } from 'react-intl'
+import { Text } from 'blockchain-info-components'
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledText = styled(Text)`
+  width: 300px;
+`
+
+const BROKERAGE_INELIGIBLE = 'BROKERAGE_INELIGIBLE'
+
+const IneligibleErrorMessage = () => (
+  <StyledText size='16px' weight={400}>
+    <FormattedMessage
+      id='modals.brokerage.ineligible_error'
+      defaultMessage='You are not eligible to make deposits and withdrawals with this currency.'
+    />
+  </StyledText>
+)
+
+export { BROKERAGE_INELIGIBLE, IneligibleErrorMessage }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/index.tsx
@@ -190,10 +190,6 @@ class TransactionsContainer extends React.PureComponent<Props> {
                           this.props.brokerageActions.handleDepositFiatClick(
                             coin as WalletFiatType
                           )
-                          // this.props.simpleBuyActions.handleSBDepositFiatClick(
-                          //   coin as WalletFiatType,
-                          //   'TransactionList'
-                          // )
                         }}
                       >
                         <FormattedMessage


### PR DESCRIPTION
## Description (optional)
A user is eligible to make deposits and withdrawals for one fiat. We need to check their eligibility when they open up the deposit or withdrawal modal and give them an informative error screen if they're not eligible.

## Testing Steps (optional)
Open one of the fiat wallets your account is not eligible for, and click deposit or withdraw buttons in the upper right hand corner. You should seen and error screen.

