### PR TITLE
feat(deposits): adds matomo tracking events for yapily/yodlee/fiat deposit flow

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/analytics/model.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/analytics/model.ts
@@ -32,6 +32,48 @@ export const AB_TEST_EVENTS = {
   EMAIL_VERIFIED: ['email_ab_test', 'email_verified']
 }
 
+export const FIAT_DEPOSIT_EVENTS = {
+  LINK_BANK_TRANSFER: ['deposit', 'click', 'bank_account_button'],
+  LINK_WIRE_TRANSFER: ['deposit', 'click', 'wire_transfer_button'],
+  SELECT_DEPOSIT_METHOD: ['deposit', 'click', 'select_deposit_method_button'],
+  SELECT_BANK_OPTION: ['deposit', 'click', 'bank_option_item'],
+  DEPOSIT_CONTINUE: ['deposit', 'click', 'continue_button'],
+  DEPOSIT_CONFIRM: ['deposit', 'click', 'confirm_button'],
+  DEPOSIT_CANCEL: ['deposit', 'click', 'cancel_button'],
+  SELECT_YAPILY_INSTITUTION: ['deposit', 'click', 'yapily_bank_institution'],
+  ACCEPT_YAPILY_AIS_AGREEMENT: [
+    'deposit',
+    'click',
+    'yapily_agreement_accept_button'
+  ],
+  DECLINE_YAPILY_AIS_AGREEMENT: [
+    'deposit',
+    'click',
+    'yapily_agreement_decline_button'
+  ],
+  YAPILY_CONT_IN_BROWSER: [
+    'deposit',
+    'click',
+    'yapily_ais_continue_in_browser'
+  ],
+  ACCEPT_YAPILY_PIS_AGREEMENT: [
+    'deposit',
+    'click',
+    'yapily_pis_agreement_accept'
+  ],
+  DECLINE_YAPILY_PIS_AGREEMENT: [
+    'deposit',
+    'click',
+    'yapily_pis_agreement_decline'
+  ],
+  YAPILY_CONT_IN_BROWSER_PIS: [
+    'deposit',
+    'click',
+    'yapily_pis_continue_in_browser'
+  ],
+  YODLEE_ADD_BANK_CONT: ['deposit', 'click', 'yodlee_add_bank_continue']
+}
+
 export const PREFERENCE_EVENTS = {
   GENERAL: {
     ENABLE_BTC_LINKS: 'enable_btc_links'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Authorize/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Authorize/index.tsx
@@ -24,6 +24,7 @@ const mapStateToProps = (state: RootState) => ({
   data: getData(state)
 })
 const mapDispatchToProps = (dispatch: Dispatch): LinkDispatchPropsType => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   brokerageActions: bindActionCreators(actions.components.brokerage, dispatch),
   simpleBuyActions: bindActionCreators(actions.components.simpleBuy, dispatch)
 })
