### PR TITLE
Hotfix(Swap): max button doesn't fill in proper amount

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
@@ -381,9 +381,10 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
             <GreyBlueCartridge
               role='button'
               data-e2e='swapMax'
-              onClick={() =>
-                props.swapActions.handleSwapMinAmountClick(fix === 'FIAT' ? fiatMax : max)
-              }
+              onClick={() => {
+                props.swapActions.switchFix(quoteAmount, 'CRYPTO')
+                props.swapActions.handleSwapMinAmountClick(max)
+              }}
             >
               <FormattedMessage id='buttons.swap_max' defaultMessage='Swap Max' />
             </GreyBlueCartridge>


### PR DESCRIPTION
## Description (optional)
In swap if you click the "swap max" button while the form is in fiat mode the conversion from fiat -> crypto often results in incorrect amounts due to rounding which results in the amount being more than the user actually has, when this amount is submitted the api errors and users get stuck in a strange state. On mobile clients, when the user clicks the "swap max" the form automatically switches to crypto mode and inputs the users actual maximum amount. I fix this issue on web by doing the same as mobile clients.

![Screen Shot 2021-08-03 at 3 50 37 PM](https://user-images.githubusercontent.com/57680122/128096257-4746d398-3e7f-4134-a05e-b00f73368f4f.png)


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

