### PR TITLE
fix(interest): form error if account balance is zero

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.utils.ts
@@ -29,23 +29,20 @@ export default ({ coreSagas, networks }: { coreSagas: any; networks: any }) => {
   })
   const { convertCoinFromBaseUnitToFiat } = coinSagas({ coreSagas, networks })
 
-  const buildAndPublishPayment = function * (
+  const buildAndPublishPayment = function* (
     coin: CoinType,
     payment: PaymentType,
     destination: string
   ): Generator<PaymentType | CallEffect, PaymentValue, any> {
-    try {
-      if (coin === 'XLM') {
-        // separate out addresses and memo
-        const depositAddressMemo = destination.split(':')
-        const txMemo = depositAddressMemo[1]
-        // throw error if we cant parse the memo for tx
-        if (
-          isNil(txMemo) ||
-          (typeof txMemo === 'string' && txMemo.length === 0)
-        ) {
-          throw new Error('Memo for transaction is missing')
-        }
+    if (coin === 'XLM') {
+      // separate out addresses and memo
+      const depositAddressMemo = destination.split(':')
+      const txMemo = depositAddressMemo[1]
+      // throw error if we cant parse the memo for tx
+      if (isNil(txMemo) || (typeof txMemo === 'string' && txMemo.length === 0)) {
+        throw new Error('Memo for transaction is missing')
+      }
+      /* eslint-disable */
         payment = yield payment.to(depositAddressMemo[0], 'CUSTODIAL')
         // @ts-ignore
         payment = yield payment.memo(txMemo)
@@ -61,11 +58,8 @@ export default ({ coreSagas, networks }: { coreSagas: any; networks: any }) => {
       const password = yield call(promptForSecondPassword)
       payment = yield payment.sign(password)
       payment = yield payment.publish()
-    } catch (e) {
-      throw e
-    }
-
-    return payment.value()
+      return payment.value()
+         /* eslint-disable */
   }
 
   const createLimits = function * (
@@ -122,14 +116,13 @@ export default ({ coreSagas, networks }: { coreSagas: any; networks: any }) => {
 
   const createPayment = function * (source: AccountTypes) {
     const coin = S.getCoinType(yield select())
-
+    if (source.balance <= 0) return
     const payment: PaymentValue = yield call(
       calculateProvisionalPayment,
       source,
       0,
       coin === 'BTC' ? 'regular' : 'priority'
     )
-
     return payment
   }
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
@@ -121,7 +121,9 @@ const DepositForm: React.FC<InjectedFormProps<{ form: string }, Props> & Props> 
   const lockUpDuration = interestLimits[coin]?.lockUpDuration || 7200
   const lockupPeriod = lockUpDuration / 86400
   const maxDepositFiat = maxFiat(depositLimits.maxFiat, walletCurrency)
-
+  const accountBalance =
+    values && values?.interestDepositAccount && values.interestDepositAccount.balance
+  const accountHasBalance = accountBalance > 0
   const depositAmountError =
     formErrors.depositAmount &&
     typeof formErrors.depositAmount === 'string' &&
@@ -266,7 +268,7 @@ const DepositForm: React.FC<InjectedFormProps<{ form: string }, Props> & Props> 
             component={NumberBox}
             data-e2e='depositAmount'
             // @ts-ignore
-            disabled={insufficientEth}
+            disabled={(insufficientEth, !accountHasBalance)}
             displayCoin={displayCoin}
             name='depositAmount'
             validate={[required, minDepositAmount, maxDepositAmount]}


### PR DESCRIPTION
## Description (optional)
Interest deposit form throws an error if user 
1) has a private key account with 0 balance selected as their deposit account 
2) and then enters an amount into the field

To fix this issue:
1) If source account balance <= 0, don't create a payment
2) Disable amount field if chosen deposit account has 0 balance

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

