### PR TITLE
fix(email-header): get email from magic link not cache

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/CloudRecovery/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/CloudRecovery/index.tsx
@@ -37,14 +37,14 @@ const BadgeRow = styled(CenteredRow)`
 `
 
 const CloudRecovery = (props: Props) => {
-  const { cachedEmail, cachedGuid, lastGuid, qrData } = props
+  const { cachedEmail, cachedGuid, emailFromMagicLink, lastGuid, qrData } = props
 
   return (
     <Wrapper>
       {cachedEmail && (
         <BackArrowFormHeader
           handleBackArrowClick={() => props.setStep(RecoverSteps.RECOVERY_OPTIONS)}
-          email={cachedEmail}
+          email={emailFromMagicLink}
           guid={cachedGuid || lastGuid}
         />
       )}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryOptions/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryOptions/index.tsx
@@ -30,13 +30,21 @@ const TextStack = styled.div`
   max-width: 312px;
 `
 const RecoveryOptions = (props: Props) => {
-  const { cachedEmail, cachedGuid, formActions, lastGuid, nabuId, routerActions } = props
+  const {
+    cachedEmail,
+    cachedGuid,
+    emailFromMagicLink,
+    formActions,
+    lastGuid,
+    nabuId,
+    routerActions
+  } = props
   return (
     <Wrapper>
       {cachedEmail && (
         <BackArrowFormHeader
           handleBackArrowClick={() => routerActions.push('/login')}
-          email={cachedEmail}
+          email={emailFromMagicLink}
           guid={cachedGuid || lastGuid}
         />
       )}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryPhrase/FirstStep/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryPhrase/FirstStep/index.tsx
@@ -27,6 +27,7 @@ const FirstStep = (props: Props) => {
   const {
     cachedEmail,
     cachedGuid,
+    emailFromMagicLink,
     formActions,
     invalid,
     lastGuid,
@@ -39,7 +40,7 @@ const FirstStep = (props: Props) => {
       {cachedEmail && (
         <BackArrowFormHeader
           handleBackArrowClick={() => setStep(RecoverSteps.RECOVERY_OPTIONS)}
-          email={cachedEmail}
+          email={emailFromMagicLink}
           guid={cachedGuid || lastGuid}
         />
       )}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/StepOne/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/StepOne/index.tsx
@@ -38,12 +38,12 @@ class StepOne extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { cachedEmail, cachedGuid, lastGuid } = this.props
+    const { cachedEmail, cachedGuid, emailFromMagicLink, lastGuid } = this.props
     return (
       <>
         <BackArrowFormHeader
           handleBackArrowClick={() => this.handleGoBackClick}
-          email={cachedEmail}
+          email={emailFromMagicLink}
           guid={cachedGuid || lastGuid}
           step={RecoverSteps.RESET_ACCOUNT}
         />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/StepTwo/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/StepTwo/index.tsx
@@ -26,6 +26,7 @@ const SecondStep = (props: Props) => {
   const {
     cachedEmail,
     cachedGuid,
+    emailFromMagicLink,
     invalid,
     isRegistering,
     lastGuid,
@@ -37,16 +38,13 @@ const SecondStep = (props: Props) => {
     <>
       <BackArrowFormHeader
         handleBackArrowClick={() => setStep(RecoverSteps.RECOVERY_OPTIONS)}
-        email={cachedEmail}
+        email={emailFromMagicLink}
         guid={cachedGuid || lastGuid}
         step={RecoverSteps.RESET_ACCOUNT}
       />
       <FormGroup>
         <FormLabel htmlFor='password'>
-          <FormattedMessage
-            id='copy.new_password'
-            defaultMessage='New Password'
-          />
+          <FormattedMessage id='copy.new_password' defaultMessage='New Password' />
         </FormLabel>
         <Field
           bgColor='grey000'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/index.tsx
@@ -53,6 +53,7 @@ const mapStateToProps = (state) => ({
   cachedEmail: selectors.cache.getEmail(state),
   cachedGuid: selectors.cache.getStoredGuid(state),
   email: formValueSelector('recover')(state, 'email'),
+  emailFromMagicLink: selectors.auth.getMagicLinkData(state)?.wallet?.email as string,
   formMeta: getFormMeta('recover')(state),
   formValues: selectors.form.getFormValues('recover')(state) as RecoverFormType,
   kycReset: selectors.auth.getKycResetStatus(state),


### PR DESCRIPTION
## Description (optional)
Uses magic link data from state for email header, rather than cache which can be unreliable sometimes. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

