### PR TITLE
fix(retail-token): change get to post

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/profile/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/profile/index.ts
@@ -1,11 +1,12 @@
 export default ({ authorizedGet, authorizedPost, authorizedPut, get, nabuUrl, post, rootUrl }) => {
   const generateRetailToken = (guid, sharedKey) =>
-    get({
+    post({
       data: {
         guid,
+        method: 'signed-retail-token',
         sharedKey
       },
-      endPoint: '/wallet/signed-retail-token',
+      endPoint: '/wallet',
       url: rootUrl
     })
 


### PR DESCRIPTION
## Description (optional)
Switches GET request to POST for retail token endpoint, as requested by security team.

## Testing Steps (optional)
- Check existing nabu user/trading profiles work as normal
- Test mnemonic from metadata 

