### PR TITLE
fix(kyc): hotfix for kyc reset

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
@@ -36,7 +36,7 @@ export const wrongFlowTypeError = 'Wrong flow type'
 export const noCampaignDataError = 'User did not come from campaign'
 
 export default ({ api, coreSagas, networks }) => {
-  const { TIERS } = model.profile
+  const { KYC_STATES, TIERS } = model.profile
   const {
     createUser,
     fetchUser,
@@ -146,7 +146,7 @@ export default ({ api, coreSagas, networks }) => {
     )).getOrElse({})
     const tiersState = (yield select(selectors.modules.profile.getTiers)).getOrElse({})
     if (kycDocResubmissionStatus === 1) {
-      if (tiers.current === 0) {
+      if (tiers.current === 0 || kycState === KYC_STATES.NONE) {
         // case where user already went through first step
         // of verfication but was rejected, want to set
         // next to 2
@@ -479,16 +479,16 @@ export default ({ api, coreSagas, networks }) => {
     goToPrevStep,
     initializeStep,
     initializeVerification,
-    resendSmsCode,
     registerUserCampaign,
+    resendSmsCode,
     saveInfoAndResidentialData,
     selectTier,
     sendDeeplink,
     sendEmailVerification,
-    updateSmsStep,
+    updateEmail,
     updateSmsNumber,
+    updateSmsStep,
     verifyIdentity,
-    verifySmsNumber,
-    updateEmail
+    verifySmsNumber
   }
 }

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
@@ -145,8 +145,11 @@ export default ({ api, coreSagas, networks }) => {
       selectors.modules.profile.getKycDocResubmissionStatus
     )).getOrElse({})
     const tiersState = (yield select(selectors.modules.profile.getTiers)).getOrElse({})
+    // Edge case where a user profile is set to tier two
+    // but kycState is none after nabu reset
+    const tierTwoKycNone = kycState === KYC_STATES.NONE && tiers.current > 1
     if (kycDocResubmissionStatus === 1) {
-      if (tiers.current === 0 || kycState === KYC_STATES.NONE) {
+      if (tiers.current === 0) {
         // case where user already went through first step
         // of verfication but was rejected, want to set
         // next to 2
@@ -155,7 +158,7 @@ export default ({ api, coreSagas, networks }) => {
         } else {
           tiers = { current: 0, next: 1, selected: 2 }
         }
-      } else if (tiers.current === 1 || tiers.current === 3) {
+      } else if (tierTwoKycNone || tiers.current === 1 || tiers.current === 3) {
         tiers = { current: 1, next: 2, selected: 2 }
       } else {
         return

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
@@ -44,8 +44,10 @@ export const getData = (state: RootState): { bannerToShow: BannerType } => {
   } as UserDataType)
 
   const { KYC_STATES } = model.profile
-  const isKycStatePending =
-    userData.kycState === KYC_STATES.PENDING || userData.kycState === KYC_STATES.UNDER_REVIEW
+  const isKycPendingOrVerified =
+    userData.kycState === KYC_STATES.PENDING ||
+    userData.kycState === KYC_STATES.UNDER_REVIEW ||
+    userData.kycState === KYC_STATES.VERIFIED
   const sddEligibleTier = selectors.components.simpleBuy.getUserSddEligibleTier(state).getOrElse(1)
 
   const limits = selectors.components.simpleBuy.getLimits(state).getOrElse({
@@ -61,7 +63,7 @@ export const getData = (state: RootState): { bannerToShow: BannerType } => {
   const isTier3SDD = sddEligibleTier === 3
 
   let bannerToShow: BannerType = null
-  if (showDocResubmitBanner && !isKycStatePending) {
+  if (showDocResubmitBanner && !isKycPendingOrVerified) {
     bannerToShow = 'resubmit'
   } else if (isSimpleBuyOrderPending && !isTier3SDD) {
     bannerToShow = 'sbOrder'


### PR DESCRIPTION
## Description (optional)
Kyc reset hotfix, accounts for users that are still tier two but still have a resubmission tag.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

