### PR TITLE
Fix/new coin fixes

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Balances/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Balances/selectors.ts
@@ -374,7 +374,7 @@ export const getPaxBalanceInfo = createDeepEqualSelector(
 
 export const getAaveBalanceInfo = createDeepEqualSelector(
   [
-    getPaxBalance,
+    getAaveBalance,
     state => selectors.core.data.eth.getErc20Rates(state, 'aave'),
     selectors.core.settings.getCurrency
   ],

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/send/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/send/sagas.ts
@@ -233,6 +233,8 @@ export default ({
       case 'PAX':
       case 'USDT':
       case 'WDGLD':
+      case 'AAVE':
+      case 'YFI':
         return coreSagas.payment.eth.create({
           payment: paymentR.getOrElse(<PaymentValue>{}),
           network: networks.eth
@@ -242,6 +244,7 @@ export default ({
           payment: paymentR.getOrElse(<PaymentValue>{})
         })
       case 'ALGO':
+      case 'DOT':
         // @ts-ignore
         return {}
       default:

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/WalletBalanceDropdown/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/WalletBalanceDropdown/selectors.ts
@@ -76,6 +76,14 @@ export const getData = (state, ownProps: OwnProps) => {
       })
       balanceDataR = balanceSelectors.getUsdtBalance(state)
       break
+    case 'AAVE':
+      addressDataR = getErc20AddressData(state, {
+        coin: 'AAVE',
+        includeCustodial: true,
+        includeInterest: true
+      })
+      balanceDataR = balanceSelectors.getAaveBalance(state)
+      break
     case 'WDGLD':
       addressDataR = getErc20AddressData(state, {
         coin: 'WDGLD',

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/WalletBalanceDropdown/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/WalletBalanceDropdown/selectors.ts
@@ -34,6 +34,14 @@ export const getData = (state, ownProps: OwnProps) => {
   // } as CoinAccountSelectorType)[coin as CoinType]
 
   switch (coin) {
+    case 'AAVE':
+      addressDataR = getErc20AddressData(state, {
+        coin: 'AAVE',
+        includeCustodial: true,
+        includeInterest: true
+      })
+      balanceDataR = balanceSelectors.getAaveBalance(state)
+      break
     case 'BTC':
       addressDataR = getBtcAddressData(state, {
         excludeLockbox: true,
@@ -76,14 +84,6 @@ export const getData = (state, ownProps: OwnProps) => {
       })
       balanceDataR = balanceSelectors.getUsdtBalance(state)
       break
-    case 'AAVE':
-      addressDataR = getErc20AddressData(state, {
-        coin: 'AAVE',
-        includeCustodial: true,
-        includeInterest: true
-      })
-      balanceDataR = balanceSelectors.getAaveBalance(state)
-      break
     case 'WDGLD':
       addressDataR = getErc20AddressData(state, {
         coin: 'WDGLD',
@@ -98,6 +98,14 @@ export const getData = (state, ownProps: OwnProps) => {
         includeInterest: true
       })
       balanceDataR = balanceSelectors.getXlmBalance(state)
+      break
+    case 'YFI':
+      addressDataR = getErc20AddressData(state, {
+        coin: 'YFI',
+        includeCustodial: true,
+        includeInterest: true
+      })
+      balanceDataR = balanceSelectors.getYfiBalance(state)
       break
     case 'ALGO':
       addressDataR = getAlgoAddressData(state, {

--- a/packages/blockchain-wallet-v4/src/exchange/currencies/AAVE.ts
+++ b/packages/blockchain-wallet-v4/src/exchange/currencies/AAVE.ts
@@ -19,7 +19,7 @@ export default {
     AAVE: {
       rate: '1000000000000000000',
       symbol: 'AAVE',
-      decimal_digits: 2,
+      decimal_digits: 8,
       currency: 'AAVE'
     }
   }

--- a/packages/blockchain-wallet-v4/src/exchange/currencies/YFI.ts
+++ b/packages/blockchain-wallet-v4/src/exchange/currencies/YFI.ts
@@ -19,7 +19,7 @@ export default {
     YFI: {
       rate: '1000000000000000000',
       symbol: 'YFI',
-      decimal_digits: 2,
+      decimal_digits: 8,
       currency: 'YFI'
     }
   }

--- a/packages/blockchain-wallet-v4/src/exchange/index.ts
+++ b/packages/blockchain-wallet-v4/src/exchange/index.ts
@@ -1590,7 +1590,7 @@ const displayAaveToAave = ({
   value: number | string
 }) => {
   return transformAaveToAave({ value, fromUnit, toUnit })
-    .map(x => Currency.coinToString({ ...x, minDigits: 2, maxDigits: 2 }))
+    .map(x => Currency.coinToString({ ...x, minDigits: 2, maxDigits: 8 }))
     .getOrElse(DefaultDisplay)
 }
 
@@ -1604,7 +1604,7 @@ const displayYfiToYfi = ({
   value: number | string
 }) => {
   return transformYfiToYfi({ value, fromUnit, toUnit })
-    .map(x => Currency.coinToString({ ...x, minDigits: 2, maxDigits: 2 }))
+    .map(x => Currency.coinToString({ ...x, minDigits: 2, maxDigits: 8 }))
     .getOrElse(DefaultDisplay)
 }
 

--- a/packages/blockchain-wallet-v4/src/redux/common/dot/selectors.ts
+++ b/packages/blockchain-wallet-v4/src/redux/common/dot/selectors.ts
@@ -1,0 +1,4 @@
+import { RootState } from 'data/rootReducer'
+
+export const getWalletTransactions = (state: RootState) =>
+  state.dataPath.dot.transactions

--- a/packages/blockchain-wallet-v4/src/redux/common/selectors.js
+++ b/packages/blockchain-wallet-v4/src/redux/common/selectors.js
@@ -1,8 +1,9 @@
 import * as algo from './algo/selectors'
 import * as bch from './bch/selectors'
 import * as btc from './btc/selectors'
+import * as dot from './dot/selectors'
 import * as eth from './eth/selectors'
 import * as stx from './stx/selectors'
 import * as xlm from './xlm/selectors'
 
-export { algo, bch, btc, eth, stx, xlm }
+export { algo, bch, btc, dot, eth, stx, xlm }


### PR DESCRIPTION
## Description (optional)
1. Uses correct balance selector for total balance and wallet balance dropdowns
2. Fixes bug where 'invalid coin' shows after send - included in paymentGetOrElse saga
3. Use 8 decimal places instead of 2 for aave and yfi
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

