### PR TITLE
fix(recurring buy): check for quote before opening first time RB flyout, and other small bug fixes

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/FrequencyScreen.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/FrequencyScreen.tsx
@@ -31,7 +31,7 @@ const FrequencyScreen = ({ children, headerAction, headerMode, setPeriod }: Prop
         onClick={headerAction}
       >
         {children ? (
-          { children }
+          <>{children}</>
         ) : (
           <FormattedMessage
             id='modals.recurringbuys.select_a_frequency'

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Header.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Header.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { FormattedMessage, IntlProvider } from 'react-intl'
 import { action } from '@storybook/addon-actions'
 import { Meta, Story } from '@storybook/react/types-6-0'
 
@@ -16,6 +17,13 @@ export default {
     mode: 'back'
   },
   component: Header,
+  decorators: [
+    (Story) => (
+      <IntlProvider locale='en'>
+        <Story />
+      </IntlProvider>
+    )
+  ],
   title: 'Flyouts/Header'
 } as Meta
 
@@ -27,4 +35,14 @@ export const BackArrowHeader: Story<Props> = (args) => (
 
 export const CloseOnlyHeader: Story<Props> = (args) => (
   <Header {...args} mode='close' onClick={action('close button clicked')} />
+)
+
+export const HeaderWithChildren: Story<Props> = (args) => (
+  <Header {...args} onClick={action('back arrow clicked')}>
+    <FormattedMessage
+      id='modals.recurringbuys.get_started.buy_amount_of_currency'
+      defaultMessage='Buy {amount} of {currency}'
+      values={{ amount: '0.005', currency: 'BTC' }}
+    />
+  </Header>
 )

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/model.tsx
@@ -119,7 +119,7 @@ const getPeriodText = (period: RecurringBuyPeriods): React.ReactNode => {
       text = <FormattedMessage id='copy.once_a_week' defaultMessage='Once a Week' />
       break
     case RecurringBuyPeriods.BI_WEEKLY:
-      text = <FormattedMessage id='copy.twice_a_week' defaultMessage='Twice a Week' />
+      text = <FormattedMessage id='copy.twice_a_month' defaultMessage='Twice a Month' />
       break
     case RecurringBuyPeriods.MONTHLY:
       text = <FormattedMessage id='copy.once_a_month' defaultMessage='Once a Month' />

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/selectors.ts
@@ -1,13 +1,15 @@
 import BigNumber from 'bignumber.js'
 import { getQuote } from 'blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/validation'
-import { head, isEmpty, lift } from 'ramda'
+import { head, isEmpty, isNil, lift } from 'ramda'
+import { createSelector } from 'reselect'
 
 import {
   ExtractSuccess,
   FiatType,
   FiatTypeEnum,
   SBPaymentMethodType,
-  SBPaymentTypes
+  SBPaymentTypes,
+  SBQuoteType
 } from 'blockchain-wallet-v4/src/types'
 import { selectors } from 'data'
 import { RootState } from 'data/rootReducer'
@@ -160,6 +162,10 @@ export const getSBCardId = (state: RootState) => state.components.simpleBuy.card
 export const getSBFiatEligible = (state: RootState) => state.components.simpleBuy.fiatEligible
 
 export const getSBQuote = (state: RootState) => state.components.simpleBuy.quote
+export const hasQuote = createSelector(getSBQuote, (quoteR) => {
+  const quote = quoteR.getOrElse({} as SBQuoteType)
+  return !isNil(quote.rate)
+})
 
 export const getSBPairs = (state: RootState) => state.components.simpleBuy.pairs
 

--- a/packages/blockchain-wallet-v4-frontend/src/data/modals/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modals/types.ts
@@ -115,6 +115,7 @@ export type ModalOriginType =
   | 'SideNav'
   | 'SimpleBuyLink'
   | 'SimpleBuyStatus'
+  | 'SimpleBuyOrderSummary'
   | 'Swap'
   | 'SwapPrompt'
   | 'SwapLimitPrompt'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/index.tsx
@@ -50,9 +50,10 @@ class OrderSummary extends PureComponent<Props> {
     if (
       this.props.isRecurringBuy &&
       this.props.orders.length > 1 &&
-      this.props.order.period !== RecurringBuyPeriods.ONE_TIME
+      this.props.order.period !== RecurringBuyPeriods.ONE_TIME &&
+      this.props.hasQuote
     ) {
-      this.props.recurringBuyActions.showModal({ origin: 'SimpleBuyStatus' })
+      this.props.recurringBuyActions.showModal({ origin: 'SimpleBuyOrderSummary' })
       this.props.recurringBuyActions.setStep({ step: RecurringBuyStepType.GET_STARTED })
     } else {
       this.props.handleClose()
@@ -80,6 +81,7 @@ class OrderSummary extends PureComponent<Props> {
 
 const mapStateToProps = (state: RootState): LinkStatePropsType => ({
   data: getData(state),
+  hasQuote: selectors.components.simpleBuy.hasQuote(state),
   isGoldVerified: equals(selectors.modules.profile.getCurrentTier(state), 2),
   isRecurringBuy: selectors.core.walletOptions
     .getFeatureFlagRecurringBuys(state)
@@ -104,6 +106,7 @@ export type SuccessStateType = ExtractSuccess<ReturnType<typeof getData>>
 
 type LinkStatePropsType = {
   data: RemoteDataType<string, SuccessStateType>
+  hasQuote: boolean
   isGoldVerified: boolean
   isRecurringBuy: boolean
   orders: SBOrderType[]


### PR DESCRIPTION
## Description (optional)
When clicking the ok button after a Buy, there's some logic to check if the recurring buy flow should pop up or not. This needed to check for an existing sb quote in order to show up or not.
![image](https://user-images.githubusercontent.com/57680122/129113546-a5ebdd85-86e5-4562-831c-d3dfe88b6565.png)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

