### PR TITLE
fix(polling): remove copy to open link in same browser

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/en.json
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/en.json
@@ -1757,7 +1757,7 @@
   "scenes.login.approve": "Approve your login",
   "scenes.login.authorize": "Authorize login",
   "scenes.login.browserwarning": "Your browser is not supported. Please update to at least Chrome 45, Firefox 45, Safari 8, Edge, or Opera.",
-  "scenes.login.checkemail": "If you have an account registered with this email address, you will receive an email with a link to verify your device. <b>Open the link in this browser window.</b>",
+  "scenes.login.checkemail": "If you have an account registered with this email address, you will receive an email with a link to verify your device.",
   "scenes.login.device_verification_failed": "Device verification failed.",
   "scenes.login.device_verified": "Your device is verified!",
   "scenes.login.device_verified.copy": "Return to previous browser to continue logging in.",

--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -2192,7 +2192,7 @@ type MessagesType = {
   'scenes.login.approve': 'Approve your login'
   'scenes.login.authorize': 'Authorize login'
   'scenes.login.browserwarning': 'Your browser is not supported. Please update to at least Chrome 45, Firefox 45, Safari 8, Edge, or Opera.'
-  'scenes.login.checkemail': 'If you have an account registered with this email address, you will receive an email with a link to verify your device. <b>Open the link in this browser window.</b>'
+  'scenes.login.checkemail': 'If you have an account registered with this email address, you will receive an email with a link to verify your device.'
   'scenes.login.clickhere': 'click here.'
   'scenes.login.device_verification_expired': 'Verification link expired.'
   'scenes.login._device_verification_expired.copy': 'The device approval link has expired, please try again.'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/CheckEmail/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/CheckEmail/index.tsx
@@ -41,7 +41,7 @@ const CheckEmail = (props: Props) => {
         >
           <FormattedMessage
             id='scenes.login.checkemail'
-            defaultMessage='If you have an account registered with this email address, you will receive an email with a link to verify your device. <b>Open the link in this browser window.</b>'
+            defaultMessage='If you have an account registered with this email address, you will receive an email with a link to verify your device.'
           />
         </Text>
       </FormBody>


### PR DESCRIPTION
## Description (optional)
Removes 'Open the link in this browser window.' copy from the Check Email screen. no longer necc. with new device authorization work. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

