### PR TITLE
fix(simple buy): fix issue where order confirmwasnt showing on yodlee orders due to yapily

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -668,7 +668,7 @@ type MessagesType = {
   'modals.brokerage.timed_out_sub': 'This happens from time to time. Wait a few minutes and then check the status of your deposit in the transaction list.'
   'modals.brokerage.use_phone_camera': 'Use your phone’s camera to scan the QR code.'
   'modals.brokerage.waiting_to_hear': 'Waiting to hear from your bank'
-  'modals.brokerage.this_can_take_a_while': 'This can take a while, hold tight!'
+  'modals.brokerage.this_can_take_a_while': 'This can take several minutes, hold tight!'
   'modals.brokerage.yodlee_description': 'Yodlee securely stores your credentials adhering to leading industry practices for data security, regulatory compliance, and privacy.'
   'modals.brokerage.daily_limit': 'Daily Limit'
   'modals.brokerage.deposit_methods': 'Select a Deposit Method'

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/model.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/model.ts
@@ -27,6 +27,11 @@ export const DEFAULT_SB_METHODS = {
   methods: []
 }
 
+export const POLLING = {
+  SECONDS: 10,
+  RETRY_AMOUNT: 30
+}
+
 export const LIMIT = { min: '500', max: '10000' } as Limits
 export const LIMIT_FACTOR = 100 // we get 10000 from API
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/components/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/components/index.tsx
@@ -124,7 +124,7 @@ const BankWaitIndicator = ({ qrCode }: { readonly qrCode?: string }) => {
         {waitCount > 0 && (
           <FormattedMessage
             id='modals.brokerage.this_can_take_a_while'
-            defaultMessage='This can take a while, hold tight!'
+            defaultMessage='This can take several minutes, hold tight!'
           />
         )}
       </Text>


### PR DESCRIPTION
## Description (optional)
Yapily logic was causing Yodlee simple buy confirmations to hang. Just needed to do a specific check for Yapily partner before running the auth url polling method.

## Testing Steps (optional)
Log into an ACH capable account and do a simple buy, it should complete successfully as it does on production.

