### PR TITLE
Replace .error color with readable color

### DIFF
--- a/packages/blockchain-info-components/src/Colors/DarkMode.ts
+++ b/packages/blockchain-info-components/src/Colors/DarkMode.ts
@@ -125,7 +125,7 @@ const DarkTheme: DefaultTheme = {
   received: '#00994C',
   transferred: '#3D89F5',
   // State
-  error: '#651D1E',
+  error: '#D93B30',
   warn: '#7F4F48',
   success: '#00422C',
   // Marketing


### PR DESCRIPTION
Error messages in darkMode are nearly unreadable.   Lightened color to increase contrast against dark background.

## Description (optional)
Replaced .error color in DarkMode to increase contrast against dark background.  Existing color definition was nearly unreadable.

![Preview](https://i.imgur.com/qLrDDGA.jpg)