### PR TITLE
fix(erc20-selector): change symbol to tokenSymbol

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Balances/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Balances/selectors.ts
@@ -330,7 +330,7 @@ export const getErc20BalancesInfoV2 = createDeepEqualSelector(
   (erc20CoinsR, ratesF, currencyR, state) => {
     const transform = (erc20Coins, currency) => {
       return erc20Coins.map((erc20) => {
-        const coin = erc20.symbol
+        const coin = erc20.tokenSymbol
         const transform2 = (balance, rates) => {
           return Exchange.convertCoinToFiat({ coin, currency, rates, value: balance })
         }


### PR DESCRIPTION
## Description (optional)
Fix for erc20 balance selector. Fixes bug where erc20 non-custodial balances was not included in total balance. 
<img width="1413" alt="Screen Shot 2021-07-30 at 2 24 18 PM" src="https://user-images.githubusercontent.com/14954836/127703731-def3129d-fe91-4ad6-bec1-98dc70fe004f.png">

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

