### PR TITLE
Hotfix(Interest): wait for deposit address before building tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockchain-wallet-v4",
-  "version": "4.48.9",
+  "version": "4.48.10",
   "license": "AGPL-3.0-or-later",
   "private": true,
   "author": {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { last, prop } from 'ramda'
+import { isEmpty, isNil, last, prop } from 'ramda'
 import { FormAction, initialize } from 'redux-form'
 import { call, delay, put, select, take } from 'redux-saga/effects'
 
@@ -397,8 +397,18 @@ export default ({
         })
       } else {
         // non-custodial deposit
+        // fetch deposit address
         yield put(A.fetchInterestAccount(coin))
+        yield take([
+          AT.FETCH_INTEREST_PAYMENT_ACCOUNT_SUCCESS,
+          AT.FETCH_INTEREST_PAYMENT_ACCOUNT_FAILURE
+        ])
         const depositAddress = yield select(S.getDepositAddress)
+
+        // abort if deposit address missing
+        if (isEmpty(depositAddress) || isNil(depositAddress)) {
+          throw new Error('Missing deposit address')
+        }
 
         // build and publish payment to network
         const transaction = yield call(


### PR DESCRIPTION
## Description 
Currently users are experiencing an issue on the initial deposit attempt to interest account. This is happening because we were not waiting for call to Nabu for deposit address to finish before we attempted to build the deposit transaction.

