### PR TITLE
fix(login): stop magic link data polling after logging in

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -169,7 +169,7 @@ export default ({ api, coreSagas, networks }) => {
       yield call(saveGoals, firstLogin)
       yield put(actions.goals.runGoals())
       yield call(upgradeAddressLabelsSaga)
-      yield put(actions.auth.loginSuccess({}))
+      yield put(actions.auth.loginSuccess(true))
       yield put(actions.auth.startLogoutTimer())
       yield call(startCoinWebsockets)
       const guid = yield select(selectors.core.wallet.getGuid)

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.utils.ts
@@ -157,6 +157,10 @@ export const pollForSessionFromAuthPayload = function* (api, session, n = 50) {
   try {
     yield delay(2000)
     const response = yield call(api.getMagicLinkData, session)
+    const isLoggedIn = (yield select(selectors.auth.getLogin)).getOrElse(false)
+    if (isLoggedIn) {
+      return true
+    }
     if (prop('wallet', response) || prop('exchange', response)) {
       yield put(actions.auth.setMagicLinkInfo(response))
       yield call(parseMagicLink)

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/types.ts
@@ -161,7 +161,7 @@ export type ExchangeResetPasswordSuccessType = any
 
 export type ExchangeResetPasswordFailureType = any
 
-export type LoginSuccessType = {}
+export type LoginSuccessType = boolean
 
 export type LoginFailureType = string | boolean | undefined
 


### PR DESCRIPTION
## Description (optional)
Stops polling for magic link data after login is successful. Previously, we'd only stop polling once magic link data was returned from the endpoint, but if a user triggers an email but logs in with guid, we still poll and user would see an expiration message which is confusing. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

