### PR TITLE
fix(FWN-758): remove failed 3ds orders

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/TransactionList/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/TransactionList/index.tsx
@@ -33,7 +33,6 @@ const TransactionsWrapper = styled.div`
 class TransactionList extends PureComponent<Props> {
   render() {
     const { coin, coinTicker, currency, data } = this.props
-
     return data.cata({
       Failure: (message) => <DataError onClick={this.props.onRefresh} message={message} />,
       Loading: () => <Loading />,
@@ -42,7 +41,7 @@ class TransactionList extends PureComponent<Props> {
         <TransactionsWrapper>
           {transactions.map((tx) => {
             // @ts-ignore
-            return 'hash' in tx ? (
+            return 'processingErrorType' in tx ? null : 'hash' in tx ? (
               <NonCustodialTxListItem
                 key={tx.hash}
                 transaction={tx}


### PR DESCRIPTION
## Description (optional)
If a user cancels a buy within the 3ds flow. hide the failed order to prevent confusion


## Testing Steps (optional)
try to buy crypto with a card -> cancel within the 3ds flow -> check that the order is not listed in the transaction list

