### PR TITLE
Fix/fwlt 1509/cc undefined text

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
@@ -179,7 +179,6 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
 
   const isCardPayment = requiresTerms && cardDetails
 
-  const fee = props.order.fee ? props.order.fee : props.quote.fee
   const totalAmount = fiatToString({
     unit: counterCurrency as FiatType,
     value: counterAmount

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/model.tsx
@@ -107,7 +107,7 @@ export const getPaymentMethodDetails = (
 ) => {
   switch (order.paymentType) {
     case SBPaymentTypes.PAYMENT_CARD:
-      return `${cardDetails?.card?.type} ${cardDetails?.card?.number}`
+      return `${cardDetails?.card?.type || ''} ${cardDetails?.card?.number || ''}`
     case SBPaymentTypes.BANK_TRANSFER:
       const defaultBankInfo = {
         accountNumber: '',


### PR DESCRIPTION
## Description (optional)
There is `undefined undefined` under "Credit Card" for silver tier users using simple buy. This ticket removes this.
![image](https://user-images.githubusercontent.com/57680122/126704415-f32bd4f7-205c-4943-a4c0-feb0dbf922fe.png)


## Testing Steps (optional)
- Get a silver tier account
- Open simple buy, enter an amount, click Next
- Credit Card should not have any text under it.
