### PR TITLE
fix(withdraw): removing height so the link can be clickable

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/EnterAmount/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/EnterAmount/template.success.tsx
@@ -223,9 +223,9 @@ const Success: React.FC<InjectedFormProps<
       </Limits>
 
       <FlyoutWrapper>
-        <CoinContainer style={{ marginTop: '4px', height: '16px' }} />
+        <CoinContainer style={{ marginTop: '4px' }} />
         {showPendingTransactions && (
-          <CoinContainer style={{ marginTop: '4px', height: '16px' }}>
+          <CoinContainer style={{ marginTop: '4px' }}>
             <PendingText size='14px' color='grey900' weight={500}>
               <FormattedHTMLMessage
                 id='modals.withdraw.lock_description'


### PR DESCRIPTION
What was happening is that one div was overlapping the other, because of the defined height. As the background of the overlapping div was transparent, we were able to see through it, but not click on the link. I had the option to change the `z-index`, but I preferred to just remove the height (unnecessary and probably just copied and pasted), to make it work.