### PR TITLE
feat(edd): show required info box only if user eddNeeded is true, in case of passed do not show it

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Interest/IntroCard/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Interest/IntroCard/index.tsx
@@ -124,7 +124,9 @@ class IntroCard extends PureComponent<ParentStateType & Props & SuccessStateType
 
     return (
       <>
-        {interestEDDStatus?.eddNeeded && this.renderAdditionalInfo()}
+        {interestEDDStatus?.eddNeeded &&
+          !interestEDDStatus?.eddPassed &&
+          this.renderAdditionalInfo()}
         {showInterestInfoBox && !interestEDDStatus?.eddNeeded && (
           <BoxStyled>
             {isGoldTier ? (


### PR DESCRIPTION
## Description (optional)
Interest account should not show up info box for EDD after it's passed from BO

## Testing Steps (optional)
Create one wallet with interest, mark it as EDD needed, and then open interest page, after that box should be visible; go to BO mark EDD of interest as passed and check wallet again

