### PR TITLE
fix(erc20-interest): fix contract address error for custodial transfers

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
@@ -158,7 +158,7 @@ const DepositForm: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   const isErc20 = !!supportedCoins[coin].contractAddress
   const insufficientEth =
     payment &&
-    !!supportedCoins[coin].contractAddress &&
+    !!supportedCoins[coin]?.contractAddress &&
     !!supportedCoins[payment.coin]?.contractAddress &&
     // @ts-ignore
     !payment.isSufficientEthForErc20

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
@@ -159,7 +159,7 @@ const DepositForm: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   const insufficientEth =
     payment &&
     !!supportedCoins[coin].contractAddress &&
-    !!supportedCoins[payment.coin].contractAddress &&
+    !!supportedCoins[payment.coin]?.contractAddress &&
     // @ts-ignore
     !payment.isSufficientEthForErc20
 


### PR DESCRIPTION
## Description (optional)
Fixes this error when selecting custodial USDT/PAX from interest dropdown on the transfer screen.
![Screen Shot 2021-04-07 at 1 56 29 PM](https://user-images.githubusercontent.com/14954836/113939145-9c36f480-97c9-11eb-871e-729bdbc27d3d.png)


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

