### PR TITLE
feat(ob): improved default minimum

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
@@ -121,6 +121,14 @@ export const getMaxMin = (
             )
           }
 
+          const defaultLimitMaxAmount = convertBaseToStandard(
+            'FIAT',
+            limitMaxAmount
+          )
+          if (Number(defaultMax.FIAT) > Number(defaultLimitMaxAmount)) {
+            defaultMax.FIAT = defaultLimitMaxAmount
+          }
+
           if (!allValues) return defaultMax
           if (!method) return defaultMax
 
@@ -177,6 +185,14 @@ export const getMaxMin = (
                 ? convertBaseToStandard('FIAT', Number(sddLimit.min))
                 : convertBaseToStandard('FIAT', pair.buyMin)
             )
+          }
+
+          const defaultLimitMinAmount = convertBaseToStandard(
+            'FIAT',
+            limitMinAmount
+          )
+          if (Number(defaultMin.FIAT) < Number(defaultLimitMinAmount)) {
+            defaultMin.FIAT = defaultLimitMinAmount
           }
 
           if (!allValues) return defaultMin


### PR DESCRIPTION
## Description (optional)
This PR resolve inconsistency with default limits if method is not selected

## Testing Steps (optional)
Try to buy some DOT

Before we had default limit set to $5
![image](https://user-images.githubusercontent.com/67264242/115580982-e2ab4980-a2c7-11eb-95f6-01164ed8366f.png)

