### PR TITLE
refactor(flyout): move account logic into a sell flyout

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/SellState/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/SellState/index.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { connect, ConnectedProps } from 'react-redux'
+import { any, map, values } from 'ramda'
+import styled from 'styled-components'
+
+import { CoinAccountListOption } from 'components/Form'
+import { SwapAccountType } from 'data/types'
+
+import SellEmptyState from '../SellEmptyState'
+import { getData } from './selectors'
+
+export const IconBackground = styled.div`
+  margin-right: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  background-color: ${(props) => props.theme.blue000};
+  border-radius: 40px;
+`
+
+export const FlexStartRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+`
+
+class SellState extends React.Component<Props> {
+  // Check to see if any accounts have balance
+  checkBalances = () =>
+    // @ts-ignore
+    any((hasFunds) => hasFunds)(
+      // @ts-ignore
+      values(
+        // @ts-ignore
+        map(
+          // @ts-ignore
+          (coin) => any((acct) => acct.balance !== 0 && acct.balance !== '0')(coin),
+          // @ts-ignore
+          this.props.data.data.accounts
+        )
+      )
+    )
+
+  render() {
+    const checkAccountsBalances = this.checkBalances()
+
+    const { data, handleClose, handleSell } = this.props
+    const {
+      data: { coins, walletCurrency }
+    } = data
+
+    return checkAccountsBalances ? (
+      coins &&
+        coins.map((coin) => {
+          const accounts = data?.data?.accounts[coin] as Array<SwapAccountType>
+          return accounts.map(
+            (account) =>
+              account.balance !== '0' &&
+              account.balance !== 0 && (
+                <CoinAccountListOption
+                  key={`${account.baseCoin}-${account.index}`}
+                  account={account}
+                  coin={account.coin}
+                  isAccountSelected={false}
+                  isSwap={false}
+                  onClick={() => handleSell(account)}
+                  showLowFeeBadges
+                  walletCurrency={walletCurrency}
+                />
+              )
+          )
+        })
+    ) : (
+      <SellEmptyState handleClose={handleClose} />
+    )
+  }
+}
+
+const mapStateToProps = (state) => ({
+  data: getData(state)
+})
+
+const connector = connect(mapStateToProps)
+
+type Props = ConnectedProps<typeof connector> & {
+  handleClose: () => void
+  handleSell: (account: SwapAccountType) => void
+}
+
+export default connector(SellState)

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/SellState/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/SellState/selectors.ts
@@ -1,0 +1,20 @@
+import { lift } from 'ramda'
+
+import { FiatType } from '@core/types'
+import { selectors } from 'data'
+import { SWAP_ACCOUNTS_SELECTOR } from 'data/coins/model/swap'
+import { getCoinAccounts } from 'data/coins/selectors'
+
+export const getData = (state) => {
+  const coins = selectors.components.swap.getCoins()
+  const accounts = getCoinAccounts(state, { coins, ...SWAP_ACCOUNTS_SELECTOR })
+  const walletCurrencyR = selectors.core.settings.getCurrency(state)
+
+  return lift((walletCurrency: FiatType) => ({
+    accounts,
+    coins,
+    walletCurrency
+  }))(walletCurrencyR)
+}
+
+export default getData

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/index.tsx
@@ -245,7 +245,6 @@ class CryptoSelector extends React.Component<InjectedFormProps<{}, Props> & Prop
           </FlyoutWrapper>
           <Currencies>
             {this.state.orderType === OrderType.SELL ? (
-              // <div>ASDKJALDJASKLDSAJDLSAJD</div>
               <SellState handleSell={this.handleSell} handleClose={this.props.handleClose} />
             ) : (
               this.props.pairs.map((value) => (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/index.tsx
@@ -1,22 +1,20 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { any, equals, map, values } from 'ramda'
+import { equals } from 'ramda'
 import { Form, InjectedFormProps, reduxForm } from 'redux-form'
 import styled from 'styled-components'
 
 import { BSOrderActionType, BSPairType, FiatType, OrderType } from '@core/types'
 import { Icon, Image, TabMenu, TabMenuItem, Text } from 'blockchain-info-components'
 import { FlyoutWrapper } from 'components/Flyout'
-import { CoinAccountListOption } from 'components/Form'
 import { model } from 'data'
 import { getCoinFromPair, getFiatFromPair } from 'data/components/buySell/model'
 import { getPreferredCurrency } from 'data/components/buySell/utils'
-import { getCoins } from 'data/components/swap/selectors'
 import { SwapAccountType } from 'data/types'
 
 import { Props as OwnProps, SuccessStateType } from '../index'
 import CryptoItem from './CryptoItem'
-import SellEmptyState from './SellEmptyState'
+import SellState from './SellState'
 
 const { FORM_BS_CHECKOUT, FORM_BS_CRYPTO_SELECTION } = model.components.buySell
 
@@ -146,26 +144,8 @@ class CryptoSelector extends React.Component<InjectedFormProps<{}, Props> & Prop
     this.props.formActions.change(FORM_BS_CHECKOUT, 'amount', '')
   }
 
-  // Check to see if any accounts have balance
-  checkBalances = () =>
-    // @ts-ignore
-    any((hasFunds) => hasFunds)(
-      // @ts-ignore
-      values(
-        // @ts-ignore
-        map(
-          // @ts-ignore
-          (coin) => any((acct) => acct.balance !== 0 && acct.balance !== '0')(coin),
-          // @ts-ignore
-          this.props.accounts
-        )
-      )
-    )
-
   render() {
     const showWelcome = this.props.isFirstLogin && !this.props.sddTransactionFinished
-
-    const checkAccountsBalances = this.checkBalances()
 
     return (
       <Wrapper>
@@ -265,29 +245,8 @@ class CryptoSelector extends React.Component<InjectedFormProps<{}, Props> & Prop
           </FlyoutWrapper>
           <Currencies>
             {this.state.orderType === OrderType.SELL ? (
-              checkAccountsBalances ? (
-                getCoins().map((coin) => {
-                  const accounts = this.props.accounts[coin] as Array<SwapAccountType>
-                  return accounts.map(
-                    (account) =>
-                      account.balance !== '0' &&
-                      account.balance !== 0 && (
-                        <CoinAccountListOption
-                          key={`${account.baseCoin}-${account.index}`}
-                          account={account}
-                          coin={account.coin}
-                          isAccountSelected={false}
-                          isSwap={false}
-                          onClick={() => this.handleSell(account)}
-                          showLowFeeBadges
-                          walletCurrency={this.props.walletCurrency}
-                        />
-                      )
-                  )
-                })
-              ) : (
-                <SellEmptyState handleClose={this.props.handleClose} />
-              )
+              // <div>ASDKJALDJASKLDSAJDLSAJD</div>
+              <SellState handleSell={this.handleSell} handleClose={this.props.handleClose} />
             ) : (
               this.props.pairs.map((value) => (
                 <CryptoItem

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/selectors.ts
@@ -2,8 +2,6 @@ import { lift } from 'ramda'
 
 import { ExtractSuccess, FiatType } from '@core/types'
 import { model, selectors } from 'data'
-import { SWAP_ACCOUNTS_SELECTOR } from 'data/coins/model/swap'
-import { getCoinAccounts } from 'data/coins/selectors'
 import { BSCheckoutFormValuesType } from 'data/types'
 
 const { FORM_BS_CHECKOUT } = model.components.buySell
@@ -21,10 +19,6 @@ export const getData = (state) => {
   const userDataR = selectors.modules.profile.getUserData(state)
   const walletCurrencyR = selectors.core.settings.getCurrency(state)
 
-  // for sell, get 'swap' accounts
-  const coins = selectors.components.swap.getCoins()
-  const accounts = getCoinAccounts(state, { coins, ...SWAP_ACCOUNTS_SELECTOR })
-
   return lift(
     (
       eligibility: ExtractSuccess<typeof eligibilityR>,
@@ -35,7 +29,6 @@ export const getData = (state) => {
       sddEligible: ExtractSuccess<typeof sddEligibleR>,
       walletCurrency: FiatType
     ) => ({
-      accounts,
       eligibility,
 
       emailVerified,


### PR DESCRIPTION
## Description (optional)
move the getaccount flyout logic away from the initial load and into the sell side

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

