### PR TITLE
fix(buysell): use preferredFiatTradingCurrency from userData when checking buy sell eligibility instead of user view currency

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/simpleBuy/sagas.ts
@@ -1205,8 +1205,8 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
     const latestPendingOrder = S.getSBLatestPendingOrder(yield select())
 
     yield put(actions.modals.showModal('SIMPLE_BUY_MODAL', { cryptoCurrency, origin }))
-    const fiatCurrencyR = selectors.core.settings.getCurrency(yield select())
-    const fiatCurrency = fiatCurrencyR.getOrElse('USD')
+    const currencies = selectors.modules.profile.getUserCurrencies(yield select())
+    const fiatCurrency = currencies?.preferredFiatTradingCurrency || 'USD'
     if (latestPendingOrder) {
       const bankAccount = yield call(getBankInformation, latestPendingOrder as SBOrderType)
       let step: T.StepActionsPayload['step'] =

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/selectors.ts
@@ -1,3 +1,4 @@
+import { createSelector } from '@reduxjs/toolkit'
 import {
   any,
   complement,
@@ -62,7 +63,10 @@ export const isSilverOrAbove = compose(
 )
 
 export const getCurrentTier = compose(path(['data', 'current']), lift(path(['tiers'])), getUserData)
-
+export const getUserCurrencies = createSelector(getUserData, (userDataR) => {
+  const userData = userDataR.getOrElse({} as UserDataType)
+  return userData.currencies
+})
 export const getUserCountryCode = compose(lift(path(['address', 'country'])), getUserData)
 export const getUserStateCode = compose(lift(path(['address', 'state'])), getUserData)
 export const getUserTiers = compose(lift(prop('tiers')), getUserData)

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/types.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios'
 
-import type { NabuAddressType, NabuApiErrorType, RemoteDataType } from '@core/types'
+import type { NabuAddressType, NabuApiErrorType, RemoteDataType, WalletFiatType } from '@core/types'
 import type { CampaignsType } from 'data/components/identityVerification/types'
 
 import * as AT from './actionTypes'
@@ -82,8 +82,15 @@ export type Tiers = {
   selected: 0 | 1 | 2 | 3
 }
 
+export type UserTradingCurencies = {
+  defaultWalletCurrency: WalletFiatType
+  preferredFiatTradingCurrency: WalletFiatType
+  usableFiatCurrencies: WalletFiatType[]
+}
+
 export type UserDataType = {
   address?: NabuAddressType
+  currencies: UserTradingCurencies
   dob: string
   email: string
   emailVerified: boolean

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/Checkout/index.tsx
@@ -26,7 +26,7 @@ class Checkout extends PureComponent<Props> {
     const amount = goalAmount || this.props.formValues?.amount || '0'
     const cryptoAmount = this.props.formValues?.cryptoAmount
     const period = this.props.formValues?.period || RecurringBuyPeriods.ONE_TIME
-
+    this.errorCallback = this.errorCallback.bind(this)
     this.props.buySellActions.initializeCheckout({
       account: this.props.swapAccount,
       amount,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/EnterAmount/template.success.tsx
@@ -10,7 +10,7 @@ const Success: React.FC<Props> = (props) => {
   const isUserEligible =
     props.paymentMethods.methods.length &&
     props.paymentMethods.methods.find(
-      (method) => method.limits.max !== '0' && method.currency === props.fiatCurrency
+      (method) => method.limits?.max !== '0' && method.currency === props.fiatCurrency
     )
 
   // Check to see if user can sell into their wallet's preferred currency


### PR DESCRIPTION
## Description (optional)
When a user changes their wallet view currency to something like the Brazilian Real, and then opens the buy sell flow. The app requests payment methods with that currency which we don't support and so the app errors. We have a relatively new set of userData which has the users eligible currency that we get from the api. We should use this currency instead as it's is much more reliable. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

