### PR TITLE
fix(recurring buy): fixes issue where recurring buy period was getting reset to ONE_TIME in the UI

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/actionTypes.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/actionTypes.ts
@@ -89,6 +89,7 @@ export const POLL_SB_ORDER = '@EVENT.POLL_SB_ORDER'
 
 export const SET_STEP = '@EVENT.SET_SB_STEP'
 export const SET_FIAT_CURRENCY = '@EVENT.SET_FIAT_CURRENCY'
+export const SET_METHOD = '@EVENT.SET_SB_METHOD'
 
 export const SHOW_MODAL = '@EVENT.SHOW_SB_MODAL'
 

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/actions.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/actions.ts
@@ -563,6 +563,11 @@ export const setStep = (payload: StepActionsPayload): SimpleBuyActionTypes => ({
   type: AT.SET_STEP
 })
 
+export const setMethod = (payload: SBPaymentMethodType): SimpleBuyActionTypes => ({
+  payload,
+  type: AT.SET_METHOD
+})
+
 export const showModal = (
   origin: SBShowModalOriginType,
   cryptoCurrency?: CoinType,

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/reducers.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/reducers.ts
@@ -344,6 +344,11 @@ export function simpleBuyReducer(
         ...state,
         fiatCurrency: action.payload.fiatCurrency
       }
+    case AT.SET_METHOD:
+      return {
+        ...state,
+        method: action.payload
+      }
     case AT.SET_STEP:
       switch (action.payload.step) {
         case 'ENTER_AMOUNT':

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/types.ts
@@ -447,6 +447,11 @@ interface SetStepAction {
   type: typeof AT.SET_STEP
 }
 
+interface SetMethodAction {
+  payload: SBPaymentMethodType
+  type: typeof AT.SET_METHOD
+}
+
 interface SetFiatCurrencyAction {
   payload: { fiatCurrency: FiatType }
   type: typeof AT.SET_FIAT_CURRENCY
@@ -553,6 +558,7 @@ export type SimpleBuyActionTypes =
   | InitializeCheckout
   | SetFiatCurrencyAction
   | SetStepAction
+  | SetMethodAction
   | ShowModalAction
   | UpdatePaymentFailureAction
   | UpdatePaymentLoadingAction

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
@@ -200,7 +200,6 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
     ) : (
       `${orderType === OrderType.BUY ? 'Buy' : 'Sell'} ${baseAmount} ${baseCurrency}`
     )
-
   return (
     <CustomForm onSubmit={props.handleSubmit}>
       <FlyoutWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/index.tsx
@@ -38,6 +38,12 @@ class Checkout extends PureComponent<Props> {
       cryptoAmount
     )
 
+    // If no method was given but we have a default method, set it in redux
+    // and the rest of the SB flow works much better
+    if (!this.props.method && this.props.defaultMethod) {
+      this.props.simpleBuyActions.setMethod(this.props.defaultMethod)
+    }
+
     if (!Remote.Success.is(this.props.data)) {
       this.props.simpleBuyActions.fetchSDDEligible()
       this.props.simpleBuyActions.fetchSBCards()

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/template.success.tsx
@@ -447,15 +447,18 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
           </QuoteActionContainer>
         </LiftedActions>
         <AnchoredActions>
-          {props.isRecurringBuy && props.formValues.period && props.orderType === OrderType.BUY && (
-            <Scheduler
-              onClick={setOrderFrequncy}
-              period={props.formValues.period}
-              method={method || props.defaultMethod}
-            >
-              {getPeriodTitleText(props.formValues.period)}
-            </Scheduler>
-          )}
+          {props.isRecurringBuy &&
+            props.formValues.period &&
+            !props.isSddFlow &&
+            props.orderType === OrderType.BUY && (
+              <Scheduler
+                onClick={setOrderFrequncy}
+                period={props.formValues.period}
+                method={method || props.defaultMethod}
+              >
+                {getPeriodTitleText(props.formValues.period)}
+              </Scheduler>
+            )}
 
           {(!props.isSddFlow || props.orderType === OrderType.SELL) &&
             props.pair &&


### PR DESCRIPTION
## Description (optional)
Logging in, opening up simple buy with only a default payment method,  selecting a recurring buy period (ex. Weekly) then submitting the form would correctly submit the recurring buy, but on the checkout confirm page, the UI would say it's only a One Time purchase.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

