### PR TITLE
fix(recurring buy): use recurring buy payment info to determine if first time buy flow should pop up or not based on the payment method used

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/recurringBuy/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/recurringBuy/selectors.ts
@@ -24,6 +24,17 @@ export const isAvailableMethod = (period: RecurringBuyPeriods, method?: SBPaymen
     return (paymentInfoPeriod && paymentInfoPeriod.eligibleMethods.includes(method.type)) || false
   })
 
+export const anyAvailablePeriods = (method?: SBPaymentMethodType) =>
+  createSelector(getPaymentInfo, (paymentInfoR) => {
+    if (!method) return false
+
+    const paymentInfo = paymentInfoR.getOrElse([]).filter((pi) => {
+      return pi.eligibleMethods.includes(method.type)
+    })
+
+    return paymentInfo.length > 0
+  })
+
 export const getRegisteredListByCoin = (coin) =>
   createSelector(getRegisteredList, (registeredListR) => {
     return registeredListR.getOrElse([]).filter((l) => l.destinationCurrency === coin)


### PR DESCRIPTION
## Description (optional)
Make a fresh account with no transactions on it. Then make a one time simple buy with a credit card, on the order summary screen click the "ok" button. The modal should simply close and no other modal prompting you to make it a recurring buy should pop up.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

