### PR TITLE
fix(brokerage): fixes infinite spinner in general settings add bank button click and infinite spinner when successfully linking a bank

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankStatus/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/AddBankStatus/selectors.ts
@@ -3,20 +3,17 @@ import { lift } from 'ramda'
 import { ExtractSuccess } from 'blockchain-wallet-v4/src/types'
 import { selectors } from 'data'
 import { RootState } from 'data/rootReducer'
+import { OBType } from 'data/types'
 
 export const getData = (state: RootState) => {
   const bankStatusR = selectors.components.brokerage.getAddBankStatus(state)
-  const bankCredentialsR = selectors.components.brokerage.getBankCredentials(
-    state
-  )
-
-  return lift(
-    (
-      bankStatus: ExtractSuccess<typeof bankStatusR>,
-      bankCredentials: ExtractSuccess<typeof bankCredentialsR>
-    ) => ({
-      bankStatus,
-      bankCredentials
-    })
-  )(bankStatusR, bankCredentialsR)
+  const bankCredentialsR = selectors.components.brokerage
+    .getBankCredentials(state)
+    .getOrElse({} as OBType)
+  return lift((bankStatus: ExtractSuccess<typeof bankStatusR>) => ({
+    bankCredentials: bankCredentialsR,
+    bankStatus
+  }))(bankStatusR)
 }
+
+export default getData

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/index.tsx
@@ -1,11 +1,17 @@
 import React, { PureComponent } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
+import { path } from 'ramda'
 import { bindActionCreators, Dispatch } from 'redux'
 
 import { ExtractSuccess, RemoteDataType, WalletFiatType } from 'blockchain-wallet-v4/src/types'
 import { actions, selectors } from 'data'
 import { RootState } from 'data/rootReducer'
-import { AddBankStepType, BankTransferAccountType, BrokerageModalOriginType } from 'data/types'
+import {
+  AddBankStepType,
+  BankTransferAccountType,
+  BrokerageModalOriginType,
+  UserDataType
+} from 'data/types'
 
 import getData from './selectors'
 import Loading from './template.loading'
@@ -18,9 +24,16 @@ class LinkedBanks extends PureComponent<Props> {
   }
 
   handleBankClick = () => {
+    // There is no reliable source of fiatCurrency so we depend on the withdrawal component for it
+    // but if the userData has a limits currency that seems fairly reliable so we'll use that. It
+    // limits is an empty array on tier 0 accounts but they're not eligible for banks anyways
+    let { fiatCurrency } = this.props
+    if (path(['userData', 'limits'], this.props)) {
+      fiatCurrency = this.props.userData?.limits[0]?.currency as WalletFiatType
+    }
     this.props.brokerageActions.showModal(
       BrokerageModalOriginType.ADD_BANK,
-      this.props.fiatCurrency === 'USD' ? 'ADD_BANK_YODLEE_MODAL' : 'ADD_BANK_YAPILY_MODAL'
+      fiatCurrency === 'USD' ? 'ADD_BANK_YODLEE_MODAL' : 'ADD_BANK_YAPILY_MODAL'
     )
     this.props.brokerageActions.setAddBankStep({
       addBankStep: AddBankStepType.ADD_BANK
@@ -62,6 +75,7 @@ class LinkedBanks extends PureComponent<Props> {
 const mapStateToProps = (state: RootState): LinkStatePropsType => ({
   data: getData(state),
   fiatCurrency: selectors.components.withdraw.getFiatCurrency(state),
+  userData: selectors.modules.profile.getUserData(state).getOrElse({} as UserDataType),
   walletCurrency: selectors.core.settings.getCurrency(state).getOrElse('USD')
 })
 
@@ -77,6 +91,7 @@ const connector = connect(mapStateToProps, mapDispatchToProps)
 type LinkStatePropsType = {
   data: RemoteDataType<string, SuccessStateType>
   fiatCurrency: WalletFiatType
+  userData: UserDataType
   walletCurrency: WalletFiatType
 }
 export type SuccessStateType = ExtractSuccess<ReturnType<typeof getData>>


### PR DESCRIPTION
## Description (optional)
There are two similar but unrelated issues. 
1. When clicking "Add a bank" from the general settings, the modal has an infinite loading screen.
2. When you link a bank through settings/simple buy/deposit the loading spinner spins infinitely and never transitions to the "Successfully linked bank" screen

## Testing Steps (optional)
Try to link a bank from general settings, and also link a bank from simple buy and it should get all the way to the success screen.

