### PR TITLE
fix(bch-send): use legacy derivations for from and to bch send

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/payment/bch/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/payment/bch/sagas.js
@@ -3,7 +3,6 @@ import * as CoinSelection from '../../../coinSelection'
 import * as S from '../../selectors'
 import {
   ADDRESS_TYPES,
-  fromAccount,
   fromCustodial,
   fromLegacy,
   fromLegacyList,
@@ -19,6 +18,7 @@ import {
   detectPrivateKeyFormat,
   privateKeyStringToKey
 } from '../../../utils/btc'
+import { fromAccount } from './utils'
 import { fromCashAddr, isCashAddr } from '../../../utils/bch'
 import { futurizeP } from 'futurize'
 import { identity, isEmpty, isNil, map, merge, prop, zip } from 'ramda'
@@ -59,7 +59,6 @@ export default ({ api }) => {
   const calculateTo = function * (destinations, type, network) {
     const appState = yield select(identity)
     const wallet = S.wallet.getWallet(appState)
-
     // if address or account index
     if (isValidAddressOrIndex(destinations)) {
       return [toOutput('BCH', network, appState, destinations, type)]

--- a/packages/blockchain-wallet-v4/src/redux/payment/btc/utils.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/btc/utils.ts
@@ -81,10 +81,7 @@ export const fromAccount = (network, state, index) => {
   let defaultDerivationXpub = HDAccount.selectXpub(account)
   let allXpubsGrouped = HDAccount.selectAllXpubsGrouped(account).toJS()
   let legacy = prop('xpub', allXpubsGrouped.find(propEq('type', 'legacy')))
-  let bech32 = prop(
-    'xpub',
-    allXpubsGrouped.find(propEq('type', 'bech32'))
-  )
+  let bech32 = prop('xpub', allXpubsGrouped.find(propEq('type', 'bech32')))
 
   let changeIndex = S.data.btc.getChangeIndex(defaultDerivationXpub, state)
   let changeAddress = changeIndex
@@ -158,7 +155,10 @@ export const fromPrivateKey = (network, wallet, key) => {
 export const toOutputAccount = (coin, network, state, accountIndex) => {
   const wallet = S.wallet.getWallet(state)
   const account = Wallet.getAccount(accountIndex, wallet).get() // throw if nothing
-  let xpub = HDAccount.selectXpub(account)
+  let xpub =
+    coin === 'BTC'
+      ? HDAccount.selectXpub(account)
+      : HDAccount.selectXpub(account, 'legacy')
   const receiveIndexR =
     coin === 'BTC'
       ? S.data.btc.getReceiveIndex(xpub, state)
@@ -166,7 +166,10 @@ export const toOutputAccount = (coin, network, state, accountIndex) => {
   const receiveIndex = receiveIndexR.getOrFail(
     new Error('missing_receive_address')
   )
-  const address = HDAccount.getReceiveAddress(account, receiveIndex, network)
+  const address =
+    coin === 'BTC'
+      ? HDAccount.getReceiveAddress(account, receiveIndex, network)
+      : HDAccount.getReceiveAddress(account, receiveIndex, network, 'legacy')
   return {
     type: ADDRESS_TYPES.ACCOUNT,
     address,


### PR DESCRIPTION
## Description (optional)
1. BCH sends to external addresses were generating a bech32 change address. This was fixed by importing the `fromAccount` util function from bch/utils rather than btc/utils, which correctly assumes default derivation as legacy.
2. BCH transfers from wallet to wallet were assuming the 'to' wallet should use bech32 as derivation. Added checks to `toOutputAccount` function which passes 'legacy' argument if coin is bch. 
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

