### PR TITLE
fix(interest): enable interest deposits for aave and yfi

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/CoinBalanceDropdown/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/CoinBalanceDropdown/selectors.ts
@@ -69,6 +69,20 @@ const getData = (state, ownProps: OwnProps) => {
         includeInterest: false
       })
       break
+    case 'AAVE':
+      addressDataR = getErc20AddressData(state, {
+        coin: 'AAVE',
+        includeCustodial,
+        includeInterest: false
+      })
+      break
+    case 'YFI':
+      addressDataR = getErc20AddressData(state, {
+        coin: 'YFI',
+        includeCustodial,
+        includeInterest: false
+      })
+      break
     default:
       addressDataR = Remote.Success({ data: [] })
   }


### PR DESCRIPTION
## Description (optional)
AAVE and YFI custodial accounts weren't showing up when trying to use them with interest. Since they're erc20 coins we can simply add the `getXlmAddressData()` to the interest dropdown selectors

## Testing Steps (optional)
Get AAVE and YFI and ETH and add it to your interest

