### PR TITLE
fix(new-wallet): fixed close button behaviour

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/AddBtcWallet/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/AddBtcWallet/template.js
@@ -38,7 +38,7 @@ const AddBtcWallet = ({
     <Modal size='large' position={position} total={total}>
       <Form onSubmit={handleSubmit}>
         <Wrapper>
-          <ModalHeader icon='arrow-up-circle' onClose={close}>
+          <ModalHeader icon='arrow-up-circle' onClose={() => close()}>
             <FormattedMessage
               id='modals.addbitcoinwallet.title'
               defaultMessage='Add New Bitcoin Wallet'


### PR DESCRIPTION
## Description (optional)
This PR solve issue with non working click on X button

## Testing Steps (optional)
Go to settings, then select 'Wallets & Addresses' and then click on button 'New Wallet', modal will appear click on X button and make sure that it's closing modal.

