### PR TITLE
fix(metadata): check the correct and incorrect encryption key

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/kvStore/index.js
+++ b/packages/blockchain-wallet-v4/src/network/api/kvStore/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import Task from 'data.task'
 import { compose, curry, dissoc, prop, set } from 'ramda'
 
@@ -57,7 +58,7 @@ export default ({ apiUrl, get, networks, put }) => {
       if (res === null) return set(KV.value, null, currentKv)
       let setFromResponse = compose(
         set(KV.magicHash, prop('compute_new_magic_hash', res)),
-        set(KV.value, KV.extractResponse(kv.encKeyBuffer, res))
+        set(KV.value, KV.extractResponse(kv.encKeyBuffer, kv.encKeyBufferPadded, res))
       )
       return setFromResponse(currentKv)
     })

--- a/packages/blockchain-wallet-v4/src/types/KVStoreEntry.spec.ts
+++ b/packages/blockchain-wallet-v4/src/types/KVStoreEntry.spec.ts
@@ -1,0 +1,52 @@
+import * as Bitcoin from 'bitcoinjs-lib'
+
+import * as KVStoreEntry from './KVStoreEntry.js'
+
+describe('KVStoreEntry', () => {
+  describe('sanitizeBuffer', () => {
+    it('removes leading 0s', () => {
+      const chaincode = Buffer.from(
+        '52ac2d2f90c0408f38fa34b1da69af54bba8153c2f4cd6b9bd68ad76494f530e',
+        'hex'
+      )
+      const privateKey = Buffer.from(
+        'a91bf9af9cbf9dbd1de0a3a4867a42cb0bd398251b807c84a6b6ac68828a02d9',
+        'hex'
+      )
+
+      const bip32 = Bitcoin.bip32.fromPrivateKey(privateKey, chaincode)
+      const pk = bip32.deriveHardened(233).deriveHardened(1).privateKey
+      const sanitizedPk = KVStoreEntry.sanitizeBuffer(pk)
+
+      expect(sanitizedPk.toString('hex')).toBe(
+        '445566da8887f8b030d3e8a357a6d58b29538449e642cfe7a5c20a87a973b2'
+      )
+      expect(pk?.toString('hex')).toBe(
+        '00445566da8887f8b030d3e8a357a6d58b29538449e642cfe7a5c20a87a973b2'
+      )
+    })
+  })
+
+  describe('fromMetadataHDNode', () => {
+    it('sets both the correct and incorrect enc keys', () => {
+      const chaincode = Buffer.from(
+        '52ac2d2f90c0408f38fa34b1da69af54bba8153c2f4cd6b9bd68ad76494f530e',
+        'hex'
+      )
+      const privateKey = Buffer.from(
+        'a91bf9af9cbf9dbd1de0a3a4867a42cb0bd398251b807c84a6b6ac68828a02d9',
+        'hex'
+      )
+
+      const bip32 = Bitcoin.bip32.fromPrivateKey(privateKey, chaincode)
+      const metadata = KVStoreEntry.fromMetadataHDNode(bip32, 233)
+
+      expect(metadata.encKeyBufferPadded.toString('hex')).toBe(
+        'd3d34a69c68bb0eee9bad63b204c5e0ff00b1a48f17bfabe73a7b6df58e6281a'
+      )
+      expect(metadata.encKeyBuffer.toString('hex')).toBe(
+        'e5a3804f14a79a69d2396c2e2359fa2439079d44379ab86d2a517533cc83a5d4'
+      )
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8190,7 +8190,7 @@ eslint-config-airbnb-base@^14.2.1:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
-eslint-config-airbnb@^18.2.1:
+eslint-config-airbnb@18.2.1:
   version "18.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz#b7fe2b42f9f8173e825b73c8014b592e449c98d9"
   integrity sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==
@@ -8217,7 +8217,7 @@ eslint-import-resolver-node@^0.3.4:
     debug "^2.6.9"
     resolve "^1.13.1"
 
-eslint-import-resolver-typescript@^2.4.0:
+eslint-import-resolver-typescript@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz#ec1e7063ebe807f0362a7320543aaed6fe1100e1"
   integrity sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==
@@ -8236,7 +8236,7 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@^2.22.1:
+eslint-plugin-import@2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
   integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
@@ -8338,7 +8338,7 @@ eslint-plugin-sort-destructure-keys@1.3.5:
   dependencies:
     natural-compare-lite "^1.4.0"
 
-eslint-plugin-sort-keys-fix@^1.1.1:
+eslint-plugin-sort-keys-fix@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.1.tgz#2ed201b53fd4a89552c6e2abd38933f330a4b62e"
   integrity sha512-x02SLBg+8OEaoT9vvMbsgeInw17wjHLsa9cOieIVQY+xMNRiXBbyMWw+NiBoxYyJIR4QKDOPDofCjQdoSvltQg==


### PR DESCRIPTION
## Description (optional)
Metadata fetch fails because of an incorrectly derived private key used for decrypting the payload.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

