### PR TITLE
Fix/btc priv ec pair

### DIFF
--- a/packages/blockchain-wallet-v4/src/utils/btc.js
+++ b/packages/blockchain-wallet-v4/src/utils/btc.js
@@ -142,39 +142,34 @@ const parseMiniKey = function(miniKey) {
   return crypto.sha256(miniKey)
 }
 
-export const privateKeyStringToKey = function(
-  value,
-  format,
-  network = networks.bitcoin,
-  addr
-) {
+export const privateKeyStringToKey = function (value, format, network = networks.bitcoin, addr) {
   if (format === 'sipa' || format === 'compsipa') {
     return ECPair.fromWIF(value, network)
-  } else {
-    let keyBuffer = null
-
-    switch (format) {
-      case 'base58':
-        keyBuffer = Base58.decode(value)
-        break
-      case 'base64':
-        keyBuffer = Buffer.from(value, 'base64')
-        break
-      case 'hex':
-        keyBuffer = Buffer.from(value, 'hex')
-        break
-      case 'mini':
-        keyBuffer = parseMiniKey(value)
-        break
-      default:
-        throw new Error('Unsupported Key Format')
-    }
-    let keyPair = ECPair.fromPrivateKey(keyBuffer)
-    if (addr && keyPairToAddress(keyPair) !== addr) {
-      keyPair.compressed = false
-    }
-    return keyPair
   }
+  let keyBuffer = null
+
+  switch (format) {
+    case 'base58':
+      keyBuffer = Base58.decode(value)
+      break
+    case 'base64':
+      keyBuffer = Buffer.from(value, 'base64')
+      break
+    case 'hex':
+      keyBuffer = Buffer.from(value, 'hex')
+      break
+    case 'mini':
+      keyBuffer = parseMiniKey(value)
+      break
+    default:
+      throw new Error('Unsupported Key Format')
+  }
+  const paddedKeyBuffer = Buffer.alloc(32).fill(keyBuffer)
+  const keyPair = ECPair.fromPrivateKey(paddedKeyBuffer)
+  if (addr && keyPairToAddress(keyPair) !== addr) {
+    keyPair.compressed = false
+  }
+  return keyPair
 }
 
 // formatPrivateKeyString :: String -> String -> String

--- a/packages/blockchain-wallet-v4/src/utils/btc.spec.js
+++ b/packages/blockchain-wallet-v4/src/utils/btc.spec.js
@@ -2,7 +2,7 @@ import { networks } from 'bitcoinjs-lib'
 
 import * as utils from './btc'
 
-const fromHex = hex => Buffer.from(hex, 'hex')
+const fromHex = (hex) => Buffer.from(hex, 'hex')
 
 describe('Btc Utils', () => {
   const validAddresses = [
@@ -24,15 +24,13 @@ describe('Btc Utils', () => {
       '76a914c4e6fa17222f7ce3b2461fb4a73b26ac5255b04e88ac'
     ),
     '1Jx89A4TcLVUNwdfrGXv7w7WasJ3HDqQ29': undefined,
-    '3QX3B2UqEiQ8kZPwAoySuzFCLawH8GbRe7': fromHex(
-      'a914fa67c6cfa1803d0621d2eca35099b2ea38e9719f87'
-    ),
+    '3QX3B2UqEiQ8kZPwAoySuzFCLawH8GbRe7': fromHex('a914fa67c6cfa1803d0621d2eca35099b2ea38e9719f87'),
     '3QX3B2UqEiQ8kZPwAoySuzFCLawH8GbRe8': undefined,
-    bc1qud8x3munrjf70t6l9dd5dt5dygnpq2vz3u8ksv: fromHex(
-      '0014e34e68ef931c93e7af5f2b5b46ae8d2226102982'
-    ),
     bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5ss52r5n8: fromHex(
       '5120da4710964f7852695de2da025290e24af6d8c281de5a0b902b7135fd9fd74d21'
+    ),
+    bc1qud8x3munrjf70t6l9dd5dt5dygnpq2vz3u8ksv: fromHex(
+      '0014e34e68ef931c93e7af5f2b5b46ae8d2226102982'
     ),
     bc1qud8x3munrjf70t6l9dd5dt5dygnpq2vz3u8ksw: undefined,
     bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej: fromHex(
@@ -42,33 +40,31 @@ describe('Btc Utils', () => {
   }
 
   const child = {
+    chainCode: '119a9dab3772c309593f6c26767a10f6c6356489fd50477ef164af7d6fd129f1',
     publicKey:
-      '0407b481a081a3e297aaafc432141247aeb441ba948b3df1db07760e677ff5387a84eb0d7b00d858746d18d436d07d2e4759dfb848d3ff689b9142f0dfe5153352',
-    chainCode:
-      '119a9dab3772c309593f6c26767a10f6c6356489fd50477ef164af7d6fd129f1'
+      '0407b481a081a3e297aaafc432141247aeb441ba948b3df1db07760e677ff5387a84eb0d7b00d858746d18d436d07d2e4759dfb848d3ff689b9142f0dfe5153352'
   }
   const parent = {
+    chainCode: 'a4edb4ef51d72c30033f0bab3eec27d6392a8b649a39687141714f39b096b5af',
     publicKey:
-      '04d68a4a499ba232fcf48f3de42706cf14ac13e210a62915cec0b6ef0c39027892aa6b612cdddce822dc702d03b1b0d0ba9f3a902e3d2ffd371f54a7c336de8ccd',
-    chainCode:
-      'a4edb4ef51d72c30033f0bab3eec27d6392a8b649a39687141714f39b096b5af'
+      '04d68a4a499ba232fcf48f3de42706cf14ac13e210a62915cec0b6ef0c39027892aa6b612cdddce822dc702d03b1b0d0ba9f3a902e3d2ffd371f54a7c336de8ccd'
   }
 
   describe('Address', () => {
     it('Should validate addresses', () => {
       validAddresses
-        .map(addr => utils.isValidBtcAddress(addr, networks.bitcoin))
-        .forEach(v => expect(v).toEqual(true))
+        .map((addr) => utils.isValidBtcAddress(addr, networks.bitcoin))
+        .forEach((v) => expect(v).toEqual(true))
     })
 
     it('Should find checksum errors', () => {
       invalidAddresses
-        .map(addr => utils.isValidBtcAddress(addr, networks.bitcoin))
-        .forEach(v => expect(v).toEqual(false))
+        .map((addr) => utils.isValidBtcAddress(addr, networks.bitcoin))
+        .forEach((v) => expect(v).toEqual(false))
     })
 
     it('Should create correct scripts', () => {
-      for (let addr in scriptMapping) {
+      for (const addr in scriptMapping) {
         const actualScript = utils.addressToScript(addr)
         const expectedScript = scriptMapping[addr]
         expect(actualScript).toEqual(expectedScript)
@@ -83,9 +79,7 @@ describe('Btc Utils', () => {
       const expectedXpub =
         'xpub6BwFGQ41Zi14LdeBtF42CBxaFeH84HBTAR9adRHbWWL53iTaRF5WNUzK2ojRQ3feH7Mx3bi2tAuBXV4qemaPrAAJjpUGgp3aAj3xVDMp8p2'
       const path = "44'/0'/0'"
-      expect(utils.createXpubFromChildAndParent(path, child, parent)).toEqual(
-        expectedXpub
-      )
+      expect(utils.createXpubFromChildAndParent(path, child, parent)).toEqual(expectedXpub)
     })
   })
 
@@ -107,10 +101,39 @@ describe('Btc Utils', () => {
 
   describe('compressPublicKey', () => {
     it('Should compress a public key', () => {
-      const cpk =
-        '0207b481a081a3e297aaafc432141247aeb441ba948b3df1db07760e677ff5387a'
+      const cpk = '0207b481a081a3e297aaafc432141247aeb441ba948b3df1db07760e677ff5387a'
       const pk = Buffer.from(child.publicKey, 'hex')
       expect(utils.compressPublicKey(pk).toString('hex')).toEqual(cpk)
+    })
+  })
+
+  describe('privateKeyStringToKey', () => {
+    const privToAddress = (priv) => {
+      const keyFormat = utils.detectPrivateKeyFormat(priv)
+      const keyPair = utils.privateKeyStringToKey(priv, keyFormat)
+      const address = utils.keyPairToAddress(keyPair)
+      return address
+    }
+
+    it('should handle a compressed WIF', () => {
+      const compressedWIF = 'L2kurXbbcK6GDxK5hEvj9LeyLh5z7DAGpJjdY5nw7S98JWBXRoah'
+      const address = privToAddress(compressedWIF)
+      expect(address).toBe('12rMiKu35FgnGHsjsgkntGTt2TEwrFj4QL')
+    })
+    it('should handle uncompressed WIF', () => {
+      const uncompressedWIF = '5Hw99PNp237fFqR1ph5iXSK6c3iNRXco5b61baqcaqiN3HDd95W'
+      const address = privToAddress(uncompressedWIF)
+      expect(address).toBe('1KLdmszPfJrow2vmrG2e7iX4JJv5TXagZP')
+    })
+    it('should handle hex format', () => {
+      const hexFormatPriv = '0F9068759F84E38016CD0D2D7AA28D0A0A98664D0A2597C679B7F3D352005E5D'
+      const address = privToAddress(hexFormatPriv)
+      expect(address).toBe('1EQqb51PAxSVPKc8TmFp23SBXxmpuhQcS')
+    })
+    it('should handle base64 format', () => {
+      const base64FormatPriv = 'D5BodZ+E44AWzQ0teqKNCgqYZk0KJZfGebfz01IAXl0='
+      const address = privToAddress(base64FormatPriv)
+      expect(address).toBe('1EQqb51PAxSVPKc8TmFp23SBXxmpuhQcS')
     })
   })
 })


### PR DESCRIPTION
I didn't really know what to do here.

The old bitcoinjs-lib ECPair didn't have typecheck against the keyBuffer. I switched to the bitcoinforkjs-lib, which we use for bitcoin cash and tried to wrap it in what I think are valid checks.

Added tests for other formats to make sure those still work as expected.