### PR TITLE
fix(2fa): show field label for google auth 2fa

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/EnterPassword/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/EnterPassword/index.tsx
@@ -102,13 +102,12 @@ const EnterPassword = (props: Props) => {
                   defaultMessage='Verify with your Yubikey'
                 />
               )}
-              {authType === 4 ||
-                (authType === 5 && (
-                  <FormattedMessage
-                    id='scenes.logins.twofa.enter_code'
-                    defaultMessage='Enter your Two Factor Authentication Code'
-                  />
-                ))}
+              {(authType === 4 || authType === 5) && (
+                <FormattedMessage
+                  id='scenes.logins.twofa.enter_code'
+                  defaultMessage='Enter your Two Factor Authentication Code'
+                />
+              )}
             </FormLabel>
             <Field
               name='code'


### PR DESCRIPTION
## Description (optional)
Fixes logic to show 2fa field label in both authType case 4 and 5 (google auth and sms)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

