### PR TITLE
fix(segwit): Fix edge case with fractional vbytes

### DIFF
--- a/packages/blockchain-wallet-v4/src/coinSelection/coinSelection.spec.js
+++ b/packages/blockchain-wallet-v4/src/coinSelection/coinSelection.spec.js
@@ -27,7 +27,7 @@ describe('Coin Selection', () => {
         expect(cs.transactionBytes([legacyInput], [segwitOutput])).toEqual(189)
       })
       it('should return the right transaction size (1 P2WPKH, 1 P2PKH)', () => {
-        // 10.75 + 67.75 + 34 = 112.5
+        // 10.75 + 67.75 + 34 = ~112.5
         expect(cs.transactionBytes([segwitInput], [legacyOutput])).toEqual(
           112.5
         )
@@ -225,8 +225,21 @@ describe('Coin Selection', () => {
       const outputs = map(Coin.fromJS, [{ value: 0 }, { value: 0 }])
 
       // sum of inputs - transactionBytes * feePerByte
-      // 45000 - 55 * (10 + 3*148 + 2*34) = 45000 - 28710 = 16290
+      // 45000 - 55 * (10 + 3*148 + 2*34) = 45000 - ceil(28710) = 16290
       expect(cs.effectiveBalance(55, inputs, outputs).value).toEqual(16290)
+    })
+    it('should return the right effective max balance with value and empty valued outputs (segwit)', () => {
+      const inputs = map(Coin.fromJS, [
+        { value: 15000, address: 'bc1qxddx2wmn97swgznpkthv940ktg8ycxg0ygxxp9' },
+        { value: 10000, address: 'bc1qxddx2wmn97swgznpkthv940ktg8ycxg0ygxxp9' },
+        { value: 20000 }
+      ])
+
+      const outputs = map(Coin.fromJS, [{ value: 0 }, { value: 0 }])
+
+      // sum of inputs - transactionBytes * feePerByte
+      // 45000 - 55 * (10.75 + 2*67.75 + 148 + 2*34) = 45000 - ceil(19923.75) = 25076
+      expect(cs.effectiveBalance(55, inputs, outputs).value).toEqual(25076)
     })
     it('should return the right effective max balance w/ no inputs or outputs', () => {
       expect(cs.effectiveBalance(55, [], []).value).toEqual(0)

--- a/packages/blockchain-wallet-v4/src/coinSelection/coinSelection.spec.js
+++ b/packages/blockchain-wallet-v4/src/coinSelection/coinSelection.spec.js
@@ -27,7 +27,7 @@ describe('Coin Selection', () => {
         expect(cs.transactionBytes([legacyInput], [segwitOutput])).toEqual(189)
       })
       it('should return the right transaction size (1 P2WPKH, 1 P2PKH)', () => {
-        // 10.75 + 67.75 + 34 = ~112.5
+        // 10.75 + 67.75 + 34 = 112.5
         expect(cs.transactionBytes([segwitInput], [legacyOutput])).toEqual(
           112.5
         )

--- a/packages/blockchain-wallet-v4/src/coinSelection/index.js
+++ b/packages/blockchain-wallet-v4/src/coinSelection/index.js
@@ -31,7 +31,7 @@ export const isFromLegacy = selection =>
   selection.inputs[0] ? selection.inputs[0].isFromLegacy() : false
 
 export const dustThreshold = feeRate =>
-  (Coin.inputBytes({}) + Coin.outputBytes({})) * feeRate
+  Math.ceil((Coin.inputBytes({}) + Coin.outputBytes({})) * feeRate)
 
 export const transactionBytes = (inputs, outputs) => {
   const coinTypeReducer = (acc, coin) => {
@@ -57,7 +57,11 @@ export const effectiveBalance = curry((feePerByte, inputs, outputs = [{}]) =>
   List(inputs)
     .fold(Coin.empty)
     .overValue(v =>
-      clamp(0, Infinity, v - transactionBytes(inputs, outputs) * feePerByte)
+      clamp(
+        0,
+        Infinity,
+        v - Math.ceil(transactionBytes(inputs, outputs) * feePerByte)
+      )
     )
 )
 
@@ -80,7 +84,7 @@ const ft = (targets, feePerByte, coins, changeAddress) => {
           [nextAcc, partialFee, restCoins]
         ]
   }
-  const partialFee = transactionBytes([], targets) * feePerByte
+  const partialFee = Math.ceil(transactionBytes([], targets) * feePerByte)
   const effectiveCoins = filter(
     c => Coin.effectiveValue(feePerByte, c) > 0,
     coins


### PR DESCRIPTION
## Description (optional)

Follow-up for #3011

Fixes edge case when `transactionBytes` multiplied by `feePerByte` contains fractional value, which is not accepted by `bitcoinjs`

## Testing Steps (optional)

```
$ npm run test:core -g "Coin*"
```
