### PR TITLE
fix(simple buy): design changes to confirm screen

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
@@ -213,10 +213,11 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
         <TopText color='grey800' size='20px' weight={600}>
           <Icon
             cursor
-            name='arrow-left'
+            data-e2e='sbBackToEnterAmount'
+            name='arrow-back'
             size='20px'
             color='grey600'
-            style={{ marginRight: '24px' }}
+            style={{ marginRight: '8px' }}
             role='button'
             onClick={handleCancel}
           />
@@ -303,34 +304,22 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
           </RowTextWrapper>
         </RowText>
       </RowItem>
-      <RowItem>
-        <RowText>
-          <FormattedMessage id='copy.purchase' defaultMessage='Purchase' />
-        </RowText>
-        <RowText>{displayFiat(props.order, props.supportedCoins, String(purchase))}</RowText>
-      </RowItem>
-      {!isBankLink && (
+      {isCardPayment && (
         <RowItem>
           <RowItemContainer>
             <TopRow>
               <RowIcon>
                 <RowText>
-                  {isCardPayment ? (
-                    <FormattedMessage id='copy.card_fee' defaultMessage='Card Fee' />
-                  ) : (
-                    <FormattedMessage id='copy.fee' defaultMessage='Fee' />
-                  )}
+                  <FormattedMessage id='copy.card_fee' defaultMessage='Card Fee' />
                 </RowText>
-                {isCardPayment && (
-                  <IconWrapper>
-                    <Icon
-                      name='question-in-circle-filled'
-                      size='16px'
-                      color={isActiveFeeTooltip ? 'blue600' : 'grey300'}
-                      onClick={() => setFeeToolTip(!isActiveFeeTooltip)}
-                    />
-                  </IconWrapper>
-                )}
+                <IconWrapper>
+                  <Icon
+                    name='question-in-circle-filled'
+                    size='16px'
+                    color={isActiveFeeTooltip ? 'blue600' : 'grey300'}
+                    onClick={() => setFeeToolTip(!isActiveFeeTooltip)}
+                  />
+                </IconWrapper>
               </RowIcon>
               <RowText data-e2e='sbFee'>
                 {props.order.fee
@@ -340,7 +329,7 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
                     }`}
               </RowText>
             </TopRow>
-            {isCardPayment && isActiveFeeTooltip && (
+            {isActiveFeeTooltip && (
               <ToolTipText>
                 <Text size='12px' weight={500} color='grey600'>
                   <TextGroup inline>


### PR DESCRIPTION
## Description (optional)
- Transition from amount screen to the checkout screen - The back button changes size, it should stay the same size. 

Fiat Wallet Checkout
- Kill the purchase line item.
- Kill the fee line item. 

Bank Checkouts
- Kill the purchase line item. 
- Kill the fee line item. 


![image](https://user-images.githubusercontent.com/57680122/121433176-7e545000-c930-11eb-92b5-64cca4996af7.png)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

