### PR TITLE
Fix/bch transactions

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
@@ -49,6 +49,28 @@ export default () => {
             ? ''
             : payload.xpub || payload.address
           yield put(actions.core.data.bch.fetchTransactions(onlyShow, true))
+          break
+        case 'status':
+          const filter = payload => {
+            switch (payload) {
+              case 'sent':
+                return 1
+              case 'received':
+                return 2
+              case 'transferred':
+                return 3
+              default:
+                
+            }
+          }
+          yield put(
+            actions.core.data.bch.fetchTransactions(
+              onlyShow,
+              true,
+              filter(payload)
+            )
+          )
+          break
       }
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'formChanged', e))

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/bchTransactions/sagas.js
@@ -60,7 +60,7 @@ export default () => {
               case 'transferred':
                 return 3
               default:
-                
+                break
             }
           }
           yield put(

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.js
@@ -49,6 +49,28 @@ export default () => {
             ? ''
             : payload.xpub || payload.address
           yield put(actions.core.data.btc.fetchTransactions(onlyShow, true))
+          break
+        case 'status':
+          const filter = payload => {
+            switch (payload) {
+              case 'sent':
+                return 1
+              case 'received':
+                return 2
+              case 'transferred':
+                return 3
+              default:
+                
+            }
+          }
+          yield put(
+            actions.core.data.bch.fetchTransactions(
+              onlyShow,
+              true,
+              filter(payload)
+            )
+          )
+          break
       }
     } catch (e) {
       yield put(actions.logs.logErrorMessage(logLocation, 'formChanged', e))

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/btcTransactions/sagas.js
@@ -60,11 +60,11 @@ export default () => {
               case 'transferred':
                 return 3
               default:
-                
+                break
             }
           }
           yield put(
-            actions.core.data.bch.fetchTransactions(
+            actions.core.data.btc.fetchTransactions(
               onlyShow,
               true,
               filter(payload)

--- a/packages/blockchain-wallet-v4/src/network/api/bch/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/bch/index.ts
@@ -3,7 +3,8 @@ import { merge } from 'ramda'
 export default ({ apiUrl, get, post }) => {
   const fetchBchData = (
     context,
-    { n = 50, offset = 0, onlyShow = false } = {}
+    { n = 50, offset = 0, onlyShow = false } = {},
+    filter?: Number
   ) => {
     const data = {
       active: (Array.isArray(context) ? context : [context]).join('|'),
@@ -13,7 +14,8 @@ export default ({ apiUrl, get, post }) => {
       ct: new Date().getTime(),
       n: n,
       language: 'en',
-      no_buttons: true
+      no_buttons: true,
+      filter: filter
     }
     return post({
       url: apiUrl,

--- a/packages/blockchain-wallet-v4/src/network/api/wallet/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/wallet/index.ts
@@ -48,7 +48,8 @@ export default ({ rootUrl, get, post }) => {
   // onlyShow is xpub or address to filter data with
   const fetchBlockchainData = (
     context,
-    { n = 50, offset = 0, onlyShow = false } = {}
+    { n = 50, offset = 0, onlyShow = false } = {},
+    filter?: Number
   ) => {
     const data = {
       active: (Array.isArray(context) ? context : [context]).join('|'),
@@ -58,7 +59,8 @@ export default ({ rootUrl, get, post }) => {
       ct: new Date().getTime(),
       n: n,
       language: 'en',
-      no_buttons: true
+      no_buttons: true,
+      filter: filter
     }
     return post({
       url: rootUrl,

--- a/packages/blockchain-wallet-v4/src/redux/data/bch/actions.js
+++ b/packages/blockchain-wallet-v4/src/redux/data/bch/actions.js
@@ -30,9 +30,9 @@ export const fetchRatesFailure = error => ({
 })
 
 // FETCH_BCH_TRANSACTIONS
-export const fetchTransactions = (address, reset) => ({
+export const fetchTransactions = (address, reset, filter) => ({
   type: AT.FETCH_BCH_TRANSACTIONS,
-  payload: { address, reset }
+  payload: { address, reset, filter }
 })
 export const fetchTransactionsLoading = reset => ({
   type: AT.FETCH_BCH_TRANSACTIONS_LOADING,

--- a/packages/blockchain-wallet-v4/src/redux/data/bch/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/data/bch/sagas.ts
@@ -63,7 +63,7 @@ export default ({ api }: { api: APIType }) => {
   }
 
   const fetchTransactions = function * ({ payload }) {
-    const { address, reset } = payload
+    const { address, reset, filter } = payload
     try {
       const pages = yield select(S.getTransactions)
       const offset = reset ? 0 : length(pages) * TX_PER_PAGE
@@ -73,11 +73,16 @@ export default ({ api }: { api: APIType }) => {
       const walletContext = yield select(S.getWalletContext)
       const context = yield select(S.getContext)
       const convertedAddress = convertFromCashAddrIfCashAddr(address)
-      const data = yield call(api.fetchBchData, context, {
-        n: TX_PER_PAGE,
-        onlyShow: convertedAddress || walletContext.join('|'),
-        offset
-      })
+      const data = yield call(
+        api.fetchBchData,
+        context,
+        {
+          n: TX_PER_PAGE,
+          onlyShow: convertedAddress || walletContext.join('|'),
+          offset
+        },
+        filter
+      )
       const filteredTxs = data.txs.filter(tx => tx.time > BCH_FORK_TIME)
       const atBounds = length(filteredTxs) < TX_PER_PAGE
       yield put(A.transactionsAtBound(atBounds))

--- a/packages/blockchain-wallet-v4/src/redux/data/btc/actions.js
+++ b/packages/blockchain-wallet-v4/src/redux/data/btc/actions.js
@@ -50,9 +50,9 @@ export const fetchRatesFailure = error => ({
 })
 
 // FETCH_BTC_TRANSACTIONS
-export const fetchTransactions = (address, reset) => ({
+export const fetchTransactions = (address, reset, filter) => ({
   type: AT.FETCH_BTC_TRANSACTIONS,
-  payload: { address, reset }
+  payload: { address, reset, filter }
 })
 export const fetchTransactionsLoading = reset => ({
   type: AT.FETCH_BTC_TRANSACTIONS_LOADING,

--- a/packages/blockchain-wallet-v4/src/redux/data/btc/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/data/btc/sagas.ts
@@ -60,7 +60,7 @@ export default ({ api }: { api: APIType }) => {
   const fetchTransactions = function * (action) {
     try {
       const { payload } = action
-      const { address, reset } = payload
+      const { address, reset, filter } = payload
       const pages = yield select(S.getTransactions)
       const offset = reset ? 0 : length(pages) * TX_PER_PAGE
       const transactionsAtBound = yield select(S.getTransactionsAtBound)
@@ -68,11 +68,16 @@ export default ({ api }: { api: APIType }) => {
       yield put(A.fetchTransactionsLoading(reset))
       const walletContext = yield select(selectors.wallet.getWalletContext)
       const context = yield select(S.getContext)
-      const data = yield call(api.fetchBlockchainData, context, {
-        n: TX_PER_PAGE,
-        onlyShow: address || walletContext,
-        offset
-      })
+      const data = yield call(
+        api.fetchBlockchainData,
+        context,
+        {
+          n: TX_PER_PAGE,
+          onlyShow: address || walletContext,
+          offset
+        },
+        filter
+      )
       const atBounds = length(data.txs) < TX_PER_PAGE
       yield put(A.transactionsAtBound(atBounds))
       const txPage: Array<ProcessedTxType> = yield call(__processTxs, data.txs)


### PR DESCRIPTION
## Description (optional)

Fixes FWLT-1084.

In the tx feed, we first only fetch the first 10 transactions from multiaddr for btc/bch. If user then goes to filter by tx type (i.e. sent), if a sent transaction is in the first 10 transactions originally fetched, the feed is empty. A new param was added to the multiaddr call to get those type directly from the backend, rather than us doing some login on the frontend 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

