### PR TITLE
fix(account-reset): skip initial address call for reset and recover

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/CloudRecovery/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/CloudRecovery/index.tsx
@@ -37,18 +37,18 @@ const BadgeRow = styled(CenteredRow)`
 `
 
 const CloudRecovery = (props: Props) => {
-  const { cachedEmail, cachedGuid, emailFromMagicLink, lastGuid, qrData } = props
+  const { cachedGuid, emailFromMagicLink, lastGuid, qrData } = props
 
   return (
     <Wrapper>
-      {cachedEmail && (
+      {emailFromMagicLink && (
         <BackArrowFormHeader
           handleBackArrowClick={() => props.setStep(RecoverSteps.RECOVERY_OPTIONS)}
           email={emailFromMagicLink}
           guid={cachedGuid || lastGuid}
         />
       )}
-      {!cachedEmail && (
+      {!emailFromMagicLink && (
         <GoBackArrow handleBackArrowClick={() => props.setStep(RecoverSteps.RECOVERY_OPTIONS)} />
       )}
       <Body>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryOptions/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryOptions/index.tsx
@@ -30,25 +30,19 @@ const TextStack = styled.div`
   max-width: 312px;
 `
 const RecoveryOptions = (props: Props) => {
-  const {
-    cachedEmail,
-    cachedGuid,
-    emailFromMagicLink,
-    formActions,
-    lastGuid,
-    nabuId,
-    routerActions
-  } = props
+  const { cachedGuid, emailFromMagicLink, formActions, lastGuid, nabuId, routerActions } = props
   return (
     <Wrapper>
-      {cachedEmail && (
+      {emailFromMagicLink && (
         <BackArrowFormHeader
           handleBackArrowClick={() => routerActions.push('/login')}
           email={emailFromMagicLink}
           guid={cachedGuid || lastGuid}
         />
       )}
-      {!cachedEmail && <GoBackArrow handleBackArrowClick={() => routerActions.push('/login')} />}
+      {!emailFromMagicLink && (
+        <GoBackArrow handleBackArrowClick={() => routerActions.push('/login')} />
+      )}
       <FormBody>
         <Text color='grey900' size='20px' weight={600} lineHeight='1.5'>
           <FormattedMessage

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryPhrase/FirstStep/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryPhrase/FirstStep/index.tsx
@@ -37,7 +37,7 @@ const FirstStep = (props: Props) => {
   } = props
   return (
     <Wrapper>
-      {cachedEmail && (
+      {emailFromMagicLink && (
         <BackArrowFormHeader
           handleBackArrowClick={() => setStep(RecoverSteps.RECOVERY_OPTIONS)}
           email={emailFromMagicLink}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/StepOne/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/StepOne/index.tsx
@@ -38,13 +38,12 @@ class StepOne extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { cachedEmail, cachedGuid, emailFromMagicLink, lastGuid } = this.props
+    const { emailFromMagicLink } = this.props
     return (
       <>
         <BackArrowFormHeader
           handleBackArrowClick={() => this.handleGoBackClick}
           email={emailFromMagicLink}
-          guid={cachedGuid || lastGuid}
           step={RecoverSteps.RESET_ACCOUNT}
         />
         {this.state.firstResetAcccountPrompt && (

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/StepTwo/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/StepTwo/index.tsx
@@ -23,23 +23,12 @@ const Footer = styled(FormGroup)`
 const validatePasswordConfirmation = validPasswordConfirmation('resetAccountPassword')
 
 const SecondStep = (props: Props) => {
-  const {
-    cachedEmail,
-    cachedGuid,
-    emailFromMagicLink,
-    invalid,
-    isRegistering,
-    lastGuid,
-    resetPassword,
-    setStep
-  } = props
-
+  const { emailFromMagicLink, invalid, isRegistering, resetPassword, setStep } = props
   return (
     <>
       <BackArrowFormHeader
         handleBackArrowClick={() => setStep(RecoverSteps.RECOVERY_OPTIONS)}
         email={emailFromMagicLink}
-        guid={cachedGuid || lastGuid}
         step={RecoverSteps.RESET_ACCOUNT}
       />
       <FormGroup>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/model.tsx
@@ -95,7 +95,7 @@ export const GoBackArrow = (props: { handleBackArrowClick: () => void }) => {
 
 export const BackArrowFormHeader = (props: {
   email: string
-  guid: string
+  guid?: string
   handleBackArrowClick: () => void
   step?: RecoverSteps
 }) => {


### PR DESCRIPTION
## Description (optional)
1. Directs to /home if account reset, not to /verify-email as it usually does with firstLogin
2. Skips setUserInitialAddress for wallet recovery and account reset
3. Fixes some issue with screen header if there's no magic link data

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

