### PR TITLE
feat(edd interest): do not show button after withdrawal success

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/AccountSummary/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/AccountSummary/template.success.tsx
@@ -409,22 +409,24 @@ const AccountSummary: React.FC<Props> = (props) => {
           </DetailsItemContainer>
         </DetailsWrapper>
       </Top>
-      <Bottom>
-        <ButtonContainer>
-          <Button
-            disabled={!account || !availToWithdraw}
-            data-e2e='interestWithdraw'
-            fullwidth
-            height='48px'
-            nature='grey800'
-            onClick={() => interestActions.showInterestModal('WITHDRAWAL', coin)}
-          >
-            <Text color='white' size='16px' weight={600}>
-              <FormattedMessage id='buttons.withdraw' defaultMessage='Withdraw' />
-            </Text>
-          </Button>
-        </ButtonContainer>
-      </Bottom>
+      {!showSupply && (
+        <Bottom>
+          <ButtonContainer>
+            <Button
+              disabled={!account || !availToWithdraw}
+              data-e2e='interestWithdraw'
+              fullwidth
+              height='48px'
+              nature='grey800'
+              onClick={() => interestActions.showInterestModal('WITHDRAWAL', coin)}
+            >
+              <Text color='white' size='16px' weight={600}>
+                <FormattedMessage id='buttons.withdraw' defaultMessage='Withdraw' />
+              </Text>
+            </Button>
+          </ButtonContainer>
+        </Bottom>
+      )}
     </Wrapper>
   )
 }


### PR DESCRIPTION
## Description (optional)
Hide button after success withdrawal

## Testing Steps (optional)
Go to interest page and transfer/withdrawal more than $500K
![image](https://user-images.githubusercontent.com/67264242/121959645-5700e700-cd65-11eb-8989-df101284d359.png)


