### PR TITLE
fix(layout): set layout chart breakpoint to 1023px width to accomodate regular laptops

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/index.tsx
@@ -13,7 +13,7 @@ const ColumnWrapper = styled.section`
   display: flex;
   flex-direction: column;
 
-  ${media.atLeastLaptopM`
+  ${media.atLeastLaptop`
     flex-direction: row;
   `}
 `
@@ -24,7 +24,7 @@ const Column = styled.div`
 `
 const ColumnLeft = styled(Column)`
   flex: 2;
-  ${media.atLeastLaptopM`
+  ${media.atLeastLaptop`
     margin-right: 24px;
   `}
 `
@@ -33,7 +33,7 @@ const ColumnRight = styled(Column)`
   flex: 3;
   margin-top: 24px;
 
-  ${media.atLeastLaptopM`
+  ${media.atLeastLaptop`
     margin-top: 0;
   `}
 `


### PR DESCRIPTION
## Description (optional)
changes layout for standard laptops from looking like:
![image](https://user-images.githubusercontent.com/57680122/120519136-25f8dd80-c387-11eb-9372-d0e347c2968c.png)
To:
![image](https://user-images.githubusercontent.com/57680122/120519243-4032bb80-c387-11eb-92b2-36bd463d6f73.png)


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

