### PR TITLE
Fix/accounts assets release

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxAlgoAddresses/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxAlgoAddresses/selectors.ts
@@ -20,7 +20,7 @@ export const getData = (
 
   const buildCustodialDisplay = x => {
     return (
-      `ALGO Trading Account` +
+      `Trading Account` +
       ` (${Exchange.displayAlgoToAlgo({
         value: x ? x.available : 0,
         fromUnit: 'mALGO',
@@ -31,14 +31,14 @@ export const getData = (
   // @ts-ignore
   // const excluded = filter(x => !exclude.includes(x.label))
   const toGroup = curry((label, options) => [{ label, options }])
-  const toExchange = x => [{ label: `Exchange ALGO Address`, value: x }]
+  const toExchange = x => [{ label: `Exchange Account`, value: x }]
   const toCustodialDropdown = currencyDetails => [
     {
       label: buildCustodialDisplay(currencyDetails),
       value: {
         ...currencyDetails,
         type: ADDRESS_TYPES.CUSTODIAL,
-        label: 'ALGO Trading Account'
+        label: 'Trading Account'
       }
     }
   ]

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxBchAddresses/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxBchAddresses/selectors.ts
@@ -93,7 +93,7 @@ export const getData = (
 
   const buildCustodialDisplay = x => {
     return (
-      `BCH Trading Account` +
+      `Trading Account` +
       ` (${Exchange.displayBchToBch({
         value: x ? x.available : 0,
         fromUnit: 'SAT',
@@ -104,7 +104,7 @@ export const getData = (
 
   const buildInterestDisplay = (x: InterestAccountBalanceType['BCH']) => {
     return (
-      `BCH Interest Account` +
+      `Interest Account` +
       ` (${Exchange.displayBchToBch({
         value: x ? x.balance : 0,
         fromUnit: 'SAT',
@@ -124,7 +124,7 @@ export const getData = (
   const toGroup = curry((label, options) => [{ label, options }])
   const toExchange = x => [
     {
-      label: `BCH Exchange Account`,
+      label: `Exchange Account`,
       value: x
     }
   ]
@@ -134,7 +134,7 @@ export const getData = (
       value: {
         ...currencyDetails,
         type: ADDRESS_TYPES.CUSTODIAL,
-        label: 'BCH Trading Account'
+        label: 'Trading Account'
       }
     }
   ]
@@ -145,7 +145,7 @@ export const getData = (
       value: {
         ...x,
         type: ADDRESS_TYPES.INTEREST,
-        label: 'BCH Interest Account'
+        label: 'Interest Account'
       }
     }
   ]

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxBtcAddresses/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxBtcAddresses/selectors.ts
@@ -85,7 +85,7 @@ export const getData = (
   }
   const buildCustodialDisplay = x => {
     return (
-      `BTC Trading Account` +
+      `Trading Account` +
       ` (${Exchange.displayBtcToBtc({
         value: x ? x.available : 0,
         fromUnit: 'SAT',
@@ -95,7 +95,7 @@ export const getData = (
   }
   const buildInterestDisplay = (x: InterestAccountBalanceType['BTC']) => {
     return (
-      `BTC Interest Account` +
+      `Interest Account` +
       ` (${Exchange.displayBtcToBtc({
         value: x ? x.balance : 0,
         fromUnit: 'SAT',
@@ -107,14 +107,14 @@ export const getData = (
   const excluded = filter(x => !exclude.includes(x.label))
   const toDropdown = map(x => ({ label: buildDisplay(x), value: x }))
   const toGroup = curry((label, options) => [{ label, options }])
-  const toExchange = x => [{ label: `BTC Exchange Account`, value: x }]
+  const toExchange = x => [{ label: `Exchange Account`, value: x }]
   const toCustodialDropdown = currencyDetails => [
     {
       label: buildCustodialDisplay(currencyDetails),
       value: {
         ...currencyDetails,
         type: ADDRESS_TYPES.CUSTODIAL,
-        label: 'BTC Trading Account'
+        label: 'Trading Account'
       }
     }
   ]
@@ -124,7 +124,7 @@ export const getData = (
       value: {
         ...x,
         type: ADDRESS_TYPES.INTEREST,
-        label: 'BTC Interest Account'
+        label: 'Interest Account'
       }
     }
   ]

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxDotAddresses/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxDotAddresses/selectors.ts
@@ -17,7 +17,7 @@ export const getData = (
 
   const buildCustodialDisplay = x => {
     return (
-      `DOT Trading Account` +
+      `Trading Account` +
       ` (${Exchange.displayDotToDot({
         value: x ? x.available : 0,
         fromUnit: 'PLANCK',
@@ -27,14 +27,14 @@ export const getData = (
   }
 
   const toGroup = curry((label, options) => [{ label, options }])
-  const toExchange = x => [{ label: `Exchange DOT Address`, value: x }]
+  const toExchange = x => [{ label: `Exchange Account`, value: x }]
   const toCustodialDropdown = currencyDetails => [
     {
       label: buildCustodialDisplay(currencyDetails),
       value: {
         ...currencyDetails,
         type: ADDRESS_TYPES.CUSTODIAL,
-        label: 'DOT Trading Account'
+        label: 'Trading Account'
       }
     }
   ]

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxEthAddresses/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxEthAddresses/selectors.ts
@@ -5,8 +5,7 @@ import { Exchange, Remote } from 'blockchain-wallet-v4/src'
 import { ADDRESS_TYPES } from 'blockchain-wallet-v4/src/redux/payment/btc/utils'
 import {
   Erc20CoinType,
-  InterestAccountBalanceType,
-  SupportedWalletCurrenciesType
+  InterestAccountBalanceType
 } from 'blockchain-wallet-v4/src/types'
 import { selectors } from 'data'
 
@@ -51,7 +50,7 @@ export const getEthData = (
   }
   const buildCustodialDisplay = x => {
     return (
-      `ETH Trading Account` +
+      `Trading Account` +
       ` (${Exchange.displayEtherToEther({
         value: x ? x.available : 0,
         fromUnit: 'WEI',
@@ -61,7 +60,7 @@ export const getEthData = (
   }
   const buildInterestDisplay = (x: InterestAccountBalanceType['ETH']) => {
     return (
-      `ETH Interest Account` +
+      `Interest Account` +
       ` (${Exchange.displayEtherToEther({
         value: x ? x.balance : 0,
         fromUnit: 'WEI',
@@ -80,7 +79,7 @@ export const getEthData = (
       value: {
         ...currencyDetails,
         type: ADDRESS_TYPES.CUSTODIAL,
-        label: 'ETH Trading Account'
+        label: 'Trading Account'
       }
     }
   ]
@@ -91,7 +90,7 @@ export const getEthData = (
       value: {
         ...x,
         type: ADDRESS_TYPES.INTEREST,
-        label: 'ETH Interest Account'
+        label: 'Interest Account'
       }
     }
   ]
@@ -178,11 +177,6 @@ export const getErc20Data = (
     includeInterest,
     forceCustodialFirst
   } = ownProps
-  const supportedCoinsR = selectors.core.walletOptions.getSupportedCoins(state)
-  const supportedCoins = supportedCoinsR.getOrElse(
-    {} as SupportedWalletCurrenciesType
-  )
-
   const displayErc20Fixed = data => {
     // TODO: ERC20 make more generic
     if (coin === 'PAX') {
@@ -227,13 +221,9 @@ export const getErc20Data = (
     }
     return {}
   }
-  const buildCustodialDisplay = (
-    x,
-    coin: Erc20CoinType,
-    displayName: string
-  ) => {
+  const buildCustodialDisplay = (x, coin: Erc20CoinType) => {
     return (
-      `${displayName} Trading Account` +
+      `Trading Account` +
       ` (${displayErc20Fixed({
         value: x ? x.available : 0,
         fromUnit: 'WEI',
@@ -242,13 +232,9 @@ export const getErc20Data = (
     )
   }
 
-  const buildInterestDisplay = (
-    coin: Erc20CoinType,
-    displayName: string,
-    x
-  ) => {
+  const buildInterestDisplay = (coin: Erc20CoinType, x) => {
     return (
-      `${displayName} Interest Account` +
+      `Interest Account` +
       ` (${Exchange.displayEtherToEther({
         value: x ? x.balance : 0,
         fromUnit: 'WEI',
@@ -274,35 +260,28 @@ export const getErc20Data = (
   const toGroup = curry((label, options) => [{ label, options }])
   const toExchange = x => [
     {
-      label:
-        coin === 'PAX'
-          ? 'USD-D Exchange Account'
-          : `${coin} Exchange Account`,
+      label: 'Exchange Account',
       value: x
     }
   ]
   const toCustodialDropdown = currencyDetails => [
     {
-      label: buildCustodialDisplay(
-        currencyDetails,
-        coin,
-        supportedCoins[coin].displayName
-      ),
+      label: buildCustodialDisplay(currencyDetails, coin),
       value: {
         ...currencyDetails,
         type: ADDRESS_TYPES.CUSTODIAL,
-        label: `${supportedCoins[coin].coinTicker} Trading Account`
+        label: `Trading Account`
       }
     }
   ]
 
   const toInterestDropdown = x => [
     {
-      label: buildInterestDisplay(x, coin, supportedCoins[coin].displayName),
+      label: buildInterestDisplay(x, coin),
       value: {
         ...x,
         type: ADDRESS_TYPES.INTEREST,
-        label: `${supportedCoins[coin].coinTicker} Interest Account`
+        label: `Interest Account`
       }
     }
   ]

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxXlmAddresses/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxXlmAddresses/selectors.ts
@@ -39,7 +39,7 @@ export const getData = (
   }
   const buildCustodialDisplay = x => {
     return (
-      `XLM Trading Account` +
+      `Trading Account` +
       ` (${Exchange.displayXlmToXlm({
         value: x ? x.available : 0,
         fromUnit: 'STROOP',
@@ -49,7 +49,7 @@ export const getData = (
   }
   const buildInterestDisplay = (x: InterestAccountBalanceType['XLM']) => {
     return (
-      `XLM Interest Account` +
+      `Interest Account` +
       ` (${Exchange.displayXlmToXlm({
         value: x ? x.balance : 0,
         fromUnit: 'STROOP',
@@ -68,7 +68,7 @@ export const getData = (
       value: {
         ...currencyDetails,
         type: ADDRESS_TYPES.CUSTODIAL,
-        label: 'XLM Trading Account'
+        label: 'Trading Account'
       }
     }
   ]
@@ -78,7 +78,7 @@ export const getData = (
       value: {
         ...x,
         type: ADDRESS_TYPES.INTEREST,
-        label: 'XLM Interest Account'
+        label: 'Interest Account'
       }
     }
   ]

--- a/packages/blockchain-wallet-v4-frontend/src/data/coins/utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/coins/utils.ts
@@ -11,13 +11,11 @@ export const generateTradingAccount = (
   coin: CoinType,
   sbBalance?: SBBalanceType
 ) => {
-  // hack to support PAX rebrand 🤬
-  const ticker = coin === 'PAX' ? 'USD-D' : coin
   return [
     {
       baseCoin: coin in Erc20CoinsEnum ? 'ETH' : coin,
       coin,
-      label: `${ticker} Trading Account`,
+      label: 'Trading Account',
       type: ADDRESS_TYPES.CUSTODIAL,
       balance: sbBalance?.available || '0'
     }

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.utils.ts
@@ -135,13 +135,13 @@ export default ({ coreSagas, networks }: { coreSagas: any; networks: any }) => {
 
   const toCustodialDropdown = currencyDetails => {
     // this object has to be equal to object we do expect in dropdown
-    const { coin, ...restDetails } = currencyDetails
+    const { ...restDetails } = currencyDetails
     return [
       {
         ...restDetails,
         address: currencyDetails.address,
         type: ADDRESS_TYPES.CUSTODIAL,
-        label: `${coin} Trading Account`
+        label: 'Trading Account'
       }
     ]
   }

--- a/packages/blockchain-wallet-v4/data/wallet.v3.json
+++ b/packages/blockchain-wallet-v4/data/wallet.v3.json
@@ -21,7 +21,7 @@
       "default_account_idx": 0,
       "accounts": [
         {
-          "label": "BTC Private Key Wallet",
+          "label": "Private Key Wallet",
           "archived": false,
           "xpriv": "xprv9ymnii74qXShFUk1bhXCWaKhGDqrWVmBg2xAvpT2eopuSjkDk79jNu3TGkg6hTQ7P6vby8f5WxGUnR4Nkqwcz1jt68B8TiJc5UkQ9MbwW3s",
           "xpub": "xpub6Cm98DdxftzzTxpUhj4CsiGRpFgLuxV33FsmjCreD9MtKY5NHeTyvhMw82aANb5GWaBGvGcey7skgcY9ZHk42KhyBXr23yYP5QYcAJzVz7D",

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/bch/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/bch/sagas.js
@@ -24,7 +24,7 @@ import { BCH, derivationMap } from '../config'
 import { getMetadataXpriv } from '../root/selectors'
 import * as A from './actions'
 
-const BCH_ACCT_NAME = 'BCH Private Key Wallet'
+const BCH_ACCT_NAME = 'Private Key Wallet'
 
 export default ({ api, networks }) => {
   const createBch = function * (kv, hdAccounts, bchAccounts) {

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/eth/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/eth/sagas.js
@@ -25,7 +25,7 @@ import { derivationMap, ETH } from '../config'
 import { getMetadataXpriv } from '../root/selectors'
 import * as A from './actions'
 
-const ETH_ACCT_NAME = 'ETH Private Key Wallet'
+const ACCT_NAME = 'Private Key Wallet'
 
 export default ({ api, networks } = {}) => {
   const deriveAccount = function * (password) {
@@ -45,7 +45,7 @@ export default ({ api, networks } = {}) => {
   }
 
   const buildErc20Entry = (token, coinModels, existingNotes) => ({
-    label: `${coinModels[token].coinTicker} Private Key Wallet`,
+    label: ACCT_NAME,
     contract: path([token, 'contractAddress'], coinModels),
     has_seen: false,
     tx_notes: existingNotes || {}
@@ -69,7 +69,7 @@ export default ({ api, networks } = {}) => {
       default_account_idx: defaultIndex,
       accounts: [
         {
-          label: ETH_ACCT_NAME,
+          label: ACCT_NAME,
           archived: false,
           correct: true,
           addr: addr
@@ -114,7 +114,7 @@ export default ({ api, networks } = {}) => {
         const erc20List = (yield select(getErc20CoinList)).getOrFail()
         const coinModels = (yield select(getSupportedCoins)).getOrFail()
         // use new ETH account label
-        newkv.value.ethereum.accounts[0].label = ETH_ACCT_NAME
+        newkv.value.ethereum.accounts[0].label = ACCT_NAME
         // create fake metadata entries for erc20 assets
         const erc20 = pathOr({}, ['value', 'ethereum', 'erc20'], newkv)
         forEach(token => {

--- a/packages/blockchain-wallet-v4/src/redux/kvStore/xlm/sagas.js
+++ b/packages/blockchain-wallet-v4/src/redux/kvStore/xlm/sagas.js
@@ -10,7 +10,7 @@ import { derivationMap, XLM } from '../config'
 import { getMetadataXpriv } from '../root/selectors'
 import * as A from './actions'
 
-const XLM_ACCT_NAME = 'XLM Private Key Wallet'
+const XLM_ACCT_NAME = 'Private Key Wallet'
 
 export default ({ api, networks } = {}) => {
   const createXlm = function * ({ kv, password }) {

--- a/packages/blockchain-wallet-v4/src/redux/payment/eth/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/eth/sagas.ts
@@ -324,7 +324,11 @@ export default ({ api }) => {
           )
           return makePayment(mergeRight(p, { signed }))
         } catch (e) {
-          throw new Error('missing_mnemonic')
+          if (e && e instanceof Error) {
+            throw e
+          } else {
+            throw new Error('missing_mnemonic')
+          }
         }
       },
 

--- a/packages/blockchain-wallet-v4/src/redux/wallet/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/wallet/sagas.ts
@@ -33,7 +33,7 @@ import { derivationMap, WALLET_CREDENTIALS } from '../kvStore/config'
 import * as SS from '../selectors'
 import * as S from './selectors'
 
-const BTC_ACCT_NAME = 'BTC Private Key Wallet'
+const BTC_ACCT_NAME = 'Private Key Wallet'
 
 const taskToPromise = t =>
   new Promise((resolve, reject) => t.fork(reject, resolve))

--- a/packages/blockchain-wallet-v4/src/signer/eth.js
+++ b/packages/blockchain-wallet-v4/src/signer/eth.js
@@ -21,7 +21,7 @@ export const signErc20 = curry(
 
     // sometimes ERC20 transfers/sends are being created with 0 amount,
     // for now just detect and throw error. ideally, we find root cause of this
-    if (!new BigNumber(amount).isZero()) {
+    if (new BigNumber(amount).isZero()) {
       return Task.rejected(new Error('erc20_amount_cannot_be_zero'))
     }
 

--- a/packages/blockchain-wallet-v4/src/signer/eth.js
+++ b/packages/blockchain-wallet-v4/src/signer/eth.js
@@ -18,6 +18,13 @@ export const signErc20 = curry(
     const { amount, gasLimit, gasPrice, index, nonce, to } = data
     const privateKey = eth.getPrivateKey(mnemonic, index)
     const transferMethodHex = '0xa9059cbb'
+
+    // sometimes ERC20 transfers/sends are being created with 0 amount,
+    // for now just detect and throw error. ideally, we find root cause of this
+    if (!new BigNumber(amount).isZero()) {
+      return Task.rejected(new Error('erc20_amount_cannot_be_zero'))
+    }
+
     const txParams = {
       to: contractAddress,
       nonce: toHex(nonce),

--- a/packages/blockchain-wallet-v4/src/types/HDWalletList.js
+++ b/packages/blockchain-wallet-v4/src/types/HDWalletList.js
@@ -32,7 +32,7 @@ export const createNew = (
   password,
   sharedKey,
   mnemonic,
-  firstAccountName = 'BTC Private Key Wallet',
+  firstAccountName = 'Private Key Wallet',
   nAccounts = 1
 ) =>
   fromJS([

--- a/packages/blockchain-wallet-v4/src/types/Wrapper.js
+++ b/packages/blockchain-wallet-v4/src/types/Wrapper.js
@@ -193,7 +193,7 @@ export const createNew = (
   sharedKey,
   mnemonic,
   language,
-  firstAccountName = 'BTC Private Key Wallet',
+  firstAccountName = 'Private Key Wallet',
   nAccounts = 1,
   network
 ) =>

--- a/packages/blockchain-wallet-v4/src/types/__mocks__/hdaccount.json
+++ b/packages/blockchain-wallet-v4/src/types/__mocks__/hdaccount.json
@@ -1,5 +1,5 @@
 {
-  "label": "BTC Private Key Wallet",
+  "label": "Private Key Wallet",
   "archived": false,
   "xpriv": "xprv9yL1ousLjQQzGNBAYykaT8J3U626NV6zbLYkRv8rvUDpY4f1RnrvAXQneGXC9UNuNvGXX4j6oHBK5KiV2hKevRxY5ntis212oxjEL11ysuG",
   "xpub": "xpub6CKNDRQEZmyHUrFdf1HapGEn27ramwpqxZUMEJYUUokoQrz9yLBAiKjGVWDuiCT39udj1r3whqQN89Tar5KrojH8oqSy7ytzJKW8gwmhwD3",

--- a/packages/blockchain-wallet-v4/src/types/__mocks__/wallet.v3-secpass.json
+++ b/packages/blockchain-wallet-v4/src/types/__mocks__/wallet.v3-secpass.json
@@ -50,7 +50,7 @@
       "default_account_idx": 0,
       "accounts": [
         {
-          "label": "BTC Private Key Wallet",
+          "label": "Private Key Wallet",
           "archived": false,
           "xpriv": "G1XRCumvdvM10xN1n9ub2JNyk3PphNhoYGQsVKnFi7tKmaDpQVaBmLX4XTWMkFENIGGmKd4PCxwZr6g1RC6RWJFWyXcAs+17DQdv7ZqdiKkj8p0Td3mEM/Ta41KYyxJdjlrT1FyW4HpH0AGejy4rJI43nHlxjpDl0rldP58eaEE=",
           "xpub": "xpub6CKNDRQEZmyHUrFdf1HapGEn27ramwpqxZUMEJYUUokoQrz9yLBAiKjGVWDuiCT39udj1r3whqQN89Tar5KrojH8oqSy7ytzJKW8gwmhwD3",

--- a/packages/blockchain-wallet-v4/src/types/__mocks__/wallet.v3.json
+++ b/packages/blockchain-wallet-v4/src/types/__mocks__/wallet.v3.json
@@ -49,7 +49,7 @@
       "default_account_idx": 0,
       "accounts": [
         {
-          "label": "BTC Private Key Wallet",
+          "label": "Private Key Wallet",
           "archived": false,
           "xpriv": "xprv9yL1ousLjQQzGNBAYykaT8J3U626NV6zbLYkRv8rvUDpY4f1RnrvAXQneGXC9UNuNvGXX4j6oHBK5KiV2hKevRxY5ntis212oxjEL11ysuG",
           "xpub": "xpub6CKNDRQEZmyHUrFdf1HapGEn27ramwpqxZUMEJYUUokoQrz9yLBAiKjGVWDuiCT39udj1r3whqQN89Tar5KrojH8oqSy7ytzJKW8gwmhwD3",

--- a/packages/blockchain-wallet-v4/src/types/__mocks__/wrapper.v3.json
+++ b/packages/blockchain-wallet-v4/src/types/__mocks__/wrapper.v3.json
@@ -55,7 +55,7 @@
         "default_account_idx": 0,
         "accounts": [
           {
-            "label": "BTC Private Key Wallet",
+            "label": "Private Key Wallet",
             "archived": false,
             "xpriv": "xprv9yL1ousLjQQzGNBAYykaT8J3U626NV6zbLYkRv8rvUDpY4f1RnrvAXQneGXC9UNuNvGXX4j6oHBK5KiV2hKevRxY5ntis212oxjEL11ysuG",
             "xpub": "xpub6CKNDRQEZmyHUrFdf1HapGEn27ramwpqxZUMEJYUUokoQrz9yLBAiKjGVWDuiCT39udj1r3whqQN89Tar5KrojH8oqSy7ytzJKW8gwmhwD3",


### PR DESCRIPTION
## Description (optional)
- renames private key accounts to match mobile (i.e. removes [coin] in name)
- correctly calculate erc20 fee amounts during Sell by using ETH rates instead of the ERC20 rates
- bandaid fix(throw error) for ERC20 sends that are created with a transfer amount of 0

