### PR TITLE
feat(brokerage): implemented new buy checkout screen for ACH/OB flows

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -1401,6 +1401,7 @@ type MessagesType = {
   'modals.simplebuy.checkout.larger_amount.info': 'After completing this transaction, upgrade to Gold level to unlock higher transaction limits and more payment methods.'
   'modals.simplebuy.checkoutconfirm': 'Checkout'
   'modals.simplebuy.confirm.ach_lock': 'For your security, buy orders with a bank account are subject to a holding period of up to {days} days. You can Swap or Sell during this time. We will notify you once the funds are fully available.'
+  'modals.simplebuy.confirm.ach_ob_lock': 'Your final amount might change due to market activity. An initial hold period of {days} days will be applied to your funds. You can Buy, Sell, and Swap during this period.'
   'modals.simplebuy.confirm.activity': 'Your final amount may change due to market activity.'
   'modals.simplebuy.confirm.activity_card11': 'Your final amount might change due to market activity. For your security, buy orders with a bank account are subject up to a 14 day holding period. You can Swap or Sell during this time. We will notify you once the funds are fully available.'
   'modals.simplebuy.confirm.activity_card2': 'Your crypto will be available to be withdrawn within <b>{days} days</b>.'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
@@ -29,7 +29,11 @@ import {
 } from 'data/components/simpleBuy/model'
 import { BankPartners, BankTransferAccountType } from 'data/types'
 
-import { displayFiat, getPaymentMethod } from '../model'
+import {
+  displayFiat,
+  getPaymentMethod,
+  getPaymentMethodDetails
+} from '../model'
 import { Props as OwnProps, SuccessStateType } from '.'
 
 const CustomForm = styled(Form)`
@@ -100,6 +104,10 @@ const IconWrapper = styled.div`
   justify-content: center;
   cursor: pointer;
   margin-left: 4px;
+`
+
+const RowTextWrapper = styled.div`
+  text-align: right;
 `
 
 const RowText = styled(Text)`
@@ -230,6 +238,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           </div>
         </Amount>
       </FlyoutWrapper>
+
       <RowItem>
         <RowItemContainer>
           <TopRow>
@@ -243,22 +252,20 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
                   }}
                 />
               </RowText>
-              {isCardPayment && (
-                <IconWrapper>
-                  <Icon
-                    name='question-in-circle-filled'
-                    size='16px'
-                    color={isActiveCoinTooltip ? 'blue600' : 'grey300'}
-                    onClick={() => setCoinToolTip(!isActiveCoinTooltip)}
-                  />
-                </IconWrapper>
-              )}
+              <IconWrapper>
+                <Icon
+                  name='question-in-circle-filled'
+                  size='16px'
+                  color={isActiveCoinTooltip ? 'blue600' : 'grey300'}
+                  onClick={() => setCoinToolTip(!isActiveCoinTooltip)}
+                />
+              </IconWrapper>
             </RowIcon>
             <RowText data-e2e='sbExchangeRate'>
               {displayFiat(props.order, props.supportedCoins, props.quote.rate)}
             </RowText>
           </TopRow>
