### PR TITLE
fix(ach deposits): add form min/max/format validation

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -352,6 +352,8 @@ type MessagesType = {
   'copy.error.locked_withdraw_error': 'Your crypto will be available to be withdrawn within {days} days.'
   'copy.failed': 'Failed'
   'copy.fee': 'Fee'
+  'copy.forms.amount_max': 'The maximum amount is {amount}'
+  'copy.forms.amount_min': 'The minimum amount is {amount}'
   'copy.free': 'FREE'
   'copy.from': 'From'
   'copy.from:': 'From: '

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
@@ -273,12 +273,10 @@ export const getUserSddEligibleTier = (state: RootState) => {
   )(sddEligibleR)
 }
 
-export const getUserLimit = (state: RootState) => {
+export const getUserLimit = (state: RootState, type: SBPaymentTypes) => {
   const sbMethodsR = getSBPaymentMethods(state)
   return lift((sbMethods: ExtractSuccess<typeof sbMethodsR>) => {
-    const paymentMethod = sbMethods.methods.find(
-      method => method.type === 'PAYMENT_CARD'
-    )
+    const paymentMethod = sbMethods.methods.find(method => method.type === type)
     return paymentMethod?.limits || LIMIT
   })(sbMethodsR)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/index.tsx
@@ -62,7 +62,9 @@ export type OwnProps = {
   handleClose: () => void
   method: SBPaymentMethodType
 }
-export type SuccessStateType = ExtractSuccess<ReturnType<typeof getData>>
+export type SuccessStateType = ExtractSuccess<ReturnType<typeof getData>> & {
+  formErrors: { amount?: 'ABOVE_MAX' | 'BELOW_MIN' | false }
+}
 export type LinkStatePropsType = {
   data: RemoteDataType<string, SuccessStateType>
   fiatCurrency: FiatType

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/selectors.ts
@@ -16,24 +16,37 @@ export const getData = state => {
   const paymentMethodsR = selectors.components.simpleBuy.getSBPaymentMethods(
     state
   )
+  const depositLimitsR = selectors.components.simpleBuy.getUserLimit(
+    state,
+    'BANK_TRANSFER'
+  )
+  const formErrors = selectors.form.getFormSyncErrors('brokerageTx')(state)
   const supportedCoinsR = selectors.core.walletOptions.getSupportedCoins(state)
   const supportedCoins = supportedCoinsR.getOrElse(
     {} as SupportedWalletCurrenciesType
   )
-
   return lift(
     (
       bankTransferAccounts: ExtractSuccess<typeof bankTransferAccountsR>,
+      depositLimits: ExtractSuccess<typeof depositLimitsR>,
       eligibility: ExtractSuccess<typeof eligibilityR>,
       paymentMethods: ExtractSuccess<typeof paymentMethodsR>,
       walletCurrency: FiatType
     ) => ({
       bankTransferAccounts,
+      depositLimits,
       defaultMethod: defaultMethodR,
       eligibility,
       paymentMethods,
       walletCurrency,
-      supportedCoins
+      supportedCoins,
+      formErrors
     })
-  )(bankTransferAccountsR, eligibilityR, paymentMethodsR, walletCurrencyR)
+  )(
+    bankTransferAccountsR,
+    depositLimitsR,
+    eligibilityR,
+    paymentMethodsR,
+    walletCurrencyR
+  )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/template.success.tsx
@@ -20,8 +20,13 @@ import { Form } from 'components/Form'
 import Currencies from 'blockchain-wallet-v4/src/exchange/currencies'
 
 import { Props as _P, LinkStatePropsType, SuccessStateType } from '.'
-import { DepositOrWithdrawal, RightArrowIcon } from '../../model'
+import {
+  DepositOrWithdrawal,
+  normalizeAmount,
+  RightArrowIcon
+} from '../../model'
 import { getDefaultMethod, getText } from './model'
+import { maximumAmount, minimumAmount } from './validation'
 // TODO: move this to somewhere more generic
 import {
   getIcon,
@@ -176,9 +181,8 @@ const Amount = ({ fiatCurrency }) => {
           data-e2e='depositAmountInput'
           name='amount'
           component={AmountTextBox}
-          // validate={[maximumAmount, minimumAmount]}
-          // normalize={normalizeAmount}
-          // onUpdate={resizeSymbol.bind(null, fix === 'FIAT')}
+          validate={[maximumAmount, minimumAmount]}
+          normalize={normalizeAmount}
           maxFontSize='56px'
           placeholder='0'
           // leave fiatActive always to avoid 50% width in HOC?
@@ -263,6 +267,7 @@ const NextButton = ({ invalid, pristine, submitting, defaultMethod }) => {
 }
 
 const Success = (props: OwnProps) => {
+  const amtError = props.formErrors.amount
   const isUserEligible =
     props.paymentMethods.methods.length &&
     props.paymentMethods.methods.find(method => method.limits.max !== '0')
@@ -277,7 +282,7 @@ const Success = (props: OwnProps) => {
             <Amount {...props} />
             <Account {...props} />
             <NextButton {...props} />
-            {props.error && (
+            {amtError && (
               <ErrorCartridge
                 style={{ marginTop: '16px' }}
                 data-e2e='checkoutError'
@@ -287,7 +292,7 @@ const Success = (props: OwnProps) => {
                   color='red600'
                   style={{ marginRight: '4px' }}
                 />
-                Error: {props.error}
+                Error: {amtError}
               </ErrorCartridge>
             )}
           </Wrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/validation.tsx
@@ -1,0 +1,27 @@
+import { convertBaseToStandard } from 'data/components/exchange/services'
+import { fiatToString } from 'core/exchange/currency'
+import { FiatType } from 'core/types'
+
+import { Props } from './template.success'
+
+export const maximumAmount = (value: string, allValues, restProps: Props) => {
+  const max = convertBaseToStandard('FIAT', restProps.depositLimits.max)
+  const formattedMax = fiatToString({
+    value: max,
+    unit: allValues.currency || ('USD' as FiatType)
+  })
+  return Number(value) > Number(max)
+    ? `Your Maximum Amount is ${formattedMax}`
+    : undefined
+}
+
+export const minimumAmount = (value: string, allValues, restProps: Props) => {
+  const min = convertBaseToStandard('FIAT', restProps.depositLimits.min)
+  const formattedMin = fiatToString({
+    value: min,
+    unit: allValues.currency || ('USD' as FiatType)
+  })
+  return Number(value) < Number(min)
+    ? `Your Minimum Amount is ${formattedMin}`
+    : undefined
+}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/validation.tsx
@@ -1,3 +1,6 @@
+import { FormattedMessage } from 'react-intl'
+import React from 'react'
+
 import { convertBaseToStandard } from 'data/components/exchange/services'
 import { fiatToString } from 'core/exchange/currency'
 import { FiatType } from 'core/types'
@@ -10,9 +13,17 @@ export const maximumAmount = (value: string, allValues, restProps: Props) => {
     value: max,
     unit: allValues.currency || ('USD' as FiatType)
   })
-  return Number(value) > Number(max)
-    ? `Your Maximum Amount is ${formattedMax}`
-    : undefined
+  return Number(value) > Number(max) ? (
+    <FormattedMessage
+      id='copy.forms.amount_max'
+      defaultMessage='The maximum amount is {amount}'
+      values={{
+        amount: formattedMax
+      }}
+    />
+  ) : (
+    undefined
+  )
 }
 
 export const minimumAmount = (value: string, allValues, restProps: Props) => {
@@ -21,7 +32,15 @@ export const minimumAmount = (value: string, allValues, restProps: Props) => {
     value: min,
     unit: allValues.currency || ('USD' as FiatType)
   })
-  return Number(value) < Number(min)
-    ? `Your Minimum Amount is ${formattedMin}`
-    : undefined
+  return Number(value) < Number(min) ? (
+    <FormattedMessage
+      id='copy.forms.amount_min'
+      defaultMessage='The minimum amount is {amount}'
+      values={{
+        amount: formattedMin
+      }}
+    />
+  ) : (
+    undefined
+  )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/EnterAmount/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/EnterAmount/template.success.tsx
@@ -12,10 +12,9 @@ import {
 } from 'core/types'
 import { BlueCartridge, ErrorCartridge } from 'components/Cartridge'
 import { Button, Icon, Text } from 'blockchain-info-components'
-import { DepositOrWithdrawal } from '../../model'
+import { DepositOrWithdrawal, normalizeAmount } from '../../model'
 import { displayFiatToFiat } from 'blockchain-wallet-v4/src/exchange'
 import { FlyoutWrapper } from 'components/Flyout'
-import { formatTextAmount } from 'services/ValidationHelper'
 
 import { Form } from 'components/Form'
 
@@ -117,10 +116,6 @@ const BlueRedCartridge = ({
   return <CustomBlueCartridge role='button'>{children}</CustomBlueCartridge>
 }
 
-const normalizeAmount = (value, prevValue) => {
-  if (isNaN(Number(value)) && value !== '.' && value !== '') return prevValue
-  return formatTextAmount(value, true)
-}
 const Success: React.FC<InjectedFormProps<
   WithdrawCheckoutFormValuesType,
   Props

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/model.tsx
@@ -18,6 +18,7 @@ import {
   DisplayPaymentIcon,
   MultiRowContainer
 } from 'components/SimpleBuy'
+import { formatTextAmount } from 'services/ValidationHelper'
 import {
   GreyCartridge,
   OrangeCartridge,
@@ -184,4 +185,9 @@ const DepositOrWithdrawal = (props: {
   )
 }
 
-export { Bank, BankWire, DepositOrWithdrawal, RightArrowIcon }
+const normalizeAmount = (value, prevValue) => {
+  if (isNaN(Number(value)) && value !== '.' && value !== '') return prevValue
+  return formatTextAmount(value, true)
+}
+
+export { Bank, BankWire, DepositOrWithdrawal, normalizeAmount, RightArrowIcon }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/selectors.ts
@@ -26,7 +26,10 @@ export const getData = (state: RootState, ownProps: OwnProps) => {
   const userSDDTierR = selectors.components.simpleBuy.getUserSddEligibleTier(
     state
   )
-  const sddLimitR = selectors.components.simpleBuy.getUserLimit(state)
+  const sddLimitR = selectors.components.simpleBuy.getUserLimit(
+    state,
+    'PAYMENT_CARD'
+  )
   const cardsR = selectors.components.simpleBuy.getSBCards(state) || []
   const bankTransferAccounts = selectors.components.brokerage
     .getBankTransferAccounts(state)


### PR DESCRIPTION
## Description (optional)
Adds standard min/max validations to the amount input and disallows "non-amounty™️" kinds of input values. 
![image](https://user-images.githubusercontent.com/57680122/110392116-509ff800-801d-11eb-90d0-b2f5c1450994.png)
![image](https://user-images.githubusercontent.com/57680122/110392142-5a296000-801d-11eb-9155-ef9f15733be9.png)


## Testing Steps (optional)
Go to US dollars wallet, click deposit, try and enter sub $1 and more than $30,000 and also try entering letters and other non-numerical characters.

