### PR TITLE
fix(simple buy): convert all min amounts from standard to base before displaying in the UI

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation.tsx
@@ -242,7 +242,7 @@ export const getMaxMin = (
             isSddFlow ? method.limits.min : limitMinAmount
           ).toString()
 
-          const minFiat = !limitMinChanged ? convertBaseToStandard('FIAT', min) : min
+          const minFiat = convertBaseToStandard('FIAT', min)
           const minCrypto = getQuote(quote.pair, quote.rate, 'FIAT', minFiat)
 
           return { CRYPTO: minCrypto, FIAT: minFiat }


### PR DESCRIPTION
## Description (optional)
Issue with min buy showing up as $685.00 instead of $6.85 because the value isn't being converted from base amount to standard amount.

![image](https://user-images.githubusercontent.com/57680122/127576050-b7c30937-236a-4dff-8779-812bbada54ca.png)