@@ -31,6 +32,7 @@ const mapDispatchToProps = (dispatch: Dispatch): LinkDispatchPropsType => ({
 const connector = connect(mapStateToProps, mapDispatchToProps)
 
 type LinkDispatchPropsType = {
+  analyticsActions: typeof actions.analytics
   brokerageActions: typeof actions.components.brokerage
   simpleBuyActions: typeof actions.components.simpleBuy
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Authorize/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Authorize/template.success.tsx
@@ -5,9 +5,15 @@ import styled from 'styled-components'
 
 import { Button, Icon, Image, Text } from 'blockchain-info-components'
 import { FlyoutWrapper, Row, Title } from 'components/Flyout'
+import { model } from 'data'
 import { AddBankStepType } from 'data/types'
 
 import { Props as _P } from '.'
+
+const {
+  ACCEPT_YAPILY_AIS_AGREEMENT,
+  DECLINE_YAPILY_AIS_AGREEMENT
+} = model.analytics.FIAT_DEPOSIT_EVENTS
 
 const Wrapper = styled.div`
   display: flex;
@@ -223,11 +229,12 @@ const Success = (props: Props) => {
           type='submit'
           fullwidth
           height='48px'
-          onClick={() =>
+          onClick={() => {
             props.brokerageActions.setAddBankStep({
               addBankStep: AddBankStepType.ADD_BANK_CONNECT
             })
-          }
+            props.analyticsActions.logEvent(ACCEPT_YAPILY_AIS_AGREEMENT)
+          }}
         >
           <FormattedMessage id='copy.approve' defaultMessage='Approve' />
         </Button>
@@ -239,7 +246,10 @@ const Success = (props: Props) => {
           height='48px'
           color='red400'
           style={{ marginTop: '16px' }}
-          onClick={() => props.handleClose()}
+          onClick={() => {
+            props.handleClose()
+            props.analyticsActions.logEvent(DECLINE_YAPILY_AIS_AGREEMENT)
+          }}
         >
           <FormattedMessage id='copy.deny' defaultMessage='Deny' />
         </Button>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Connect/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Connect/index.tsx
@@ -42,6 +42,7 @@ const mapStateToProps = (state: RootState) => ({
   account: selectors.components.brokerage.getAccount(state)
 })
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   brokerageActions: bindActionCreators(actions.components.brokerage, dispatch)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Connect/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Connect/template.success.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
+import { model } from 'data'
+
 import {
   BankWaitIndicator,
   BankWrapper,
@@ -12,6 +14,8 @@ import {
   Section
 } from '../../../../components'
 import { OwnProps, Props as _P, SuccessStateType } from '.'
+
+const { YAPILY_CONT_IN_BROWSER } = model.analytics.FIAT_DEPOSIT_EVENTS
 
 type Props = OwnProps & SuccessStateType & _P
 
@@ -35,6 +39,9 @@ const Success = (props: Props) => {
         <Section>
           <LinkViaDesktop
             authUrl={props.account?.attributes?.authorisationUrl as string}
+            onClick={() => {
+              props.analyticsActions.logEvent(YAPILY_CONT_IN_BROWSER)
+            }}
           />
           <BankWaitIndicator
             qrCode={props.account?.attributes?.qrcodeUrl as string}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/SelectBank/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/SelectBank/index.tsx
@@ -37,6 +37,7 @@ const mapStateToProps = (state: RootState) => ({
 })
 
 const mapDispatchToProps = (dispatch: Dispatch): LinkDispatchPropsType => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   simpleBuyActions: bindActionCreators(actions.components.simpleBuy, dispatch),
   brokerageActions: bindActionCreators(actions.components.brokerage, dispatch)
 })
@@ -48,6 +49,7 @@ export type OwnProps = {
   setYapilyBankId: (string) => void
 }
 export type LinkDispatchPropsType = {
+  analyticsActions: typeof actions.analytics
   brokerageActions: typeof actions.components.brokerage
   simpleBuyActions: typeof actions.components.simpleBuy
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/SelectBank/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/SelectBank/template.success.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 
+import { model } from 'data'
 import { AddBankStepType, OBInstitution } from 'data/types'
 
 import {
@@ -12,6 +13,8 @@ import {
   SimpleBankRow
 } from '../../../../components'
 import { LinkDispatchPropsType, OwnProps, SuccessStateType } from '.'
+
+const { SELECT_YAPILY_INSTITUTION } = model.analytics.FIAT_DEPOSIT_EVENTS
 
 type Props = LinkDispatchPropsType & OwnProps & SuccessStateType
 
@@ -54,6 +57,7 @@ const Success = (props: Props) => {
               props.brokerageActions.setAddBankStep({
                 addBankStep: AddBankStepType.ADD_BANK_AUTHORIZE
               })
+              props.analyticsActions.logEvent(SELECT_YAPILY_INSTITUTION)
             }}
           />
         )

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYodlee/Add/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYodlee/Add/index.tsx
@@ -57,6 +57,7 @@ const mapStateToProps = (state: RootState) => ({
 })
 
 const mapDispatchToProps = (dispatch: Dispatch): LinkDispatchPropsType => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   simpleBuyActions: bindActionCreators(actions.components.simpleBuy, dispatch),
   brokerageActions: bindActionCreators(actions.components.brokerage, dispatch)
 })
@@ -67,6 +68,7 @@ type OwnProps = {
   handleClose: () => void
 }
 type LinkDispatchPropsType = {
+  analyticsActions: typeof actions.analytics
   brokerageActions: typeof actions.components.brokerage
   simpleBuyActions: typeof actions.components.simpleBuy
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYodlee/Add/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYodlee/Add/template.success.tsx
@@ -6,10 +6,13 @@ import styled from 'styled-components'
 import { Button, Icon, Image, Link, Text } from 'blockchain-info-components'
 import { FlyoutWrapper } from 'components/Flyout'
 import { FormGroup } from 'components/Form'
+import { model } from 'data'
 import { SBAddCardErrorType } from 'data/types'
 
 import { NavText } from '../../../../components'
 import { Props as _P, SuccessStateType } from '.'
+
+const { YODLEE_ADD_BANK_CONT } = model.analytics.FIAT_DEPOSIT_EVENTS
 
 const CustomFlyoutWrapper = styled(FlyoutWrapper)`
   height: 100%;
@@ -51,6 +54,7 @@ const TermsText = styled(Text)`
 `
 
 const Success: React.FC<InjectedFormProps<{}, Props, ErrorType> & Props> = ({
+  analyticsActions,
   handleBack,
   handleSubmit,
   submitting
@@ -112,6 +116,7 @@ const Success: React.FC<InjectedFormProps<{}, Props, ErrorType> & Props> = ({
           <Button
             nature='primary'
             data-e2e='linkBankContinue'
+            onClick={() => analyticsActions.logEvent(YODLEE_ADD_BANK_CONT)}
             height='48px'
             size='16px'
             type='submit'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/Authorize/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/Authorize/index.tsx
@@ -13,9 +13,14 @@ import {
   SupportedWalletCurrenciesType
 } from 'blockchain-wallet-v4/src/types'
 import { FlyoutWrapper, Row, Title, Value } from 'components/Flyout'
-import { actions, selectors } from 'data'
+import { actions, model,selectors } from 'data'
 import { RootState } from 'data/rootReducer'
 import { BankDWStepType } from 'data/types'
+
+const {
+  ACCEPT_YAPILY_PIS_AGREEMENT,
+  DECLINE_YAPILY_PIS_AGREEMENT
+} = model.analytics.FIAT_DEPOSIT_EVENTS
 
 const Wrapper = styled.div`
   display: flex;
@@ -310,11 +315,12 @@ const Authorize = (props: Props) => {
           type='submit'
           fullwidth
           height='48px'
-          onClick={() =>
+          onClick={() => {
             props.brokerageActions.setDWStep({
               dwStep: BankDWStepType.CONFIRM
             })
-          }
+            props.analyticsActions.logEvent(ACCEPT_YAPILY_PIS_AGREEMENT)
+          }}
         >
           <FormattedMessage id='copy.approve' defaultMessage='Approve' />
         </Button>
@@ -326,7 +332,10 @@ const Authorize = (props: Props) => {
           height='48px'
           color='red400'
           style={{ marginTop: '16px' }}
-          onClick={() => props.handleClose()}
+          onClick={() => {
+            props.handleClose()
+            props.analyticsActions.logEvent(DECLINE_YAPILY_PIS_AGREEMENT)
+          }}
         >
           <FormattedMessage id='copy.deny' defaultMessage='Deny' />
         </Button>
@@ -345,6 +354,7 @@ const mapStateToProps = (state: RootState) => ({
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   brokerageActions: bindActionCreators(actions.components.brokerage, dispatch)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/BankList/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/BankList/template.success.tsx
@@ -9,11 +9,14 @@ import {
 } from 'blockchain-wallet-v4/src/types'
 import { AddNewButton } from 'components/Brokerage'
 import { FlyoutWrapper } from 'components/Flyout'
+import { model } from 'data'
 import { BankDWStepType, BankTransferAccountType } from 'data/types'
 import { getBankLogoImageName } from 'services/images'
 
 import { Bank, BankWire } from '../../model'
 import { Props as _P } from '.'
+
+const { SELECT_BANK_OPTION } = model.analytics.FIAT_DEPOSIT_EVENTS
 
 type OwnProps = {
   account: BankTransferAccountType | undefined
@@ -85,6 +88,7 @@ const BankList = (props: Props) => {
               props.brokerageActions.setDWStep({
                 dwStep: BankDWStepType.ENTER_AMOUNT
               })
+              props.analyticsActions.logEvent(SELECT_BANK_OPTION)
             }}
           />
         ))}
@@ -96,6 +100,7 @@ const BankList = (props: Props) => {
               props.brokerageActions.setDWStep({
                 dwStep: BankDWStepType.WIRE_INSTRUCTIONS
               })
+              props.analyticsActions.logEvent(SELECT_BANK_OPTION)
             }}
             type={'DEPOSIT'}
           />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/Confirm/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/Confirm/index.tsx
@@ -23,6 +23,7 @@ const mapStateToProps = (state: RootState) => ({
 })
 
 export const mapDispatchToProps = (dispatch: Dispatch) => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   brokerageActions: bindActionCreators(actions.components.brokerage, dispatch)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/Confirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/Confirm/template.success.tsx
@@ -7,9 +7,12 @@ import { Button, HeartbeatLoader, Icon, Text } from 'blockchain-info-components'
 import { fiatToString } from 'blockchain-wallet-v4/src/exchange/currency'
 import { FiatType } from 'blockchain-wallet-v4/src/types'
 import { FlyoutWrapper } from 'components/Flyout'
+import { model } from 'data'
 import { BankDWStepType, BankPartners } from 'data/types'
 
 import { FormattedBank, LineItemText } from './model'
+
+const { DEPOSIT_CANCEL, DEPOSIT_CONFIRM } = model.analytics.FIAT_DEPOSIT_EVENTS
 
 const Wrapper = styled.div`
   height: 100%;
@@ -132,6 +135,7 @@ const Success = props => {
           onClick={() => {
             setSubmitting(true)
             props.brokerageActions.createFiatDeposit()
+            props.analyticsActions.logEvent(DEPOSIT_CONFIRM)
           }}
           fullwidth
           disabled={submitting}
@@ -158,7 +162,10 @@ const Success = props => {
           size='16px'
           height='48px'
           nature='light-red'
-          onClick={props.handleClose}
+          onClick={() => {
+            props.handleClose()
+            props.analyticsActions.logEvent(DEPOSIT_CANCEL)
+          }}
           fullwidth
           style={{ marginTop: '16px' }}
         >

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/DepositMethods/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/DepositMethods/template.success.tsx
@@ -8,6 +8,7 @@ import {
   SBPaymentMethodType
 } from 'blockchain-wallet-v4/src/types'
 import { FlyoutWrapper } from 'components/Flyout'
+import { model } from 'data'
 import {
   AddBankStepType,
   BankDWStepType,
@@ -18,6 +19,11 @@ import {
 import BankWire from '../../../../SimpleBuy/PaymentMethods/Methods/BankWire'
 import { mapDispatchToProps, Props as _P } from '.'
 import BankDeposit from './BankDeposit'
+
+const {
+  LINK_BANK_TRANSFER,
+  LINK_WIRE_TRANSFER
+} = model.analytics.FIAT_DEPOSIT_EVENTS
 
 const Wrapper = styled.section`
   display: flex;
@@ -96,6 +102,7 @@ const getType = (value: SBPaymentMethodType) => {
 
 const Success = ({
   addNew,
+  analyticsActions,
   brokerageActions,
   close,
   fiatCurrency,
@@ -158,6 +165,7 @@ const Success = ({
                   dwStep: BankDWStepType.ENTER_AMOUNT
                 })
               }
+              analyticsActions.logEvent(LINK_BANK_TRANSFER)
             }}
             text={getType(bankTransfer)}
             value={bankTransfer}
@@ -166,11 +174,12 @@ const Success = ({
         {bankWire && (
           <BankWire
             icon={getIcon(bankWire)}
-            onClick={() =>
+            onClick={() => {
               brokerageActions.setDWStep({
                 dwStep: BankDWStepType.WIRE_INSTRUCTIONS
               })
-            }
+              analyticsActions.logEvent(LINK_WIRE_TRANSFER)
+            }}
             text={getType(bankWire)}
             value={bankWire}
           />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/EnterAmount/template.success.tsx
@@ -12,6 +12,7 @@ import { AmountTextBox } from 'components/Exchange'
 import { FlyoutWrapper } from 'components/Flyout'
 import { Form } from 'components/Form'
 import { DisplayPaymentIcon } from 'components/SimpleBuy'
+import { model } from 'data'
 import { convertBaseToStandard } from 'data/components/exchange/services'
 import {
   AddBankStepType,
@@ -35,6 +36,11 @@ import {
 import { LinkStatePropsType, Props as _P, SuccessStateType } from '.'
 import { getDefaultMethod, getText } from './model'
 import { maximumAmount, minimumAmount } from './validation'
+
+const {
+  DEPOSIT_CONTINUE,
+  SELECT_DEPOSIT_METHOD
+} = model.analytics.FIAT_DEPOSIT_EVENTS
 
 const CustomForm = styled(Form)`
   height: 100%;
@@ -198,6 +204,7 @@ const Amount = ({ fiatCurrency }) => {
 }
 
 const Account = ({
+  analyticsActions,
   bankTransferAccounts,
   brokerageActions,
   defaultMethod,
@@ -229,6 +236,7 @@ const Account = ({
             dwStep: BankDWStepType.BANK_LIST
           })
         }
+        analyticsActions.logEvent(SELECT_DEPOSIT_METHOD)
       }}
       isMethod={!!dMethod}
     >
@@ -249,7 +257,13 @@ const Account = ({
   )
 }
 
-const NextButton = ({ defaultMethod, invalid, pristine, submitting }) => {
+const NextButton = ({
+  analyticsActions,
+  defaultMethod,
+  invalid,
+  pristine,
+  submitting
+}) => {
   return (
     <Button
       data-e2e='submitDepositAmount'
@@ -259,6 +273,7 @@ const NextButton = ({ defaultMethod, invalid, pristine, submitting }) => {
       type='submit'
       fullwidth
       disabled={invalid || pristine || submitting || !defaultMethod}
+      onClick={() => analyticsActions.logEvent(DEPOSIT_CONTINUE)}
     >
       {submitting ? (
         <HeartbeatLoader height='16px' width='16px' color='white' />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/OpenBankingConnect/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/OpenBankingConnect/index.tsx
@@ -40,6 +40,7 @@ const mapStateToProps = (state: RootState) => ({
   }
 })
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   brokerageActions: bindActionCreators(actions.components.brokerage, dispatch)
 })
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/OpenBankingConnect/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/OpenBankingConnect/template.success.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
+import { model } from 'data'
+
 import {
   BankWaitIndicator,
   BankWrapper,
@@ -12,6 +14,8 @@ import {
   Section
 } from '../../../../components'
 import { Props as _P } from '.'
+
+const { YAPILY_CONT_IN_BROWSER_PIS } = model.analytics.FIAT_DEPOSIT_EVENTS
 
 type Props = _P
 
@@ -40,7 +44,12 @@ const Success = (props: Props) => {
         <ScanWithPhone qrCode={qrCode} />
         <Hr />
         <Section>
-          <LinkViaDesktop authUrl={authUrl} />
+          <LinkViaDesktop
+            authUrl={authUrl}
+            onClick={() => {
+              props.analyticsActions.logEvent(YAPILY_CONT_IN_BROWSER_PIS)
+            }}
+          />
           <BankWaitIndicator qrCode={qrCode} />
         </Section>
       </LinkOptionsWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/components/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/components/index.tsx
@@ -141,7 +141,13 @@ const StyledButton = styled(Button)`
   margin: 20px 0 0;
   display: unset;
 `
-const LinkViaDesktop = ({ authUrl }: { authUrl?: string }) => {
+const LinkViaDesktop = ({
+  authUrl,
+  onClick = () => {}
+}: {
+  authUrl?: string
+  onClick?: () => void
+}) => {
   if (!authUrl) return null
   return (
     <Section>
@@ -156,6 +162,7 @@ const LinkViaDesktop = ({ authUrl }: { authUrl?: string }) => {
         nature='empty-blue'
         onClick={() => {
           window.open(authUrl, '_blank')
+          onClick() // additional callback from implementing component
         }}
       >
         <FormattedMessage


### PR DESCRIPTION
## Description (optional)
Adds matomo events to the fiat deposit flow for both yapily and yodlee

## Testing Steps (optional)
Go through a fiat deposit with both a USD and EUR/GBP enabled account and watch for the wallet helper matomo events in the network inspector.

