### PR TITLE
fix(recurring buy): only show the first time buyer flow if its truly the users first purchase

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/OrderSummary/index.tsx
@@ -40,12 +40,11 @@ class OrderSummary extends PureComponent<Props> {
   }
 
   okButtonHandler = () => {
-    // first time buyers have 1 tx at this point so and RB is set to one time buy so send them to RB walkthrough flow
-    // FIXME: The logic on the line below is hacked to be wrong so I can test.
+    // first time buyers have 1 tx at this point and RB is set to one time buy so send them to RB walkthrough flow
     if (
       this.props.isRecurringBuy &&
-      this.props.orders.length > 1 &&
-      this.props.order.period !== RecurringBuyPeriods.ONE_TIME &&
+      this.props.orders.length <= 1 &&
+      this.props.order.period === RecurringBuyPeriods.ONE_TIME &&
       this.props.hasQuote
     ) {
       this.props.recurringBuyActions.showModal({ origin: 'SimpleBuyOrderSummary' })


### PR DESCRIPTION
## Description (optional)
When clicking the 'Ok' button on the buy order confirmation screen you should be taken to the first time recurring buy flow only if it's the accounts first purchase on the app and if they didn't already select a recurring buy option on the enter amount screen.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

