### PR TITLE
Fix/interest custodial

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
@@ -158,7 +158,7 @@ const DepositForm: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   const isErc20 = !!supportedCoins[coin].contractAddress
   const insufficientEth =
     payment &&
-    !!supportedCoins[coin].contractAddress &&
+    !!supportedCoins[coin]?.contractAddress &&
     !!supportedCoins[payment.coin]?.contractAddress &&
     // @ts-ignore
     !payment.isSufficientEthForErc20

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
@@ -159,7 +159,7 @@ const DepositForm: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   const insufficientEth =
     payment &&
     !!supportedCoins[coin].contractAddress &&
-    !!supportedCoins[payment.coin].contractAddress &&
+    !!supportedCoins[payment.coin]?.contractAddress &&
     // @ts-ignore
     !payment.isSufficientEthForErc20
 


### PR DESCRIPTION
## Description (optional)
hotfix was made to master for this, fixes issue where selecting the custodial USDT/USD-D wallet as the 'transfer-from' wallet caused this explosion:

![Screen Shot 2021-04-07 at 1 56 29 PM](https://user-images.githubusercontent.com/14954836/113939584-2e3efd00-97ca-11eb-8237-59d01792f453.png)


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

