### PR TITLE
fix(withdrawals): check for usd when filtering out payment methods for the openbanking invite list

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/BankPicker/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/BankPicker/selectors.ts
@@ -20,7 +20,7 @@ export const getData = (state: RootState, ownProps: OwnProps) => {
       openBanking: false
     } as InvitationsType)
 
-  if (!invitations.openBanking) {
+  if (!invitations.openBanking && ownProps.fiatCurrency !== 'USD') {
     defaultMethodR = undefined
     bankTransferAccountsR = Remote.Success([])
   }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/EnterAmount/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/EnterAmount/selectors.ts
@@ -39,7 +39,7 @@ export const getData = (state: RootState, ownProps: OwnProps) => {
       openBanking: false
     } as InvitationsType)
 
-  if (!invitations.openBanking) {
+  if (!invitations.openBanking && ownProps.fiatCurrency !== 'USD') {
     defaultMethodR = undefined
     bankTransferAccountsR = Remote.Success([])
   }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/WithdrawalMethods/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Withdraw/WithdrawalMethods/selectors.ts
@@ -35,7 +35,9 @@ export const getData = state => {
       paymentMethods:
         (!invitations.openBanking && {
           ...paymentMethods,
-          methods: paymentMethods.methods.filter(m => m.type === 'BANK_ACCOUNT')
+          methods: paymentMethods.methods.filter(m => {
+            return m.type === 'BANK_ACCOUNT' || m.currency === 'USD'
+          })
         }) ||
         paymentMethods,
       userData,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/PaymentMethods/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/PaymentMethods/selectors.ts
@@ -45,7 +45,10 @@ export const getData = state => {
         (!invitations.openBanking && {
           ...paymentMethods,
           methods: paymentMethods.methods.filter(
-            m => m.type === 'BANK_ACCOUNT' || m.type === 'PAYMENT_CARD'
+            m =>
+              m.type === 'BANK_ACCOUNT' ||
+              m.type === 'PAYMENT_CARD' ||
+              m.currency === 'USD'
           )
         }) ||
         paymentMethods,

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/selectors.ts
@@ -20,7 +20,6 @@ export const getData = (state: RootState) => {
     .getOrElse({
       openBanking: false
     } as InvitationsType)
-
   return lift(
     (
       bankAccounts: ExtractSuccess<typeof bankAccountsR>,
@@ -30,7 +29,9 @@ export const getData = (state: RootState) => {
       paymentMethods:
         (!invitations.openBanking && {
           ...paymentMethods,
-          methods: paymentMethods.methods.filter(m => m.type === 'BANK_ACCOUNT')
+          methods: paymentMethods.methods.filter(m => {
+            return m.type === 'BANK_ACCOUNT' || m.currency === 'USD'
+          })
         }) ||
         paymentMethods
     })


### PR DESCRIPTION
## Description (optional)
Need to check for USD bank_transfers payment methods and not filter them out when checking the open banking invites list.
