### PR TITLE
fix(prices-buy-sell): only show buy and sell on select tokens

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/actions.column.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/actions.column.tsx
@@ -21,28 +21,30 @@ export const getActionsColumn = (
 ) => ({
   Cell: ({ row: { original: values } }) => (
     <CellWrapper>
-      <Button
-        data-e2e={`${values.coin}BuySellBtn`}
-        height='32px'
-        nature='primary'
-        onClick={() => {
-          buySellActions.showModal({
-            cryptoCurrency: values.coin,
-            orderType: OrderType.BUY,
-            origin: 'Prices'
-          })
-        }}
-        width='96px'
-        style={{ marginRight: '12px' }}
-      >
-        <Text size='14px' color='white' weight={600}>
-          {Number(values.balance) > 0 ? (
-            <FormattedMessage id='buttons.buy_sell' defaultMessage='Buy & Sell' />
-          ) : (
-            <FormattedMessage id='buttons.buy' defaultMessage='Buy' />
-          )}
-        </Text>
-      </Button>
+      {values.products.includes('CustodialWalletBalance') ? (
+        <Button
+          data-e2e={`${values.coin}BuySellBtn`}
+          height='32px'
+          nature='primary'
+          onClick={() => {
+            buySellActions.showModal({
+              cryptoCurrency: values.coin,
+              orderType: OrderType.BUY,
+              origin: 'Prices'
+            })
+          }}
+          width='96px'
+          style={{ marginRight: '12px' }}
+        >
+          <Text size='14px' color='white' weight={600}>
+            {Number(values.balance) > 0 ? (
+              <FormattedMessage id='buttons.buy_sell' defaultMessage='Buy & Sell' />
+            ) : (
+              <FormattedMessage id='buttons.buy' defaultMessage='Buy' />
+            )}
+          </Text>
+        </Button>
+      ) : null}
       <Button
         data-e2e={`${values.coin}SwapBtn`}
         height='32px'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/selectors.ts
@@ -35,7 +35,8 @@ export const getData = createDeepEqualSelector(
           price: currentPrice,
           priceChange: Number(((currentPrice - yesterdayPrice) / yesterdayPrice) * 100).toPrecision(
             2
-          )
+          ),
+          products: coinfig.products
         }
       })
 


### PR DESCRIPTION
## Description (optional)
https://blockchain.atlassian.net/browse/FWN-969

Only select token will have buy and sell depending on `CustodialWalletBalance` is in `window.coins.ETH.coinfig.products`

## Testing Steps (optional)
It works using account provided by Phil: 

bbdca2df-XXXX

