### PR TITLE
feat(open banking): link bank modal back button click now works

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYodlee/Add/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYodlee/Add/index.tsx
@@ -29,15 +29,6 @@ class Add extends PureComponent<Props> {
     })
   }
 
-  handleBack = () => {
-    // this.props.simpleBuyActions.setStep({
-    //   step: 'PAYMENT_METHODS',
-    //   cryptoCurrency: this.props.cryptoCurrency,
-    //   fiatCurrency: this.props.fiatCurrency,
-    //   pair: this.props.pair
-    // })
-  }
-
   render() {
     return this.props.data.cata({
       Success: val => (
@@ -45,7 +36,7 @@ class Add extends PureComponent<Props> {
           {...this.props}
           {...val}
           onSubmit={this.handleSubmit}
-          handleBack={this.handleBack}
+          handleBack={this.props.handleClose}
         />
       ),
       Failure: e => (


### PR DESCRIPTION
## Description (optional)
This PR solves the issue with back button click

## Testing Steps (optional)
Login to wallet
Navigate to SB
Select any crypto and any sum
Select payment methods
Press 'Link a Bank'
Attempt to press 'Back' arrow, nothing happens

