### PR TITLE
fix(btc): add transfer address for new chains

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/payment/btc/utils.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/btc/utils.ts
@@ -96,7 +96,7 @@ export const fromAccount = (network, state, index) => {
     // received to a receive chain, the backend will not lookup change.
     let shouldTransferToReceive = receiveIndex.getOrElse(0) === 0
     let receiveAddress = shouldTransferToReceive
-      ? HDAccount.getReceiveAddress(account, 0, network).getOrElse('')
+      ? HDAccount.getReceiveAddress(account, 0, network)
       : ''
 
     if (shouldTransferToReceive && receiveAddress) {


### PR DESCRIPTION
## Description (optional)
// When moving from one chain to another i.e legacy to segwit we must send to the receive chain so that backend services will search for funds on the change chain. Without funds received to a receive chain, the backend will not lookup change.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

