### PR TITLE
feat(buy): we do not need to convert to base since amount is already converted to base

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
@@ -122,12 +122,8 @@ export const getMaxMin = (
             )
           }
 
-          const defaultLimitMaxAmount = convertBaseToStandard(
-            'FIAT',
-            limitMaxAmount
-          )
-          if (Number(defaultMax.FIAT) > Number(defaultLimitMaxAmount)) {
-            defaultMax.FIAT = defaultLimitMaxAmount
+          if (Number(defaultMax.FIAT) > limitMaxAmount) {
+            defaultMax.FIAT = String(limitMaxAmount)
           }
 
           if (!allValues) return defaultMax
@@ -193,12 +189,8 @@ export const getMaxMin = (
             )
           }
 
-          const defaultLimitMinAmount = convertBaseToStandard(
-            'FIAT',
-            limitMinAmount
-          )
-          if (Number(defaultMin.FIAT) < Number(defaultLimitMinAmount)) {
-            defaultMin.FIAT = defaultLimitMinAmount
+          if (Number(defaultMin.FIAT) < limitMinAmount) {
+            defaultMin.FIAT = String(limitMinAmount)
           }
 
           if (!allValues) return defaultMin


### PR DESCRIPTION
## Description (optional)
This PR fix max/min amount in c

## Testing Steps (optional)
Try to buy some crypto with and without method selected, max amount should be aligned to API response not minor one

![image](https://user-images.githubusercontent.com/67264242/117647767-b596dc00-b18d-11eb-95a5-020f6b5227eb.png)

![image](https://user-images.githubusercontent.com/67264242/117647802-bfb8da80-b18d-11eb-8a3c-534a3aac80fb.png)


