### PR TITLE
Modernize createPaymentTransactionNew API

### DIFF
--- a/packages/blockchain-wallet-v4/src/signer/bch.js
+++ b/packages/blockchain-wallet-v4/src/signer/bch.js
@@ -130,19 +130,15 @@ export const signWithLockbox = function * (
     BitcoinCash.Transaction.SIGHASH_ALL |
     BitcoinCash.Transaction.SIGHASH_BITCOINCASHBIP143
 
-  const txHex = yield BTC.createPaymentTransactionNew(
+  const txHex = yield BTC.createPaymentTransactionNew({
     inputs,
-    paths,
+    associatedKeysets: paths,
     changePath,
-    outputs,
-    undefined,
-    hashType,
-    undefined,
-    undefined,
-    ['abc'],
-    undefined,
-    multisigInputs
-  )
+    outputScriptHex: outputs,
+    sigHashType: hashType,
+    additionals: ['abc'],
+    useTrustedInputForSegwit: multisigInputs
+  })
   const txId = crypto
     .sha256(crypto.sha256(Buffer.from(txHex, 'hex')))
     .reverse()

--- a/packages/blockchain-wallet-v4/src/signer/btc.js
+++ b/packages/blockchain-wallet-v4/src/signer/btc.js
@@ -143,12 +143,12 @@ export const signWithLockbox = function * (
       coin.script.toString('hex')
   })
 
-  const txHex = yield BTC.createPaymentTransactionNew(
+  const txHex = yield BTC.createPaymentTransactionNew({
     inputs,
-    paths,
+    associatedKeysets: paths,
     changePath,
-    outputs
-  )
+    outputScriptHex: outputs
+  })
   const txId = crypto
     .sha256(crypto.sha256(Buffer.from(txHex, 'hex')))
     .reverse()


### PR DESCRIPTION
## Description

The Ledger createPaymentTransactionNew API was updated. Currently, using the legacy interface prints a warning. The new interface is also makes code easier to read.

https://github.com/LedgerHQ/ledgerjs/blob/7184a62c3469949743efa3c4fc2b93293add5e04/packages/hw-app-btc/src/Btc.js#L137-L157

## Testing Steps
Any tests that run the signer.

