### PR TITLE
fix(open banking): several small fixes to imports and formatted messages, as well as open the proper add bank modal using the users fiatCurrency

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/types.ts
@@ -45,7 +45,7 @@ export interface OBInstitution {
   countries: OBCountryType[]
   credentialsType: string
   environmentType: string
-  features: [string]
+  features: string[]
   fullName: string
   id: string
   media: OBMediaType

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Authorize/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Authorize/template.success.tsx
@@ -78,7 +78,7 @@ const DropdownItem = ({ bodyText, titleText }) => {
   )
 }
 
-const Success: React.FC<Props> = props => {
+const Success = (props: Props) => {
   const { entity } = props
   const entityName = entity === 'Fintecture (EU)' ? 'Fintecture' : 'SafeConnect'
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Connect/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Connect/template.success.tsx
@@ -11,9 +11,9 @@ import {
   ScanWithPhone,
   Section
 } from '../../../../components'
-import { OwnProps as _O, Props as _P, SuccessStateType as _SS } from '.'
+import { OwnProps, Props as _P, SuccessStateType } from '.'
 
-type Props = _O & _SS & _P
+type Props = OwnProps & SuccessStateType & _P
 
 const Success = (props: Props) => {
   return (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/SelectBank/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/SelectBank/template.success.tsx
@@ -11,12 +11,9 @@ import {
   ModalNavWithBackArrow,
   SimpleBankRow
 } from '../../../../components'
-import {
-  LinkDispatchPropsType as _LD,
-  OwnProps as _O,
-  SuccessStateType as _SS} from '.'
+import { LinkDispatchPropsType, OwnProps, SuccessStateType } from '.'
 
-type Props = _SS & _LD & _O
+type Props = LinkDispatchPropsType & OwnProps & SuccessStateType
 
 const Success = (props: Props) => {
   const [banks, setBanks] = useState<OBInstitution[]>(

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/index.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
+import { ModalPropsType } from 'blockchain-wallet-v4-frontend/src/modals/types'
 import { compose } from 'redux'
 
 import Flyout, { duration, FlyoutChild } from 'components/Flyout'
@@ -8,7 +9,6 @@ import { RootState } from 'data/rootReducer'
 import { AddBankStepType } from 'data/types'
 import ModalEnhancer from 'providers/ModalEnhancer'
 
-import { ModalPropsType } from '../../../types'
 import AddBankStatus from '../AddBankStatus'
 import Authorize from './Authorize'
 import Connect from './Connect'
@@ -56,7 +56,10 @@ class Banks extends PureComponent<Props> {
       >
         {this.props.step === AddBankStepType.ADD_BANK && (
           <FlyoutChild>
-            <SelectBank setYapilyBankId={this.setYapilyBankId} handleClose={this.handleClose}/>
+            <SelectBank
+              setYapilyBankId={this.setYapilyBankId}
+              handleClose={this.handleClose}
+            />
           </FlyoutChild>
         )}
         {this.props.step === AddBankStepType.ADD_BANK_CONNECT && (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/template.tsx
@@ -61,9 +61,11 @@ const Template: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   const { account, walletCurrency } = props
 
   const bankAccountName =
-    account && 'details' in account
-      ? `${account.details?.bankName} ${account.details?.accountNumber}`
-      : `bank account`
+    account && 'details' in account ? (
+      `${account.details?.bankName} ${account.details?.accountNumber}`
+    ) : (
+      <FormattedMessage id='copy.bank_account' defaultMessage='Bank Account' />
+    )
 
   const accountDetails = account && 'details' in account && account.details
   return (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/template.success.tsx
@@ -201,6 +201,7 @@ const Account = ({
   bankTransferAccounts,
   brokerageActions,
   defaultMethod,
+  fiatCurrency,
   invalid
 }: OwnProps) => {
   const dMethod = getDefaultMethod(defaultMethod, bankTransferAccounts)
@@ -216,7 +217,9 @@ const Account = ({
         if (!bankTransferAccounts.length) {
           brokerageActions.showModal(
             BrokerageModalOriginType.ADD_BANK,
-            'ADD_BANK_YODLEE_MODAL'
+            fiatCurrency === 'USD'
+              ? 'ADD_BANK_YODLEE_MODAL'
+              : 'ADD_BANK_YAPILY_MODAL'
           )
           brokerageActions.setAddBankStep({
             addBankStep: AddBankStepType.ADD_BANK

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/Payment/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/Payment/model.tsx
@@ -98,12 +98,16 @@ export const DisplayValue = styled(Value)`
 
 export const renderBankText = (
   value: SBPaymentMethodType | BankTransferAccountType
-): string => {
-  return value.details
-    ? value.details.bankName
-      ? value.details.bankName
-      : value.details.accountNumber
-    : 'Bank Account'
+): string | ReactElement => {
+  return value.details ? (
+    value.details.bankName ? (
+      value.details.bankName
+    ) : (
+      value.details.accountNumber
+    )
+  ) : (
+    <FormattedMessage id='copy.bank_account' defaultMessage='Bank Account' />
+  )
 }
 
 export const renderBank = (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/LinkedPaymentAccounts/Accounts/Bank/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/LinkedPaymentAccounts/Accounts/Bank/index.tsx
@@ -25,7 +25,7 @@ const StyledValue = styled(Value)`
 type Props = {
   icon: ReactElement
   onClick: () => void
-  text: string
+  text: string | ReactElement
   value: SBPaymentMethodType
 }
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/LinkedPaymentAccounts/Accounts/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/LinkedPaymentAccounts/Accounts/index.tsx
@@ -161,12 +161,16 @@ class Accounts extends PureComponent<InjectedFormProps<{}, Props> & Props> {
     }
   }
 
-  renderBankText = (value: SBPaymentMethodType): string => {
-    return value.details
-      ? value.details.bankName
-        ? value.details.bankName
-        : value.details.accountNumber
-      : 'Bank Account'
+  renderBankText = (value: SBPaymentMethodType): string | ReactElement => {
+    return value.details ? (
+      value.details.bankName ? (
+        value.details.bankName
+      ) : (
+        value.details.accountNumber
+      )
+    ) : (
+      <FormattedMessage id='copy.bank_account' defaultMessage='Bank Account' />
+    )
   }
 
   renderCardText = (value: SBPaymentMethodType): string => {
@@ -230,11 +234,18 @@ class Accounts extends PureComponent<InjectedFormProps<{}, Props> & Props> {
     }))
 
     const bankMethods = availableBankAccounts.map(account => ({
-      text: account.details
-        ? account.details.accountName
-          ? account.details.accountName
-          : account.details.accountNumber
-        : 'Bank Account',
+      text: account.details ? (
+        account.details.accountName ? (
+          account.details.accountName
+        ) : (
+          account.details.accountNumber
+        )
+      ) : (
+        <FormattedMessage
+          id='copy.bank_account'
+          defaultMessage='Bank Account'
+        />
+      ),
       value: {
         ...account,
         type: 'BANK_TRANSFER',

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/PaymentMethods/Methods/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/PaymentMethods/Methods/index.tsx
@@ -19,7 +19,6 @@ import {
   getCoinFromPair,
   getFiatFromPair
 } from 'data/components/simpleBuy/model'
-import { getBankLogoImageName } from 'services/images'
 
 import { Props as OwnProps, SuccessStateType } from '../index'
 import BankWire from './BankWire'
@@ -102,10 +101,6 @@ class Methods extends PureComponent<InjectedFormProps<{}, Props> & Props> {
     this.props.simpleBuyActions.handleSBMethodChange(method)
   }
 
-  getLinkedBankIcon = (bankName: string): ReactElement => (
-    <Image name={getBankLogoImageName(bankName)} height='48px' />
-  )
-
   getIcon = (value: SBPaymentMethodType): ReactElement => {
     switch (value.type) {
       case 'BANK_TRANSFER':
@@ -147,22 +142,6 @@ class Methods extends PureComponent<InjectedFormProps<{}, Props> & Props> {
       default:
         return <Image name='blank-card' />
     }
-  }
-
-  renderBankText = (value: SBPaymentMethodType): string => {
-    return value.details
-      ? value.details.accountName
-        ? value.details.accountName
-        : value.details.accountNumber
-      : 'Bank Account'
-  }
-
-  renderCardText = (value: SBPaymentMethodType): string => {
-    return value.card
-      ? value.card.label
-        ? value.card.label
-        : value.card.type
-      : 'Credit or Debit Card'
   }
 
   render() {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/model.tsx
@@ -39,7 +39,12 @@ export const getOrigin = (
         return `${details.bankName} ${details.bankAccountType?.toLowerCase() ||
           ''} ${details.accountNumber}`
       }
-      return 'Bank Account'
+      return (
+        <FormattedMessage
+          id='copy.bank_account'
+          defaultMessage='Bank Account'
+        />
+      )
     case undefined:
       return 'Unknown Payment Type'
     default:


### PR DESCRIPTION
## Description (optional)
Fixes issues @milan-bc had in original open banking PR and fixes an issue with deposit button defaulting to USD add bank modal instead of using the user's fiat currency to determine yodlee or yapily.
