### PR TITLE
fix(balance-dropdown): increase height to show all coins

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuLeft/Balances/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/MenuLeft/Balances/model.tsx
@@ -48,7 +48,7 @@ export const BalancesWrapper = styled.div`
   overflow: hidden;
   transition: max-height 0.3s;
   &.active {
-    max-height: ${props => React.Children.count(props.children) * 20}px;
+    max-height: ${props => React.Children.count(props.children) * 30}px;
   }
 `
 


### PR DESCRIPTION
## Description (optional)
Increase height of wallet balance dropdown to accommodate all coins. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

