### PR TITLE
feat(ach): load fiatCurrency based on page where user did clicked

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/reducers.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/reducers.ts
@@ -15,7 +15,8 @@ const INITIAL_STATE: BrokerageState = {
   account: undefined,
   redirectBackToStep: false,
   addNew: false, // TODO: Put this stuff in redux-form
-  bankStatus: Remote.NotAsked
+  bankStatus: Remote.NotAsked,
+  fiatCurrency: undefined
 }
 
 export function brokerageReducer (
@@ -57,6 +58,11 @@ export function brokerageReducer (
         ...state,
         account: action.payload.account,
         redirectBackToStep: action.payload.redirectBackToStep || false
+      }
+    case AT.HANDLE_DEPOSIT_FIAT_CLICK:
+      return {
+        ...state,
+        fiatCurrency: action.payload.fiatCurrency
       }
     case AT.SET_ADD_BANK_STEP:
       switch (action.payload.addBankStep) {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/selectors.ts
@@ -19,3 +19,6 @@ export const getRedirectBackToStep = (state: RootState) =>
 
 export const getAddBankStatus = (state: RootState) =>
   state.components.brokerage.bankStatus
+
+export const getFiatCurrency = (state: RootState) =>
+  state.components.brokerage.fiatCurrency

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/types.ts
@@ -1,4 +1,8 @@
-import { BankTransferAccountType, RemoteDataType } from 'core/types'
+import {
+  BankTransferAccountType,
+  RemoteDataType,
+  WalletFiatType
+} from 'core/types'
 
 import * as AT from './actionTypes'
 
@@ -85,6 +89,7 @@ export type BrokerageState = {
   bankTransferAccounts: RemoteDataType<string, Array<BankTransferAccountType>>
   dwStep: BankDWStepType
   fastLink: RemoteDataType<string, FastLinkType>
+  fiatCurrency: WalletFiatType | undefined
   redirectBackToStep: boolean
 }
 
@@ -131,6 +136,10 @@ interface SetBankAccountAction {
   payload: BankDetailsPayload
   type: typeof AT.SET_BANK_DETAILS
 }
+interface HandeDepositFiatClickAction {
+  payload: { fiatCurrency: WalletFiatType }
+  type: typeof AT.HANDLE_DEPOSIT_FIAT_CLICK
+}
 
 export type BrokerageActionTypes =
   | FetchBankTransferAccountsFailure
@@ -142,3 +151,4 @@ export type BrokerageActionTypes =
   | SetAddBankStepAction
   | SetBankAccountAction
   | SetDWStepAction
+  | HandeDepositFiatClickAction

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/index.tsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react'
 import { actions, selectors } from 'data'
 import { BankDWStepType } from 'data/types'
 import { BROKERAGE_INELIGIBLE } from '../../components'
-import { FiatType, WalletFiatType } from 'core/types'
+import { WalletFiatType } from 'core/types'
 import DataError from 'components/DataError'
 import Flyout, { duration, FlyoutChild } from 'components/Flyout'
 import ModalEnhancer from 'providers/ModalEnhancer'
@@ -125,7 +125,7 @@ class Deposit extends PureComponent<Props> {
 
 const mapStateToProps = (state: RootState) => ({
   step: selectors.components.brokerage.getDWStep(state),
-  fiatCurrency: 'USD' as FiatType // TODO: Unhardcode this
+  fiatCurrency: selectors.components.brokerage.getFiatCurrency(state)
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({


### PR DESCRIPTION
## Description (optional)
This PR load proper fiat currency for deposit/withdrawal click

## Testing Steps (optional)
- login with wallet which have USD account, try to use deposit/withdrawal they should work as before, the only difference is that we now load fiat currency it from store it's not hardcoded anymore

