### PR TITLE
feat(interest): close previous modal, once when starting interest modal

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
@@ -339,6 +339,7 @@ export default ({
         }
         yield put(A.setPaymentSuccess(payment.value()))
       }
+      yield put(actions.modals.closeModal('SIMPLE_BUY_MODAL'))
     }
     yield put(
       initialize(DEPOSIT_FORM, {


### PR DESCRIPTION
## Description (optional)
This PR close simple buy modal once when user clicks on show interest.

## Testing Steps (optional)
Go ove tier 2 wallet, buy some crypto, on last page interest banner will be visible, click on earn now, close interest modal, make sure that Simple Buy modal is not visible anymore

