### PR TITLE
fix(sb): correct button copy

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/CheckoutConfirm/template.success.tsx
@@ -201,7 +201,11 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
     paymentPartner === BankPartners.YAPILY ? (
       <FormattedMessage id='copy.next' defaultMessage='Next' />
     ) : (
-      `${orderType === OrderType.BUY ? 'Buy' : 'Sell'} ${baseAmount} ${baseCurrencyDisplay}`
+      <FormattedMessage
+        id='buttons.buy_sell_now'
+        defaultMessage='{orderType} Now'
+        values={{ orderType: orderType === OrderType.BUY ? 'Buy' : 'Sell' }}
+      />
     )
   return (
     <CustomForm onSubmit={props.handleSubmit}>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/PreviewSell/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SimpleBuy/PreviewSell/index.tsx
@@ -38,18 +38,15 @@ const CustomForm = styled(Form)`
 
 const RowItem = styled(Row)`
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
 `
 const TopRow = styled.div`
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
 `
 
 const RowIcon = styled.div`
   display: flex;
-  flex-direction: row;
 `
 
 const RowItemContainer = styled.div`
@@ -76,7 +73,6 @@ const AdditionalText = styled(Text)`
 `
 const ToolTipText = styled.div`
   display: flex;
-  flex-direction: row;
   border-radius: 8px;
   margin-top: 8px;
   padding: 16px;
@@ -127,7 +123,6 @@ const DisclaimerText = styled(Text)`
   display: flex;
   font-size: 14px;
   font-weight: 500;
-  flex-direction: row;
   margin-top: 24px;
   text-align: left;
   a {
@@ -538,10 +533,10 @@ class PreviewSell extends PureComponent<
                   ) : (
                     <Text weight={600} color='white'>
                       <FormattedMessage
-                        id='buttons.sell_coin'
-                        defaultMessage='Sell {displayName}'
+                        id='buttons.buy_sell_now'
+                        defaultMessage='{orderType} Now'
                         values={{
-                          displayName: this.displayAmount(formValues, account)
+                          orderType: 'Sell'
                         }}
                       />
                     </Text>


### PR DESCRIPTION
## Description (optional)
Buy/Sell Crypto → Sell → go all the way to checkout screen and make sure it says `Sell Now` or `Buy Now`


####Screenshots
![Screen Shot 2021-11-19 at 3 14 17 PM](https://user-images.githubusercontent.com/39777266/142687005-2922ee5b-9bf5-4794-bb3a-fed8447582b3.png)
![Screen Shot 2021-11-19 at 3 13 52 PM](https://user-images.githubusercontent.com/39777266/142687008-faff8bce-ca12-488e-aede-158b9e1bdad7.png)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

