### PR TITLE
Fix(ETH): Transaction fetching

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/data/eth/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/data/eth/sagas.ts
@@ -44,8 +44,8 @@ import * as A from './actions'
 import * as AT from './actionTypes'
 import * as S from './selectors'
 const { transformErc20Tx, transformTx } = transactions.eth
-const TX_PER_PAGE = 10
-const TX_REPORT_PAGE_SIZE = 50
+const TX_PER_PAGE = 50
+const TX_REPORT_PAGE_SIZE = 500
 const CONTEXT_FAILURE = 'Could not get ETH context.'
 
 export default ({ api }) => {


### PR DESCRIPTION
## Description
There is a pagination bug on backend ingestion service that can result in transactions being missed. By raising the page sizes for both transaction list and reports, the odds of this bug occurring is drastically reduced.
