### PR TITLE
feat(ob): prevent rendeering of null for account number and bank name

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/template.tsx
@@ -62,7 +62,8 @@ const Template: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
 
   const bankAccountName =
     account && 'details' in account ? (
-      `${account.details?.bankName} ${account.details?.accountNumber}`
+      `${account.details?.bankName || ''} ${account.details?.accountNumber ||
+        ''}`
     ) : (
       <FormattedMessage id='copy.bank_account' defaultMessage='Bank Account' />
     )
@@ -100,7 +101,10 @@ const Template: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
               id='scenes.settings.general.account'
               defaultMessage='account'
             />{' '}
-            {account && 'details' in account && account.details.accountNumber}
+            {(account &&
+              'details' in account &&
+              account.details.accountNumber) ||
+              ''}
           </Text>
         </BankDetails>
       </FlyoutWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/RemoveBank/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/RemoveBank/template.tsx
@@ -43,10 +43,10 @@ type Props = OwnProps & LinkDispatchPropsType & LinkStatePropsType
 const Template: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
   const bankAccountName =
     props.account && 'details' in props.account
-      ? `${props.account.details?.bankName} ${props.account.details?.accountNumber}`
+      ? `${props.account.details?.bankName} ${props.account.details
+          ?.accountNumber || ''}`
       : `bank account`
 
-  // `${props.account.details?.bankName} ${props.account.details?.accountNumber}`
   return (
     <Wrapper>
       <RemoveBankFlyout>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/model.tsx
@@ -95,9 +95,8 @@ export const getPaymentMethod = (
         accountNumber: ''
       }
       const d = (bankAccount && bankAccount.details) || defaultBankInfo
-      return `${d.bankName} ${d.bankAccountType?.toLowerCase() || ''} ${
-        d.accountNumber
-      }`
+      return `${d.bankName} ${d.bankAccountType?.toLowerCase() ||
+        ''} ${d.accountNumber || ''}`
     default:
       return (
         <FormattedMessage

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/template.success.tsx
@@ -94,7 +94,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
                         id='scenes.settings.general.account'
                         defaultMessage='account'
                       />{' '}
-                      {account.details?.accountNumber}
+                      {account.details?.accountNumber || ''}
                     </Text>
                   </CardDetails>
                 </Child>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/SBOrderTx/model.tsx
@@ -37,7 +37,7 @@ export const getOrigin = (
       if (bankAccount) {
         const { details } = bankAccount
         return `${details.bankName} ${details.bankAccountType?.toLowerCase() ||
-          ''} ${details.accountNumber}`
+          ''} ${details.accountNumber || ''}`
       }
       return (
         <FormattedMessage


### PR DESCRIPTION
## Description (optional)
This PR resolve issue with possible render of null

## Testing Steps (optional)
Use wallet with EU based and for example connect Commerz bank then try to remove it you should not see null in name
![image](https://user-images.githubusercontent.com/67264242/115672037-6ce8c180-a34b-11eb-8282-8887e8327c8d.png)


