### PR TITLE
feat(seamless limits): improved error message when amount is over max for deposit flow

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/EnterAmount.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/EnterAmount.tsx
@@ -234,7 +234,7 @@ const debounceValidate = (limits, crossBorderLimits, orderType, fiatCurrency, ba
       dispatch(stopAsyncValidation('brokerageTx', limitError))
     }
 
-    const error = minMaxAmount(limits, orderType, fiatCurrency, newValue)
+    const error = minMaxAmount(limits, orderType, fiatCurrency, newValue, bankText)
     if (error) {
       dispatch(stopAsyncValidation('brokerageTx', error))
     }

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/validation.tsx
@@ -13,7 +13,8 @@ export const minMaxAmount = (
   limits: { max: string; min: string },
   orderType: BrokerageOrderType,
   fiatCurrency: FiatType,
-  amount: string
+  amount: string,
+  bankText: string
 ) => {
   const max = convertBaseToStandard('FIAT', limits.max)
   const min = convertBaseToStandard('FIAT', limits.min)
@@ -26,8 +27,13 @@ export const minMaxAmount = (
     value: min
   })
 
+  const formattedAmount = fiatToString({
+    unit: fiatCurrency,
+    value: amount
+  })
+
   // This handles the default case where we show "0" in the input field but
-  // it's just a placeholder and amount actuall equals '' in redux
+  // it's just a placeholder and amount actual equals '' in redux
   if (amount === '') return undefined
   // The min max logic
   if (Number(amount) > Number(max)) {
@@ -66,6 +72,25 @@ export const minMaxAmount = (
                 values={{
                   amount: formattedMax,
                   currency: fiatCurrency
+                }}
+              />
+            </Text>
+          )}
+
+          {orderType === BrokerageOrderType.DEPOSIT && (
+            <Text
+              size='14px'
+              color='textBlack'
+              weight={500}
+              style={{ marginTop: '24px', textAlign: 'center' }}
+            >
+              <FormattedMessage
+                id='modals.brokerage.deposit_limit'
+                defaultMessage='Looks like your {bank} only allows deposits up to {maxAmount} at at time. To deposit {enterAmount}, split your deposit into multiple transactions.'
+                values={{
+                  bank: bankText,
+                  enterAmount: formattedAmount,
+                  maxAmount: formattedMax
                 }}
               />
             </Text>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/components/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/components/index.tsx
@@ -434,24 +434,6 @@ const OverYourLimitMessage = ({ amount, currency, limit, period }) => (
 const StyledOvalButton = styled(Button)`
   border-radius: 32px;
 `
-const OverLimitButton = ({ coin }) => (
-  <StyledOvalButton
-    data-e2e='overLimitButton'
-    height='48px'
-    size='16px'
-    nature='dark-grey'
-    fullwidth
-  >
-    <Image width='16px' height='16px' name='alert-orange' />
-    <Text weight={600} size='16px' style={{ marginLeft: '2px' }} color='white'>
-      <FormattedMessage
-        id='copy.not_enough_coin'
-        defaultMessage='Not Enough {coin}'
-        values={{ coin }}
-      />
-    </Text>
-  </StyledOvalButton>
-)
 
 const AlertButton = ({ children }) => (
   <StyledOvalButton
@@ -509,7 +491,6 @@ export {
   ModalNavWithBackArrow,
   ModalNavWithCloseIcon,
   NavText,
-  OverLimitButton,
   OverYourLimitMessage,
   ScanWithPhone,
   Section,


### PR DESCRIPTION
## Description (optional)
This PR fix the issue with missing deposit error message

## Testing Steps (optional)
Any account deposit flow try to enter greater than maximum error message should be visible
![image](https://user-images.githubusercontent.com/67264242/143909264-f050b249-1383-4aad-810a-ff751464efcf.png)


