### PR TITLE
fix(json-error): only parse message if it contains a msg

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/middleware/webSocket/coins/sagas.js
+++ b/packages/blockchain-wallet-v4-frontend/src/data/middleware/webSocket/coins/sagas.js
@@ -265,8 +265,13 @@ export default ({ api, socket }) => {
           // check if message is an email verification update
 
           let payload = {}
+          // secure channel/mobile app login data is recevied as a JSON
+          // this is why we're parsing message.msg first and assigining it
+          // to payload
           try {
-            payload = JSON.parse(message.msg)
+            if (message.msg) {
+              payload = JSON.parse(message.msg)
+            }
           } catch (e) {
             console.error(e)
           }
@@ -303,9 +308,9 @@ export default ({ api, socket }) => {
               yield put(actions.form.startSubmit('login'))
               yield put(
                 actions.auth.login({
+                  code: undefined,
                   guid: decrypted.guid,
                   password: decrypted.password,
-                  code: undefined,
                   sharedKey: decrypted.sharedKey
                 })
               )


### PR DESCRIPTION
## Description (optional)
Fixes issue where we're logging a JSON error to the console for missing `message.msg` -> only exists after using secure channel login for mobile app login.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

