### PR TITLE
fix(nc-sell): update payment with form value if it exists on initiali…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
@@ -1083,12 +1083,15 @@ export default ({
           failure: take(AT.FETCH_SELL_QUOTE_FAILURE)
         })
         const quote = S.getSellQuote(yield select()).getOrFail(NO_QUOTE)
+        const formValues = selectors.form.getFormValues('simpleBuyCheckout')(
+          yield select()
+        ) as T.SBCheckoutFormValuesType
         if (account.type === 'ACCOUNT') {
           let payment = yield call(
             calculateProvisionalPayment,
             account,
             quote.quote,
-            0
+            formValues ? formValues.cryptoAmount : 0
           )
           yield put(A.updatePaymentSuccess(payment))
         } else {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
@@ -1083,10 +1083,11 @@ export default ({
           failure: take(AT.FETCH_SELL_QUOTE_FAILURE)
         })
         const quote = S.getSellQuote(yield select()).getOrFail(NO_QUOTE)
-        const formValues = selectors.form.getFormValues('simpleBuyCheckout')(
-          yield select()
-        ) as T.SBCheckoutFormValuesType
+
         if (account.type === 'ACCOUNT') {
+          const formValues = selectors.form.getFormValues('simpleBuyCheckout')(
+            yield select()
+          ) as T.SBCheckoutFormValuesType
           let payment = yield call(
             calculateProvisionalPayment,
             account,

--- a/packages/blockchain-wallet-v4/src/redux/payment/types.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/types.ts
@@ -104,7 +104,7 @@ export type BtcPaymentType = IPaymentType & {
 
 export type EthPaymentType = IPaymentType & {
   amount: (n: number | string) => EthPaymentType
-  coin: 'ETH' | 'PAX' | 'USDT' | 'WDGLD'
+  coin: 'ETH' | 'PAX' | 'USDT' | 'WDGLD' | 'YFI' | 'AAVE'
   description: (arg: string) => EthPaymentType
   fee: (arg: number, account: string) => EthPaymentType
   init: (arg: {

--- a/packages/blockchain-wallet-v4/src/signer/eth.js
+++ b/packages/blockchain-wallet-v4/src/signer/eth.js
@@ -19,8 +19,7 @@ export const signErc20 = curry(
     const privateKey = eth.getPrivateKey(mnemonic, index)
     const transferMethodHex = '0xa9059cbb'
 
-    // sometimes ERC20 transfers/sends are being created with 0 amount,
-    // for now just detect and throw error. ideally, we find root cause of this
+    // block ERC20 transfers/sends that are being created with 0 amount
     if (new BigNumber(amount).isZero()) {
       return Task.rejected(new Error('erc20_amount_cannot_be_zero'))
     }


### PR DESCRIPTION
…ze checkout

## Description (optional)

Should fix FWLT-1199 and possibly other Non-custodial sell issues.

In some cases, the wallet is sending 0 funds non-for custodial sells. I believe this would happen when:
1. User enters amount in sell checkout form
2. User then wants to change 'Receive To' option and selects another payment method, i.e. change from sell to EUR to USD
3. User is then redirected back to checkout form
4. User doesn't change form values at all and then continues onto confirm screen

At step 3, `initializeCheckout` would run again and update provisional payment with an amount of 0. I added a check `calculateProvisionalPayment`. If there's an amount form value, use that to update provisional payment. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

