### PR TITLE
feat(trading limits): use proper currency on enter amount screen

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/template.success.tsx
@@ -392,7 +392,6 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                   // Always reset back to walletCurrency
                   // Otherwise FUNDS currency and Pairs currency can mismatch
                   fiatCurrency: props.walletCurrency || 'USD',
-
                   step: 'CRYPTO_SELECTION'
                 })
               }
@@ -623,7 +622,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                       values={{
                         amount:
                           fix === 'FIAT'
-                            ? fiatToString({ unit: props.walletCurrency, value: min })
+                            ? fiatToString({ unit: props.fiatCurrency, value: min })
                             : `${min} ${Currencies[fiatCurrency].units[fiatCurrency].symbol}`
                       }}
                     />
@@ -634,7 +633,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                       values={{
                         amount:
                           fix === 'FIAT'
-                            ? fiatToString({ unit: props.walletCurrency, value: max })
+                            ? fiatToString({ unit: props.fiatCurrency, value: max })
                             : `${max} ${Currencies[fiatCurrency].units[fiatCurrency].symbol}`
                       }}
                     />
@@ -666,7 +665,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                       values={{
                         amount:
                           fix === 'FIAT'
-                            ? fiatToString({ unit: props.walletCurrency, value: min })
+                            ? fiatToString({ unit: props.fiatCurrency, value: min })
                             : `${min} ${Currencies[fiatCurrency].units[fiatCurrency].symbol}`,
                         currency: fiatCurrency
                       }}
@@ -678,7 +677,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                       values={{
                         amount:
                           fix === 'FIAT'
-                            ? fiatToString({ unit: props.walletCurrency, value: min })
+                            ? fiatToString({ unit: props.fiatCurrency, value: min })
                             : `${min} ${Currencies[fiatCurrency].units[fiatCurrency].symbol}`,
                         currency: fiatCurrency
                       }}
@@ -693,7 +692,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                       values={{
                         amount:
                           fix === 'FIAT'
-                            ? fiatToString({ unit: props.walletCurrency, value: max })
+                            ? fiatToString({ unit: props.fiatCurrency, value: max })
                             : `${min} ${Currencies[fiatCurrency].units[fiatCurrency].symbol}`,
                         coin: cryptoCurrency,
                         currency: fiatCurrency
@@ -706,7 +705,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                       values={{
                         amount:
                           fix === 'FIAT'
-                            ? fiatToString({ unit: props.walletCurrency, value: max })
+                            ? fiatToString({ unit: props.fiatCurrency, value: max })
                             : `${min} ${Currencies[fiatCurrency].units[fiatCurrency].symbol}`,
                         coin: cryptoCurrency
                       }}


### PR DESCRIPTION
## Description (optional)
Use selected trading currency instead of wallet currency during buy/sell flow

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

![image](https://user-images.githubusercontent.com/67264242/146771180-97f3e718-5416-4702-a033-511b39167394.png)

