### PR TITLE
fix(recovery): allow recovery for valid phrase without metadata

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/SecondStep/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/SecondStep/index.js
@@ -31,15 +31,18 @@ class RecoverContainer extends React.PureComponent {
 
     return metadataRestore.cata({
       Failure: () =>
-        kycReset ? (
+        // strict check here to only show error if kyc cannot be reset
+        // if metadataRestore fails, we still allow users to restore with
+        // a valid phrase, and kycReset is undefined
+        kycReset === false ? (
+          <Error previousStep={previousStep} />
+        ) : (
           <Recover
             previousStep={previousStep}
             onSubmit={this.onSubmit}
             isRegistering={isRegistering}
             password={password}
           />
-        ) : (
-          <Error previousStep={previousStep} />
         ),
       Loading: () => <SpinningLoader width='36px' height='36px' />,
       NotAsked: () => <SpinningLoader width='36px' height='36px' />,


### PR DESCRIPTION
## Description (optional)
Fixes issue where we show an error if valid recovery phrase isn't associated with a known wallet ID. We should still allow user to proceed with recovery into a new wallet. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

