### PR TITLE
fix(register): dont show upgrade prompt at wallet creation

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -146,7 +146,7 @@ export default ({ api, coreSagas }) => {
         .getInvitations(yield select())
         .getOrElse(DEFAULT_INVITATIONS)
       const isSegwitEnabled = invitations.segwit
-      if (!isLatestVersion && !isRecovering && isSegwitEnabled) {
+      if (!isLatestVersion && !isRecovering && !firstLogin && isSegwitEnabled) {
         yield call(upgradeWalletSaga, isDoubleEncrypted, 4)
       }
       // Finish upgrades


### PR DESCRIPTION
## Description (optional)
This fixes the issue where wallet creating would hang after submitting the form. We were trying to show the upgrade modal, now it will only show if it's not the user's first login. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

