### PR TITLE
feat(country on signup): use currency from user details after signup

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -11,7 +11,7 @@ import profileSagas from 'data/modules/profile/sagas'
 import walletSagas from 'data/wallet/sagas'
 import * as C from 'services/alerts'
 import { isGuid } from 'services/forms'
-import { askSecondPasswordEnhancer, confirm } from 'services/sagas'
+import { askSecondPasswordEnhancer } from 'services/sagas'
 
 import { guessCurrencyBasedOnCountry } from './helpers'
 import { parseMagicLink } from './sagas.utils'
@@ -22,7 +22,7 @@ const { MOBILE_LOGIN } = model.analytics
 
 export default ({ api, coreSagas, networks }) => {
   const logLocation = 'auth/sagas'
-  const { createUser, generateRetailToken, setSession } = profileSagas({
+  const { createUser, generateRetailToken, setSession, waitForUserData } = profileSagas({
     api,
     coreSagas,
     networks
@@ -202,6 +202,32 @@ export default ({ api, coreSagas, networks }) => {
       if (firstLogin && signupCountryEnabled && !isAccountReset && !recovery) {
         // create nabu user
         yield call(createUser)
+        // store initial address in case of US state we add prefix
+        const userState = country === 'US' ? `US-${state}` : state
+        yield call(api.setUserInitialAddress, country, userState)
+        yield call(coreSagas.settings.fetchSettings)
+      }
+
+      if (firstLogin && signupCountryEnabled && !isAccountReset && !recovery) {
+        // create nabu user
+        yield call(createUser)
+        yield call(waitForUserData)
+
+        yield put(actions.modules.profile.fetchUser())
+        yield take(actionTypes.modules.profile.FETCH_USER_DATA_SUCCESS)
+        const currencieData = (yield select(selectors.modules.profile.getUserCurrencies)).getOrElse(
+          {
+            currencies: {}
+          }
+        )
+        const countryCode = country || 'US'
+        let currency = guessCurrencyBasedOnCountry(countryCode)
+        if (currencieData && currencieData.defaultWalletCurrency) {
+          currency = currencieData.defaultWalletCurrency
+        }
+
+        yield put(actions.modules.settings.updateCurrency(currency, true))
+
         // store initial address in case of US state we add prefix
         const userState = country === 'US' ? `US-${state}` : state
         yield call(api.setUserInitialAddress, country, userState)

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/selectors.ts
@@ -31,6 +31,7 @@ export const getUserData = (state: RootState) => state.profile.userData
 export const getUserCampaigns = (state: RootState) => state.profile.userCampaigns
 
 export const getUserId = compose(lift(prop('id')), getUserData)
+export const getUserCurrencies = compose(lift(prop('currencies')), getUserData)
 export const getWalletAddresses = compose(lift(prop('walletAddresses')), getUserData)
 export const getUserActivationState = compose(lift(prop('state')), getUserData)
 export const getUserKYCState = compose(lift(prop('kycState')), getUserData) as (


### PR DESCRIPTION
## Description (optional)
This is improvement to use API help for setting default currency based on country on signup

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.


We are missing BE support
