### PR TITLE
fix(deposits): default to USD when adding a new bank from deposit

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/DepositMethods/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/DepositMethods/index.tsx
@@ -11,7 +11,7 @@ import { getData } from './selectors'
 import Failure from './template.failure'
 import Success from './template.success'
 
-const DepositMethods = props => {
+const DepositMethods = (props) => {
   useEffect(() => {
     if (props.fiatCurrency && !Remote.Success.is(props.data)) {
       props.simpleBuyActions.fetchSBFiatEligible(props.fiatCurrency)
@@ -21,24 +21,24 @@ const DepositMethods = props => {
   }, [])
 
   return props.data.cata({
-    Success: val => <Success {...val} {...props} />,
     Failure: () => <Failure {...props} />,
     Loading: () => <Loading text={LoadingTextEnum.LOADING} />,
-    NotAsked: () => <Loading text={LoadingTextEnum.LOADING} />
+    NotAsked: () => <Loading text={LoadingTextEnum.LOADING} />,
+    Success: (val) => <Success {...val} {...props} />,
   })
 }
 
 const mapStateToProps = (state: RootState) => ({
   addNew: state.components.brokerage.addNew,
   data: getData(state),
-  fiatCurrency: selectors.core.settings.getCurrency(state)
+  fiatCurrency: selectors.core.settings.getCurrency(state).getOrElse('USD'),
 })
 
 export const mapDispatchToProps = (dispatch: Dispatch) => ({
   analyticsActions: bindActionCreators(actions.analytics, dispatch),
   brokerageActions: bindActionCreators(actions.components.brokerage, dispatch),
   formActions: bindActionCreators(actions.form, dispatch),
-  simpleBuyActions: bindActionCreators(actions.components.simpleBuy, dispatch)
+  simpleBuyActions: bindActionCreators(actions.components.simpleBuy, dispatch),
 })
 
 const connector = connect(mapStateToProps, mapDispatchToProps)


### PR DESCRIPTION
## Description (optional)
Fiat deposit -> add bank screen wasn't showing up because of the fiatcurrency prop. Set a getOrElse default to USD to solve the issue for USD, EUR, and GBP.