-          {isCardPayment && isActiveCoinTooltip && (
+          {isActiveCoinTooltip && (
             <ToolTipText>
               <Text size='12px' weight={500} color='grey600'>
                 <TextGroup inline>
@@ -286,6 +293,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           )}
         </RowItemContainer>
       </RowItem>
+
       <RowItem>
         <RowText>
           <FormattedMessage
@@ -294,16 +302,12 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           />
         </RowText>
         <RowText>
-          {isCardPayment ? (
-            <>
-              {cardDetails?.card?.label}
-              <AdditionalText>
-                {`${cardDetails?.card?.type} ${cardDetails?.card?.number}`}
-              </AdditionalText>
-            </>
-          ) : (
-            getPaymentMethod(props.order, props.supportedCoins, bankAccount)
-          )}
+          <RowTextWrapper>
+            {getPaymentMethod(props.order, props.supportedCoins, bankAccount)}
+            <AdditionalText>
+              {getPaymentMethodDetails(props.order, bankAccount, cardDetails)}
+            </AdditionalText>
+          </RowTextWrapper>
         </RowText>
       </RowItem>
       <RowItem>
@@ -314,79 +318,87 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           {displayFiat(props.order, props.supportedCoins, String(purchase))}
         </RowText>
       </RowItem>
-      <RowItem>
-        <RowItemContainer>
-          <TopRow>
-            <RowIcon>
-              <RowText>
-                {isCardPayment ? (
-                  <FormattedMessage
-                    id='copy.card_fee'
-                    defaultMessage='Card Fee'
-                  />
-                ) : (
-                  <FormattedMessage id='copy.fee' defaultMessage='Fee' />
+      {!isBankLink && (
+        <RowItem>
+          <RowItemContainer>
+            <TopRow>
+              <RowIcon>
+                <RowText>
+                  {isCardPayment ? (
+                    <FormattedMessage
+                      id='copy.card_fee'
+                      defaultMessage='Card Fee'
+                    />
+                  ) : (
+                    <FormattedMessage id='copy.fee' defaultMessage='Fee' />
+                  )}
+                </RowText>
+                {isCardPayment && (
+                  <IconWrapper>
+                    <Icon
+                      name='question-in-circle-filled'
+                      size='16px'
+                      color={isActiveFeeTooltip ? 'blue600' : 'grey300'}
+                      onClick={() => setFeeToolTip(!isActiveFeeTooltip)}
+                    />
+                  </IconWrapper>
                 )}
+              </RowIcon>
+              <RowText data-e2e='sbFee'>
+                {props.order.fee
+                  ? displayFiat(
+                      props.order,
+                      props.supportedCoins,
+                      props.order.fee
+                    )
+                  : `${displayFiat(
+                      props.order,
+                      props.supportedCoins,
+                      props.quote.fee
+                    )} ${props.order.inputCurrency}`}
               </RowText>
-              {isCardPayment && (
-                <IconWrapper>
-                  <Icon
-                    name='question-in-circle-filled'
-                    size='16px'
-                    color={isActiveFeeTooltip ? 'blue600' : 'grey300'}
-                    onClick={() => setFeeToolTip(!isActiveFeeTooltip)}
-                  />
-                </IconWrapper>
-              )}
-            </RowIcon>
-            <RowText data-e2e='sbFee'>
-              {props.order.fee
-                ? displayFiat(
-                    props.order,
-                    props.supportedCoins,
-                    props.order.fee
-                  )
-                : `${displayFiat(
-                    props.order,
-                    props.supportedCoins,
-                    props.quote.fee
-                  )} ${props.order.inputCurrency}`}
-            </RowText>
-          </TopRow>
-          {isCardPayment && isActiveFeeTooltip && (
-            <ToolTipText>
-              <Text size='12px' weight={500} color='grey600'>
-                <TextGroup inline>
-                  <Text size='14px'>
-                    <FormattedMessage
-                      id='modals.simplebuy.paying_with_card'
-                      defaultMessage='Blockchain.com requires a fee when paying with a card.'
-                    />
-                  </Text>
-                  {/* TODO: update link */}
-                  <Link
-                    href='https://blockchain.zendesk.com/hc/en-us/sections/360002593291-Setting-Up-Lockbox'
-                    size='14px'
-                    rel='noopener noreferrer'
-                    target='_blank'
-                  >
-                    <FormattedMessage
-                      id='modals.simplebuy.summary.learn_more'
-                      defaultMessage='Learn more'
-                    />
-                  </Link>
-                </TextGroup>
-              </Text>
-            </ToolTipText>
-          )}
-        </RowItemContainer>
-      </RowItem>
+            </TopRow>
+            {isCardPayment && isActiveFeeTooltip && (
+              <ToolTipText>
+                <Text size='12px' weight={500} color='grey600'>
+                  <TextGroup inline>
+                    <Text size='14px'>
+                      <FormattedMessage
+                        id='modals.simplebuy.paying_with_card'
+                        defaultMessage='Blockchain.com requires a fee when paying with a card.'
+                      />
+                    </Text>
+                    {/* TODO: update link */}
+                    <Link
+                      href='https://blockchain.zendesk.com/hc/en-us/sections/360002593291-Setting-Up-Lockbox'
+                      size='14px'
+                      rel='noopener noreferrer'
+                      target='_blank'
+                    >
+                      <FormattedMessage
+                        id='modals.simplebuy.summary.learn_more'
+                        defaultMessage='Learn more'
+                      />
+                    </Link>
+                  </TextGroup>
+                </Text>
+              </ToolTipText>
+            )}
+          </RowItemContainer>
+        </RowItem>
+      )}
       <RowItem>
         <RowText>
           <FormattedMessage id='copy.total' defaultMessage='Total' />
         </RowText>
-        <RowText data-e2e='sbFiatBuyAmount'>{totalAmount}</RowText>
+        <RowText>
+          <RowTextWrapper>
+            <div data-e2e='sbFiatBuyAmount'>{totalAmount}</div>
+            <AdditionalText>{`${baseAmount} ${baseCurrency}`}</AdditionalText>
+          </RowTextWrapper>
+        </RowText>
       </RowItem>
+
       <Bottom>
         <Info style={{ marginBottom: '12px' }}>
           {requiresTerms ? (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
@@ -400,23 +400,25 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
       </RowItem>
 
       <Bottom>
-        <Info style={{ marginBottom: '12px' }}>
-          {requiresTerms ? (
-            <Text size='12px' weight={500} color='grey900'>
-              <FormattedHTMLMessage
-                id='modals.simplebuy.confirm.activity_card11'
-                defaultMessage='Your final amount might change due to market activity. For your security, buy orders with a bank account are subject up to a 14 day holding period. You can Swap or Sell during this time. We will notify you once the funds are fully available.'
-              />
-            </Text>
-          ) : (
-            <Text size='12px' weight={500} color='grey900'>
-              <FormattedMessage
-                id='modals.simplebuy.confirm.activity'
-                defaultMessage='Your final amount may change due to market activity.'
-              />
-            </Text>
-          )}
-        </Info>
+        {!isBankLink && (
+          <Info style={{ marginBottom: '12px' }}>
+            {requiresTerms ? (
+              <Text size='12px' weight={500} color='grey900'>
+                <FormattedHTMLMessage
+                  id='modals.simplebuy.confirm.activity_card11'
+                  defaultMessage='Your final amount might change due to market activity. For your security, buy orders with a bank account are subject up to a 14 day holding period. You can Swap or Sell during this time. We will notify you once the funds are fully available.'
+                />
+              </Text>
+            ) : (
+              <Text size='12px' weight={500} color='grey900'>
+                <FormattedMessage
+                  id='modals.simplebuy.confirm.activity'
+                  defaultMessage='Your final amount may change due to market activity.'
+                />
+              </Text>
+            )}
+          </Info>
+        )}
 
         {showLock && props.order.paymentType === 'USER_CARD' && (
           <Info>
@@ -456,8 +458,8 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = props => {
           <Info>
             <Text size='12px' weight={500} color='grey900'>
               <FormattedMessage
-                id='modals.simplebuy.confirm.ach_lock'
-                defaultMessage='For your security, buy orders with a bank account are subject to a holding period of up to {days} days. You can Swap or Sell during this time. We will notify you once the funds are fully available.'
+                id='modals.simplebuy.confirm.ach_ob_lock'
+                defaultMessage='Your final amount might change due to market activity. An initial hold period of {days} days will be applied to your funds. You can Buy, Sell, and Swap during this period.'
                 values={{ days: days }}
               />
             </Text>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/model.tsx
@@ -5,6 +5,7 @@ import { fiatToString } from 'blockchain-wallet-v4/src/exchange/currency'
 import {
   CoinType,
   FiatType,
+  SBCardType,
   SBOrderActionType,
   SBOrderType,
   SupportedWalletCurrenciesType,
@@ -95,8 +96,7 @@ export const getPaymentMethod = (
         accountNumber: ''
       }
       const d = (bankAccount && bankAccount.details) || defaultBankInfo
-      return `${d.bankName} ${d.bankAccountType?.toLowerCase() ||
-        ''} ${d.accountNumber || ''}`
+      return `${d.bankName}`
     default:
       return (
         <FormattedMessage
@@ -118,4 +118,26 @@ export const displayFiat = (
     unit: counterCurrency as FiatType,
     value: convertBaseToStandard('FIAT', amt)
   })
+}
+
+export const getPaymentMethodDetails = (
+  order: SBOrderType,
+  bankAccount: BankTransferAccountType,
+  cardDetails: SBCardType | null
+) => {
+  switch (order.paymentType) {
+    case 'PAYMENT_CARD':
+      return `${cardDetails?.card?.type} ${cardDetails?.card?.number}`
+    case 'BANK_TRANSFER':
+      const defaultBankInfo = {
+        bankName: 'Bank Transfer',
+        bankAccountType: '',
+        accountNumber: ''
+      }
+      const d = (bankAccount && bankAccount.details) || defaultBankInfo
+      return `${d.bankAccountType?.toLowerCase() || ''} ${d.accountNumber ||
+        ''}`
+    default:
+      return null
+  }
 }


### PR DESCRIPTION
## Description (optional)
This PR implements new checkout screen for ACH and open banking

## Testing Steps (optional)
Try Buy flow and buy some crypto, checkout screen should looks like



![image](https://user-images.githubusercontent.com/67264242/118126300-6f918080-b3f8-11eb-8c84-1f5c19af75b1.png)

