### PR TITLE
fix(simple buy): coin icon doesnt match designs

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CryptoSelection/CryptoSelector/CryptoItem/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CryptoSelection/CryptoSelector/CryptoItem/template.success.tsx
@@ -6,6 +6,7 @@ import { fiatToString } from 'blockchain-wallet-v4/src/exchange/currency'
 import { Title, Value } from 'components/Flyout'
 import { DisplayContainer } from 'components/SimpleBuy'
 import { media } from 'services/styles'
+import { hexToRgb } from 'utils/helpers'
 
 import PriceMovement from '../PriceMovement'
 import {
@@ -38,7 +39,7 @@ const DisplayTitle = styled(Title)`
   font-weight: 600;
   color: ${props => props.theme.grey800};
 `
-const IconBackground = styled.div<{ color: string }>`
+const IconBackground = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -46,7 +47,19 @@ const IconBackground = styled.div<{ color: string }>`
   height: 24px;
   border-radius: 24px;
   z-index: 100;
-  background: ${props => props.theme[props.color]};
+  background: white;
+`
+const StyledIcon = styled(Icon)<{ background: string }>`
+  background: rgba(${props => hexToRgb(props.theme[props.background])}, 0.15);
+  border-radius: 50%;
+
+  & :not(::before) {
+    opacity: 0.15;
+  }
+
+  &::before {
+    color: ${props => props.theme[props.background]};
+  }
 `
 const PlusMinusIconWrapper = styled.div`
   z-index: 10;
@@ -95,11 +108,11 @@ const Success: React.FC<Props> = props => {
             style={{ position: 'relative', left: '5px' }}
           />
           <PlusMinusIconWrapper>
-            <IconBackground color={coinType.coinCode}>
-              <Icon
+            <IconBackground>
+              <StyledIcon
                 name={props.orderType === 'BUY' ? 'plus' : 'minus'}
                 size='24px'
-                color='white'
+                background={coinType.coinCode}
               />
             </IconBackground>
           </PlusMinusIconWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/utils/helpers.js
+++ b/packages/blockchain-wallet-v4-frontend/src/utils/helpers.js
@@ -22,3 +22,26 @@ export const checkHasWebcam = () => {
 
 export const collapse = text =>
   text.length > 30 ? text.replace(/(.{17})..+/, '$1…') : text
+
+export const hexToRgb = colour => {
+  let r, g, b
+  if (colour.charAt(0) === '#') {
+    colour = colour.substr(1)
+  }
+  if (colour.length === 3) {
+    colour =
+      colour.substr(0, 1) +
+      colour.substr(0, 1) +
+      colour.substr(1, 2) +
+      colour.substr(1, 2) +
+      colour.substr(2, 3) +
+      colour.substr(2, 3)
+  }
+  r = colour.charAt(0) + '' + colour.charAt(1)
+  g = colour.charAt(2) + '' + colour.charAt(3)
+  b = colour.charAt(4) + '' + colour.charAt(5)
+  r = parseInt(r, 16)
+  g = parseInt(g, 16)
+  b = parseInt(b, 16)
+  return `${r}, ${g}, ${b}`
+}


### PR DESCRIPTION
## Description (optional)
Simple buy icon should look like this: ![image](https://user-images.githubusercontent.com/57680122/116621776-9039e080-a8f8-11eb-8e0c-7f9653268e18.png)
I also added a `hexToRbg()` util function that can be helpful for future devs

## Testing Steps (optional)
Open Simple buy for any coin, look in top right corner of modal.

