### PR TITLE
fix(interest): skip payment dot build if account has 0 balance

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
@@ -210,6 +210,7 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
       const rate = rates[userCurrency].last
       const isDisplayed = S.getCoinDisplay(yield select())
       const isCustodialDeposit = prop('type', formValues.interestDepositAccount) === 'CUSTODIAL'
+      const accountBalance = prop('balance', formValues.interestDepositAccount)
       switch (action.meta.field) {
         case 'depositAmount':
           const value = isDisplayed
@@ -220,7 +221,7 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
             let payment = yield getOrUpdateProvisionalPaymentForCoin(coin, paymentR)
             const paymentAmount = generateProvisionalPaymentAmount(coin, value)
             payment = yield payment.amount(paymentAmount)
-            if (!isCustodialDeposit) {
+            if (!isCustodialDeposit && accountBalance > 0) {
               payment = yield payment.build()
               yield put(A.setPaymentSuccess(payment.value()))
             } else {


### PR DESCRIPTION
## Description (optional)
Interest deposit form throws an error if user

1) has a private key account with 0 balance selected as their deposit account
2) and then enters an amount into the field

Fix: If selected account has 0 balance, skip payment.build(). This will prevent form from breaking. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

