### PR TITLE
fix(nfts): allow for big eth amounts

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/nfts/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/nfts/types.ts
@@ -80,11 +80,11 @@ export interface ExchangeMetadataForBundle {
 export type ExchangeMetadata = ExchangeMetadataForAsset | ExchangeMetadataForBundle
 
 export interface WyvernOrder {
-  basePrice: BigNumber
+  basePrice: BigNumber | string
   calldata: string
   exchange: string
   expirationTime: BigNumber
-  extra: BigNumber
+  extra: BigNumber | string
   feeMethod: number
   feeRecipient: string
   howToCall: number

--- a/packages/blockchain-wallet-v4/src/redux/payment/nfts/utils.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/nfts/utils.ts
@@ -1065,7 +1065,7 @@ export async function _makeSellOrder({
   quantity: number
   startAmount: number
   waitForHighestBid: boolean
-}): Promise<any> {
+}): Promise<UnhashedOrder> {
   // todo: re-implement this later:
   // accountAddress = validateAndFormatWalletAddress(this.web3, accountAddress)
   // const schema = _getSchema(asset.schemaName)
@@ -2012,7 +2012,9 @@ export async function _atomicMatch({
   }
   if (buy.paymentToken === NULL_ADDRESS) {
     // For some reason uses wyvern contract for calculating the max price?.. update if needed from basePrice => max price
-    const fee = sell.takerRelayerFee.div(INVERSE_BASIS_POINT).times(sell.basePrice)
+    let fee = sell.takerRelayerFee.div(INVERSE_BASIS_POINT).times(sell.basePrice)
+    fee = typeof fee === 'string' ? new BigNumber(fee) : fee
+    // @ts-ignore: BigNumber is guaranteed
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     value = sell.basePrice.plus(fee)
   }

--- a/packages/blockchain-wallet-v4/src/redux/payment/nfts/utils.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/nfts/utils.ts
@@ -165,8 +165,8 @@ const getOrderHashHex = (order: UnhashedOrder): string => {
     // eslint-disable-next-line no-buffer-constructor
     { type: SolidityTypes.Bytes, value: new Buffer(order.staticExtradata.slice(2), 'hex') },
     { type: SolidityTypes.Address, value: order.paymentToken },
-    { type: SolidityTypes.Uint256, value: order.basePrice.toString() },
-    { type: SolidityTypes.Uint256, value: order.extra.toString() },
+    { type: SolidityTypes.Uint256, value: order.basePrice.toString(10) },
+    { type: SolidityTypes.Uint256, value: order.extra.toString(10) },
     { type: SolidityTypes.Uint256, value: order.listingTime.toString() },
     { type: SolidityTypes.Uint256, value: order.expirationTime.toString() },
     { type: SolidityTypes.Uint256, value: order.salt.toString() }
@@ -1065,7 +1065,7 @@ export async function _makeSellOrder({
   quantity: number
   startAmount: number
   waitForHighestBid: boolean
-}): Promise<UnhashedOrder> {
+}): Promise<any> {
   // todo: re-implement this later:
   // accountAddress = validateAndFormatWalletAddress(this.web3, accountAddress)
   // const schema = _getSchema(asset.schemaName)
@@ -1118,7 +1118,7 @@ export async function _makeSellOrder({
     throw new Error('contract address not defined within asset')
   }
   return {
-    basePrice: new BigNumber(basePrice.toString()),
+    basePrice: new BigNumber(basePrice.toString()).toString(10),
     calldata,
     englishAuctionReservePrice: reservePrice ? new BigNumber(reservePrice.toString()) : undefined,
     exchange: (network === 'rinkeby'
@@ -1126,7 +1126,7 @@ export async function _makeSellOrder({
       : WYVERN_CONTRACT_ADDR_MAINNET
     ).toLowerCase(),
     expirationTime: times.expirationTime,
-    extra: new BigNumber(extra.toString()),
+    extra: new BigNumber(extra.toString()).toString(10),
     feeMethod,
     feeRecipient,
     howToCall: HowToCall.Call,
@@ -1687,8 +1687,8 @@ export async function _validateOrderWyvern({
       order.takerRelayerFee.toString(),
       order.makerProtocolFee.toString(),
       order.takerProtocolFee.toString(),
-      order.basePrice.toString(),
-      order.extra.toString(),
+      order.basePrice.toString(10),
+      order.extra.toString(10),
       order.listingTime.toString(),
       order.expirationTime.toString(),
       order.salt.toString()


### PR DESCRIPTION
## Description (optional)

Converting to full string since BigNumber forces scientific notation, but opensea doesn't want
(ex. auto converts to 1e27 when we actually want '1000000000000000000000000000')
 
basePrice: BigNumber | string
extra: BigNumber | string

