### PR TITLE
fix(swap): amount form

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/swap/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/swap/sagas.ts
@@ -13,6 +13,7 @@ import { generateProvisionalPaymentAmount } from 'data/coins/utils'
 
 import profileSagas from '../../modules/profile/sagas'
 import { convertStandardToBase } from '../exchange/services'
+import { swap } from '../selectors'
 import sendSagas from '../send/sagas'
 import { selectReceiveAddress } from '../utils/sagas'
 import * as A from './actions'
@@ -385,6 +386,10 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas; network
         return yield put(A.setStep({ step: 'INIT_SWAP' }))
       }
 
+      const swapAmountFormValues = selectors.form.getFormValues('swapAmount')(
+        yield select()
+      ) as SwapAmountFormValues
+
       yield race({
         failure: take(AT.FETCH_QUOTE_FAILURE),
         success: take(AT.FETCH_QUOTE_SUCCESS)
@@ -393,7 +398,12 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas; network
 
       const { BASE } = initSwapFormValues
       if (BASE.type === SwapBaseCounterTypes.ACCOUNT) {
-        payment = yield call(calculateProvisionalPayment, BASE, quote.quote, 0)
+        payment = yield call(
+          calculateProvisionalPayment,
+          BASE,
+          quote.quote,
+          swapAmountFormValues?.cryptoAmount || 0
+        )
         yield put(A.updatePaymentSuccess(payment))
       } else {
         yield put(A.updatePaymentSuccess(undefined))


### PR DESCRIPTION
## Description (optional)
If you are on the summary page of swap and return to the `swapAmount` form, we will rerun initAmountForm with a  provisionalPayment with value = `0`. This fixes that problem. This problem is live in prod as well.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

