### PR TITLE
fix(charts): svg width param cannot be negative

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Chart/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Chart/template.success.tsx
@@ -66,7 +66,7 @@ const Chart = ({ coin, currency, data }: OwnProps) => {
       fontFamily:
         '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif '
     }),
-    [color]
+    []
   )
 
   const xScale = useMemo(
@@ -110,7 +110,7 @@ const Chart = ({ coin, currency, data }: OwnProps) => {
 
   return (
     <Wrapper ref={ref}>
-      <svg width={width - margin} height={height}>
+      <svg width={Math.abs(width - margin)} height={height}>
         <LinearGradient id={color} fromOpacity={0.5} toOpacity={0} from={color} to='white' />
 
         <AreaClosed<Data>
@@ -146,7 +146,7 @@ const Chart = ({ coin, currency, data }: OwnProps) => {
           <g>
             <Line
               from={{ x: tooltipLeft, y: 0 }}
-              to={{ x: tooltipLeft, y: innerHeight }}
+              to={{ x: tooltipLeft, y: window.innerHeight }}
               stroke={color}
               opacity={0.2}
               strokeWidth={strokeWidth}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CoinPerformance/CoinChart/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/CoinPerformance/CoinChart/template.tsx
@@ -111,7 +111,7 @@ const Chart = ({ coin, currency, data }: { coin: CoinType; currency: FiatType; d
 
   return (
     <Wrapper ref={ref}>
-      <svg width={width - margin} height={height}>
+      <svg width={Math.abs(width - margin)} height={height}>
         <LinearGradient id={color} fromOpacity={0.5} toOpacity={0} from={color} to='white' />
 
         <AreaClosed<Data>
@@ -147,7 +147,7 @@ const Chart = ({ coin, currency, data }: { coin: CoinType; currency: FiatType; d
           <g>
             <Line
               from={{ x: tooltipLeft, y: 0 }}
-              to={{ x: tooltipLeft, y: innerHeight }}
+              to={{ x: tooltipLeft, y: window.innerHeight }}
               stroke={color}
               opacity={0.2}
               strokeWidth={strokeWidth}


### PR DESCRIPTION
## Description (optional)
The charts were doing some math to set the width of the chart, but some of the first renders were rendering a negative number which is not allowed for svg element. I just used `Math.abs()` to make sure it's always a positive number.

![image](https://user-images.githubusercontent.com/57680122/129768884-be30e6ca-3920-4f18-b6da-b1eedca1db63.png)

