### PR TITLE
fix(mobile-auth): clear phoneKey on logout

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.js
@@ -587,15 +587,24 @@ export default ({ api, coreSagas }) => {
     const isEmailVerified = (yield select(
       selectors.core.settings.getEmailVerified
     )).getOrElse(0)
-    yield put(actions.modules.profile.clearSession())
-    yield put(actions.middleware.webSocket.rates.stopSocket())
-    yield put(actions.middleware.webSocket.coins.stopSocket())
-    yield put(actions.middleware.webSocket.xlm.stopStreams())
-    // only show browser de-auth page to accounts with verified email
-    isEmailVerified
-      ? yield put(actions.router.push('/logout'))
-      : yield logoutClearReduxStore()
-    yield put(actions.analytics.stopSession())
+    try {
+      yield put(actions.cache.disconnectChannelPhone())
+      yield put(actions.modules.profile.clearSession())
+      yield put(actions.middleware.webSocket.rates.stopSocket())
+      yield put(actions.middleware.webSocket.coins.stopSocket())
+      yield put(actions.middleware.webSocket.xlm.stopStreams())
+    } catch (e) {
+      yield put(actions.logs.logErrorMessage(logLocation, 'logout', e))
+    } finally {
+      // only show browser de-auth page to accounts with verified email
+      // delay allows for all actions to run and complete
+      // before clearing redux store
+      yield delay(100)
+      isEmailVerified
+        ? yield put(actions.router.push('/logout'))
+        : yield call(logoutClearReduxStore)
+      yield put(actions.analytics.stopSession())
+    }
   }
 
   const deauthorizeBrowser = function * () {


### PR DESCRIPTION
## Description (optional)
Mobile authorization fix:
Clears channelPhonePubkey from cache so user sees QR code when visiting login page.  

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

