### PR TITLE
fix(interest): fixed issue with download transaction history since we did pass array as object which is not ok

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
@@ -160,7 +160,7 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
       }
       // TODO figure out any replacement type
       const report = concat(reportHeaders, txList) as any
-      yield put(A.fetchInterestTransactionsReportSuccess({ ...report }))
+      yield put(A.fetchInterestTransactionsReportSuccess(report))
     } catch (e) {
       const error = errorHandler(e)
       yield put(A.fetchInterestTransactionsReportFailure(error))


### PR DESCRIPTION
## Description (optional)
This PR fix issue with download transaction history

## Testing Steps (optional)
You need a wallet with interest rewards(transactions), go to rewards page and check transaction list, try to download it you should be able to see generated link

