### PR TITLE
feat(ob): prevent infinite loading of QR code since order attributes are missing after repen of SB flow

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OpenBankingConnect/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OpenBankingConnect/index.tsx
@@ -20,6 +20,12 @@ const Connect = (props: Props) => {
       )
     }
   }
+  useEffect(() => {
+    const { id } = props.order
+    if (id) {
+      props.simpleBuyActions.pollSBOrder(id)
+    }
+  }, [])
 
   useEffect(fetchBank, [props.walletCurrency])
 
@@ -37,7 +43,8 @@ const mapStateToProps = (state: RootState) => ({
   account: selectors.components.brokerage.getAccount(state)
 })
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  brokerageActions: bindActionCreators(actions.components.brokerage, dispatch)
+  brokerageActions: bindActionCreators(actions.components.brokerage, dispatch),
+  simpleBuyActions: bindActionCreators(actions.components.simpleBuy, dispatch)
 })
 
 const connector = connect(mapStateToProps, mapDispatchToProps)


### PR DESCRIPTION
## Description (optional)
This PR improve loading of order details

## Testing Steps (optional)
create OB order close it after bank is linked, you will see banner that there is pending order, click on it and then QR screen will be stuck to infinite load since there are no order attribute details

