### PR TITLE
fix(open banking): makes action text for qrcode screen a child so it can be changed more easily

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -659,7 +659,7 @@ type MessagesType = {
   'modals.brokerage.authorize.bol.title': 'Bank of Lithuania Authorisation'
   'modals.brokerage.authorize.fca': 'Blockchain.com is an agent of {entityName} Ltd. {entityName} Ltd is authorised and regulated by the Financial Conduct Authority under the Payment Service Regulations 2017 [827001] for the provision of Account Information and Payment Initiation services.'
   'modals.brokerage.authorize.bol': 'SafeConnect UAB is authorised and regulated by the Bank of Lithuania under Payments Law (LB002045) for the provision of Account Information and Payment Initiation services.'
-  'modals.brokerage.authorize.bol.terms': "View SafeConnect UAB <a>Terms and Conditions</a> for more information."
+  'modals.brokerage.authorize.bol.terms': 'View SafeConnect UAB <a>Terms and Conditions</a> for more information.'
   'modals.brokerage.authorize.data': 'In order to share your bank account data with Blockchain.com, you will now be securely redirected to your bank to confirm your consent for {entityName} to read the following information:'
   'modals.brokerage.authorize.deposit_data.first': 'To easily set up payments from your bank to Blockchain.com, we are about to securely re-direct you to your bank where you will be asked to confirm the payment via {entityName}, an FCA regulated payment initiation provider for Blockchain.com.'
   'modals.brokerage.authorize.deposit_data.second': '{entityName} will share these details with your bank, where you will then be asked to confirm the following payment setup.'
@@ -691,6 +691,8 @@ type MessagesType = {
   'modals.brokerage.wire_fee': 'Wire Fee'
   'modals.brokerage.withdraw_fiat': 'Withdraw {fiat}'
   'modals.brokerage.confirm_deposit': 'Confirm Deposit'
+  'modals.brokerage.confirm_via_mobile': 'Confirm via mobile'
+  'modals.brokerage.confirm_via_desktop': 'Confirm via desktop'
   'modals.brokerage.bank_deposit': 'Bank Deposit'
   'modals.brokerage.bank_deposit_description': 'Securely link a bank and send cash to your Blockchain.com Wallet at anytime.'
   'modals.brokerage.deposit_currency': 'Deposit {currency}'
@@ -924,7 +926,7 @@ type MessagesType = {
   'modals.interest.deposit.termsservice': 'Terms of Service'
   'modals.interest.deposit.edd_need': "Transferring this amount requires further verification. We'll ask you for those details in the next step."
   'modals.interest.deposit.supply_information_description_1': "You've transferred an amount that requires further verification for legal and compliance reasons."
-  'modals.interest.deposit.supply_information_description_2': "Your funds are safe with us and have started accruing interest already. To avoid delays when you decide to withdraw your funds, submit your information now."
+  'modals.interest.deposit.supply_information_description_2': 'Your funds are safe with us and have started accruing interest already. To avoid delays when you decide to withdraw your funds, submit your information now.'
   'modals.interest.totalearned': 'Total Interest Earned'
   'modals.interest.unsupported-title': 'Rates Unavailable'
   'modals.interest.unsupported-subcontent-1': "Interest rates are currently unavailable for {walletCurrency}. Please change your wallet's local currency in Preferences."
@@ -939,7 +941,7 @@ type MessagesType = {
   'modals.interest.withdrawal.edd_need': 'This amount requires further information. Confirm the withdrawal and follow the instructions on the next screen.'
   'modals.interest.withdrawal.success': 'Waiting on your withdrawal to be confirmed by our team. It may take a few moments to show in your Interest Account History. No action is required at this time.'
   'modals.interest.withdrawal.supply_information_description_1': "You've requested a withdrawal for an amount that requires further verification for legal and compliance reasons."
-  'modals.interest.withdrawal.supply_information_description_2': "Your funds are safe with us. Please submit the additional information so we can start processing your withdrawal."
+  'modals.interest.withdrawal.supply_information_description_2': 'Your funds are safe with us. Please submit the additional information so we can start processing your withdrawal.'
   'modals.interest.supply_information_disclaimer': 'Our Support team may contact you if further clarification is needed.'
   'modals.interest.withdrawal.totalinterest': 'Total Interest Earned'
   'modals.interest.withdrawal.warning': 'In the last month you have earned {pendingInterestCrypto} in interest. Once you withdraw {withdrawalAmount} ({withdrawalAmountCrypto}), you will continue to earn interest on the remaining balance.'
@@ -1115,7 +1117,7 @@ type MessagesType = {
   'modals.onboarding.linkfromexchange.success_subinfo2_title': 'To Log In to Your Exchange'
   'modals.onboarding.linkfromexchange.success_subinfo2_description1': '- Use Email Address: {exchangeEmail}'
   'modals.onboarding.linkfromexchange.success_subinfo2_description2': '- Exchange’s Password'
-  'modals.onboarding.linkfromexchange.success_disclaimer': "Having different Exchange and Wallet passwords helps to keep your accounts safe! <a>Learn more</a> about the Wallet."
+  'modals.onboarding.linkfromexchange.success_disclaimer': 'Having different Exchange and Wallet passwords helps to keep your accounts safe! <a>Learn more</a> about the Wallet.'
   'modals.onboarding.linkfromexchange.successheader': 'Your Accounts are Connected!'
   'modals.onboarding.linkfromexchange.to_continue': "to continue. We'll be waiting right here in the meantime."
   'modals.onboarding.linkfromexchange.unverified_email': 'Please Verify Your Email'
@@ -1415,7 +1417,7 @@ type MessagesType = {
   'modals.simplebuy.confirm.activity': 'Your final amount may change due to market activity.'
   'modals.simplebuy.confirm.activity_card11': 'Your final amount might change due to market activity. For your security, buy orders with a bank account are subject up to a 14 day holding period. You can Swap or Sell during this time. We will notify you once the funds are fully available.'
   'modals.simplebuy.confirm.activity_card2': 'Your crypto will be available to be withdrawn within <b>{days} days</b>.'
-  'modals.simplebuy.confirm.activity_accept_terms': "I agree to Blockchain’s <a>Terms of Service</a> and its return, refund and cancellation policy."
+  'modals.simplebuy.confirm.activity_accept_terms': 'I agree to Blockchain’s <a>Terms of Service</a> and its return, refund and cancellation policy.'
   'modals.simplebuy.confirm.funds_wallet': '{coin} Wallet'
   'modals.simplebuy.confirm.payment_card': 'Credit Card'
   'modals.simplebuy.confirm.buynow': 'Buy Now'
@@ -1691,7 +1693,7 @@ type MessagesType = {
   'modals.withdraw.tooltip_info_day': 'The remaining balance will be available to be withdrawn within 1 day.'
   'modals.withdraw.tooltip_info': 'The remaining balance will be available to be withdrawn within {days} days.'
   'modals.withdraw.available_for_withdrawal': 'Available to Withdraw'
-  'modals.withdraw.lock_description': "You have {locks} pending transactions. We’ll email you when these funds become available for withdrawal. <a>Learn more.</a>"
+  'modals.withdraw.lock_description': 'You have {locks} pending transactions. We’ll email you when these funds become available for withdrawal. <a>Learn more.</a>'
   'modals.withdraw.not_enought_founds': 'Amount is greater than your max withdrawalable balance ({symbol} {balance}) minus the fee ({symbol} {fee}).'
   'modals.withdraw.success': 'Success! We are withdrawing the cash from your {currency} Wallet now. The funds should be in your bank in 1-3 business days.'
   'modals.xlmairdropwelcome.inprogress.completenow': 'Complete Now'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Connect/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankYapily/Connect/template.success.tsx
@@ -25,16 +25,18 @@ const Success = (props: Props) => {
   return (
     <BankWrapper>
       <ModalNavWithCloseIcon {...props}>
-        <FormattedMessage
-          id='copy.connect_to_your_bank'
-          defaultMessage='Connect to your bank'
-        />
+        <FormattedMessage id='copy.connect_to_your_bank' defaultMessage='Connect to your bank' />
       </ModalNavWithCloseIcon>
       <LinkOptionsWrapper>
         <ScanWithPhone
           logo={logo as string}
           qrCode={props.account?.attributes?.qrcodeUrl as string}
-        />
+        >
+          <FormattedMessage
+            id='modals.brokerage.link_via_mobile'
+            defaultMessage='Link via mobile'
+          />
+        </ScanWithPhone>
         <Hr />
         <Section>
           <LinkViaDesktop
@@ -42,10 +44,13 @@ const Success = (props: Props) => {
             onClick={() => {
               props.analyticsActions.logEvent(YAPILY_CONT_IN_BROWSER)
             }}
-          />
-          <BankWaitIndicator
-            qrCode={props.account?.attributes?.qrcodeUrl as string}
-          />
+          >
+            <FormattedMessage
+              id='modals.brokerage.link_via_desktop'
+              defaultMessage='Link via desktop'
+            />
+          </LinkViaDesktop>
+          <BankWaitIndicator qrCode={props.account?.attributes?.qrcodeUrl as string} />
         </Section>
       </LinkOptionsWrapper>
     </BankWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/OpenBankingConnect/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/OpenBankingConnect/template.success.tsx
@@ -35,13 +35,15 @@ const Success = (props: Props) => {
   return (
     <BankWrapper>
       <ModalNavWithCloseIcon handleClose={props.handleClose}>
-        <FormattedMessage
-          id='copy.connect_to_your_bank'
-          defaultMessage='Connect to your bank'
-        />
+        <FormattedMessage id='copy.connect_to_your_bank' defaultMessage='Connect to your bank' />
       </ModalNavWithCloseIcon>
       <LinkOptionsWrapper>
-        <ScanWithPhone qrCode={qrCode} />
+        <ScanWithPhone qrCode={qrCode}>
+          <FormattedMessage
+            id='modals.brokerage.link_via_mobile'
+            defaultMessage='Link via mobile'
+          />
+        </ScanWithPhone>
         <Hr />
         <Section>
           <LinkViaDesktop
@@ -49,7 +51,12 @@ const Success = (props: Props) => {
             onClick={() => {
               props.analyticsActions.logEvent(YAPILY_CONT_IN_BROWSER_PIS)
             }}
-          />
+          >
+            <FormattedMessage
+              id='modals.brokerage.link_via_desktop'
+              defaultMessage='Link via desktop'
+            />
+          </LinkViaDesktop>
           <BankWaitIndicator qrCode={qrCode} />
         </Section>
       </LinkOptionsWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OpenBankingConnect/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OpenBankingConnect/template.success.tsx
@@ -27,18 +27,21 @@ const Success = (props: Props) => {
         />
       </ModalNavWithCloseIcon>
       <LinkOptionsWrapper>
-        <ScanWithPhone
-          logo={logo as string}
-          qrCode={props.order?.attributes?.qrcodeUrl as string}
-        />
+        <ScanWithPhone logo={logo as string} qrCode={props.order?.attributes?.qrcodeUrl as string}>
+          <FormattedMessage
+            id='modals.brokerage.confirm_via_mobile'
+            defaultMessage='Confirm via mobile'
+          />
+        </ScanWithPhone>
         <Hr />
         <Section>
-          <LinkViaDesktop
-            authUrl={props.order?.attributes?.authorisationUrl as string}
-          />
-          <BankWaitIndicator
-            qrCode={props.order?.attributes?.qrcodeUrl as string}
-          />
+          <LinkViaDesktop authUrl={props.order?.attributes?.authorisationUrl as string}>
+            <FormattedMessage
+              id='modals.brokerage.confirm_via_desktop'
+              defaultMessage='Confirm via desktop'
+            />
+          </LinkViaDesktop>
+          <BankWaitIndicator qrCode={props.order?.attributes?.qrcodeUrl as string} />
         </Section>
       </LinkOptionsWrapper>
     </BankWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/components/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/components/index.tsx
@@ -2,13 +2,7 @@ import React, { useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 import styled, { css } from 'styled-components'
 
-import {
-  Button,
-  Icon,
-  Image,
-  SpinningLoader,
-  Text
-} from 'blockchain-info-components'
+import { Button, Icon, Image, SpinningLoader, Text } from 'blockchain-info-components'
 import { FlyoutWrapper } from 'components/Flyout'
 import { OBInstitution } from 'data/types'
 
@@ -41,7 +35,7 @@ const QrContainer = styled.div`
   align-items: center;
   margin: 40px auto 0;
   padding: 15px;
-  border: 2px solid ${p => p.theme.blue600};
+  border: 2px solid ${(p) => p.theme.blue600};
   border-radius: 4px;
 
   & img {
@@ -77,18 +71,16 @@ const LogoImage = styled.img`
 `
 
 interface ScanWithPhoneType {
+  children: React.ReactChild
   readonly logo?: string
   readonly qrCode?: string
 }
-const ScanWithPhone = ({ logo, qrCode }: ScanWithPhoneType) => {
+const ScanWithPhone = ({ children, logo, qrCode }: ScanWithPhoneType) => {
   return (
     <Section>
       {logo && <LogoImage src={logo} />}
       <Text weight={600} size='20px' color='grey900'>
-        <FormattedMessage
-          id='modals.brokerage.link_via_mobile'
-          defaultMessage='Link via mobile'
-        />
+        {children}
       </Text>
       <Text weight={500} size='14px' color='grey600'>
         <FormattedMessage
@@ -98,7 +90,7 @@ const ScanWithPhone = ({ logo, qrCode }: ScanWithPhoneType) => {
       </Text>
       <QrContainer>
         {qrCode ? (
-          <img src={qrCode} />
+          <img alt='Use your phone’s camera to scan the QR code.' src={qrCode} />
         ) : (
           <SpinningLoader width='30px' height='30px' />
         )}
@@ -143,19 +135,19 @@ const StyledButton = styled(Button)`
 `
 const LinkViaDesktop = ({
   authUrl,
-  onClick = () => {}
+  children,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onClick = () => {} // noop
 }: {
   authUrl?: string
+  children: React.ReactChild
   onClick?: () => void
 }) => {
   if (!authUrl) return null
   return (
     <Section>
       <Text weight={600} size='20px' color='grey900'>
-        <FormattedMessage
-          id='modals.brokerage.link_via_desktop'
-          defaultMessage='Link via desktop'
-        />
+        {children}
       </Text>
       <StyledButton
         data-e2e='yapilyBankLink'
@@ -217,16 +209,10 @@ const Loading = ({ text }: Props) => {
           <FormattedMessage id='copy.loading' defaultMessage='Loading...' />
         )}
         {text === LoadingTextEnum.GETTING_READY && (
-          <FormattedMessage
-            id='loader.message.gettingready'
-            defaultMessage='Getting Ready...'
-          />
+          <FormattedMessage id='loader.message.gettingready' defaultMessage='Getting Ready...' />
         )}
         {text === LoadingTextEnum.PROCESSING && (
-          <FormattedMessage
-            id='modals.simplebuy.processing'
-            defaultMessage='Processing…'
-          />
+          <FormattedMessage id='modals.simplebuy.processing' defaultMessage='Processing…' />
         )}
       </Text>
     </Wrapper>
@@ -281,7 +267,7 @@ const BankRow = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  border: 0px solid ${p => p.theme.grey000};
+  border: 0px solid ${(p) => p.theme.grey000};
   border-bottom-width: 1px;
   padding: 28px 40px;
 
@@ -292,7 +278,7 @@ const BankRow = styled.div`
     align-items: center;
   }
 
-  ${props =>
+  ${(props) =>
     props.onClick &&
     css`
       cursor: pointer;
@@ -300,7 +286,7 @@ const BankRow = styled.div`
         cursor: pointer;
       }
       &:hover {
-        background-color: ${props => props.theme.blue000};
+        background-color: ${(props) => props.theme.blue000};
       }
     `}
 `
@@ -308,7 +294,7 @@ const BankRow = styled.div`
 const BankIcon = styled.div<BankIconProps>`
   height: 30px;
   width: 30px;
-  background: url("${p => p.url}") 0 0 no-repeat;
+  background: url('${(p) => p.url}') 0 0 no-repeat;
   background-size: 30px;
   background-position: center;
 `
@@ -317,7 +303,7 @@ const BankSearchWrapper = styled.div`
   position: relative;
 `
 const BankSearchInput = styled.input`
-  border: 1px solid ${p => p.theme.grey000};
+  border: 1px solid ${(p) => p.theme.grey000};
   font-size: 16px;
   width: 100%;
   border-width: 1px 0;
@@ -338,10 +324,7 @@ const BankSearchIcon = () => (
   />
 )
 
-const SimpleBankRow = (props: {
-  institution: OBInstitution
-  onClick: () => void
-}) => {
+const SimpleBankRow = (props: { institution: OBInstitution; onClick: () => void }) => {
   return (
     <BankRow onClick={props.onClick}>
       <div>
@@ -362,7 +345,7 @@ const SimpleBankRow = (props: {
   )
 }
 
-const ModalNavWithBackArrow = props => {
+const ModalNavWithBackArrow = (props) => {
   return (
     <NavText color='grey800' size='20px' weight={600}>
       <Icon
@@ -379,14 +362,9 @@ const ModalNavWithBackArrow = props => {
   )
 }
 
-const ModalNavWithCloseIcon = props => {
+const ModalNavWithCloseIcon = (props) => {
   return (
-    <NavText
-      color='grey800'
-      size='20px'
-      weight={600}
-      style={{ justifyContent: 'space-between' }}
-    >
+    <NavText color='grey800' size='20px' weight={600} style={{ justifyContent: 'space-between' }}>
       {props.children}
       <Icon
         cursor
@@ -403,7 +381,7 @@ const ModalNavWithCloseIcon = props => {
 
 const HrEl = styled.hr`
   border: none;
-  border-top: 1px solid ${p => p.theme.grey100};
+  border-top: 1px solid ${(p) => p.theme.grey100};
   text-align: center;
   overflow: visible;
   color: #333;
@@ -415,7 +393,7 @@ const HrEl = styled.hr`
     padding: 0 4px;
     position: relative;
     top: -10px;
-    background: ${p => p.theme.alwaysWhite};
+    background: ${(p) => p.theme.alwaysWhite};
   }
 `
 


### PR DESCRIPTION
## Description (optional)
The "Link via mobile" and "Link via desktop" text is no longer hardcoded in the reusable component. For the PIS flow it now shows as "Confirm via mobile" "Confirm via desktop"
![image](https://user-images.githubusercontent.com/57680122/119908348-3b918180-bf07-11eb-947d-528d4b026c81.png)

