### PR TITLE
feat(add payment): show unsupported method in case that user is not aligible to add payment method

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -1546,6 +1546,8 @@ type MessagesType = {
   'modals.simplebuy.add_card.billing_address': 'Billing Address'
   'modals.simplebuy.add_card.residential_address': 'Same as Residential Address'
   'modals.simplebuy.add_card.pricacy_disclaimer': 'Privacy protected with 256-Bit SSL encryption.'
+  'modals.simplebuy.add_card.unsupported-title': 'Adding Payment Coming Soon for your region.'
+  'modals.simplebuy.add_card.unsupported-subcontent': "Well this is awkward. We don't support adding payment method yet for your region."
   'modals.simplebuy.fetching_methods': 'Loading Payment Options...'
   'modals.simplebuy.billing_address': 'Billing Address'
   'modals.simplebuy.canceled': 'Trade Canceled'

--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -1546,8 +1546,6 @@ type MessagesType = {
   'modals.simplebuy.add_card.billing_address': 'Billing Address'
   'modals.simplebuy.add_card.residential_address': 'Same as Residential Address'
   'modals.simplebuy.add_card.pricacy_disclaimer': 'Privacy protected with 256-Bit SSL encryption.'
-  'modals.simplebuy.add_card.unsupported-title': 'Adding Payment Coming Soon for your region.'
-  'modals.simplebuy.add_card.unsupported-subcontent': "Well this is awkward. We don't support adding payment method yet for your region."
   'modals.simplebuy.fetching_methods': 'Loading Payment Options...'
   'modals.simplebuy.billing_address': 'Billing Address'
   'modals.simplebuy.canceled': 'Trade Canceled'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/index.tsx
@@ -9,6 +9,7 @@ import { RootState } from 'data/rootReducer'
 
 import { getData } from './selectors'
 import Success from './template.success'
+import Unsupported from './template.unsupported'
 
 const AddCardCheckoutDotCom = (props: Props) => {
   const [isError, setError] = useState(false)
@@ -67,13 +68,23 @@ const AddCardCheckoutDotCom = (props: Props) => {
     ),
     Loading: () => null,
     NotAsked: () => null,
-    Success: (val) => (
-      <Success
-        {...props}
-        {...val}
-        domain={`${props.domains.walletHelper}/wallet-helper/checkoutdotcom/#/add-card/${props.checkoutDotComApiKey}`}
-      />
-    )
+    Success: (val) => {
+      const isUserEligible =
+        val.paymentMethods.methods.length &&
+        val.paymentMethods.methods.find(
+          (method) => method.limits?.max !== '0' && method.currency === props.fiatCurrency
+        )
+
+      return isUserEligible ? (
+        <Success
+          {...props}
+          {...val}
+          domain={`${props.domains.walletHelper}/wallet-helper/checkoutdotcom/#/add-card/${props.checkoutDotComApiKey}`}
+        />
+      ) : (
+        <Unsupported handleClose={props.handleClose} />
+      )
+    }
   })
 }
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 
+import { Remote } from '@core'
 import { BSPairType, CoinType, WalletOptionsType } from '@core/types'
 import DataError from 'components/DataError'
 import { actions, selectors } from 'data'
@@ -58,6 +59,12 @@ const AddCardCheckoutDotCom = (props: Props) => {
     return () => window.removeEventListener('message', handlePostMessage, false)
   })
 
+  useEffect(() => {
+    if (props.fiatCurrency && !Remote.Success.is(props.data)) {
+      props.buySellActions.fetchFiatEligible(props.fiatCurrency)
+    }
+  }, [])
+
   if (isError) {
     return <DataError />
   }
@@ -82,7 +89,11 @@ const AddCardCheckoutDotCom = (props: Props) => {
           domain={`${props.domains.walletHelper}/wallet-helper/checkoutdotcom/#/add-card/${props.checkoutDotComApiKey}`}
         />
       ) : (
-        <Unsupported handleClose={props.handleClose} />
+        <Unsupported
+          handleClose={props.handleClose}
+          paymentAccountEligible={val.eligibility?.eligible}
+          fiatCurrency={props.fiatCurrency}
+        />
       )
     }
   })

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/selectors.ts
@@ -9,17 +9,20 @@ export const getData = (state: RootState) => {
   const paymentMethodsR = selectors.components.buySell.getBSPaymentMethods(state)
   const supportedCountriesR = selectors.components.identityVerification.getSupportedCountries(state)
   const userDataR = selectors.modules.profile.getUserData(state)
+  const eligibilityR = selectors.components.buySell.getBSFiatEligible(state)
 
   return lift(
     (
       paymentMethods: ExtractSuccess<typeof paymentMethodsR>,
       supportedCountries: ExtractSuccess<typeof supportedCountriesR>,
-      userData: ExtractSuccess<typeof userDataR>
+      userData: ExtractSuccess<typeof userDataR>,
+      eligibility: ExtractSuccess<typeof eligibilityR>
     ) => ({
+      eligibility,
       order,
       paymentMethods,
       supportedCountries,
       userData
     })
-  )(paymentMethodsR, supportedCountriesR, userDataR)
+  )(paymentMethodsR, supportedCountriesR, userDataR, eligibilityR)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/template.unsupported.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/template.unsupported.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import styled from 'styled-components'
+
+import { Button, Icon, Image, Text } from 'blockchain-info-components'
+import { FlyoutWrapper } from 'components/Flyout'
+
+const Top = styled(FlyoutWrapper)`
+  padding-bottom: 0px;
+  position: relative;
+  height: 100%;
+`
+
+const CloseIcon = styled(Icon)`
+  position: absolute;
+  padding: inherit;
+  left: 0px;
+  top: 0px;
+`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`
+
+const Title = styled(Text)`
+  margin: 56px 0 16px 0;
+  text-align: center;
+`
+
+const SubContent = styled(Text)`
+  margin-bottom: 56px;
+  text-align: center;
+`
+
+type Props = {
+  handleClose: () => void
+}
+
+const Unsupported = ({ handleClose }: Props) => {
+  return (
+    <Top>
+      <CloseIcon
+        cursor
+        name='arrow-left'
+        size='20px'
+        color='grey600'
+        role='button'
+        onClick={handleClose}
+      />
+      <Container>
+        <Image
+          width='48px'
+          height='48px'
+          name='world-alert'
+          srcset={{ 'world-alert2': '2x', 'world-alert3': '3x' }}
+        />
+        <Title color='grey800' size='20px' weight={600}>
+          <FormattedMessage
+            id='modals.simplebuy.add_card.unsupported-title'
+            defaultMessage='Adding Payment Coming Soon for your region.'
+          />
+        </Title>
+        <SubContent color='grey600' weight={500}>
+          <FormattedMessage
+            id='modals.simplebuy.add_card.unsupported-subcontent'
+            defaultMessage="Well this is awkward. We don't support adding payment method yet for your region."
+          />
+        </SubContent>
+        <Button
+          data-e2e='addCardUnsupported'
+          height='48px'
+          size='16px'
+          nature='primary'
+          onClick={handleClose}
+          fullwidth
+        >
+          <FormattedMessage id='buttons.ok' defaultMessage='OK' />
+        </Button>
+      </Container>
+    </Top>
+  )
+}
+
+export default Unsupported

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/template.unsupported.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/template.unsupported.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import styled from 'styled-components'
 
+import { FiatType } from '@core/types'
 import { Button, Icon, Image, Text } from 'blockchain-info-components'
 import { FlyoutWrapper } from 'components/Flyout'
 
@@ -38,10 +39,12 @@ const SubContent = styled(Text)`
 `
 
 type Props = {
+  fiatCurrency: FiatType
   handleClose: () => void
+  paymentAccountEligible: boolean
 }
 
-const Unsupported = ({ handleClose }: Props) => {
+const Unsupported = ({ fiatCurrency, handleClose, paymentAccountEligible }: Props) => {
   return (
     <Top>
       <CloseIcon
@@ -61,14 +64,40 @@ const Unsupported = ({ handleClose }: Props) => {
         />
         <Title color='grey800' size='20px' weight={600}>
           <FormattedMessage
-            id='modals.simplebuy.add_card.unsupported-title'
-            defaultMessage='Adding Payment Coming Soon for your region.'
-          />
+            id='modals.simplebuy.unsupported-title'
+            defaultMessage='Buy Crypto Coming Soon for'
+          />{' '}
+          {paymentAccountEligible ? (
+            fiatCurrency
+          ) : (
+            <FormattedMessage
+              id='modals.simplebuy.fiataccountineligible'
+              defaultMessage='your region.'
+            />
+          )}
         </Title>
         <SubContent color='grey600' weight={500}>
+          {paymentAccountEligible ? (
+            <>
+              <FormattedMessage
+                id='modals.simplebuy.unsupported-subcontent'
+                defaultMessage="Currently we don't support buying crypto with {currency}."
+                values={{
+                  currency: fiatCurrency
+                }}
+              />
+            </>
+          ) : (
+            <>
+              <FormattedMessage
+                id='modals.simplebuy.unsupported-subcontent-1'
+                defaultMessage="Well this is awkward. We don't support buying crypto yet for your region."
+              />
+            </>
+          )}
           <FormattedMessage
-            id='modals.simplebuy.add_card.unsupported-subcontent'
-            defaultMessage="Well this is awkward. We don't support adding payment method yet for your region."
+            id='modals.simplebuy.unsupported-subcontent-2'
+            defaultMessage="We'll send you an update when we do."
           />
         </SubContent>
         <Button


### PR DESCRIPTION
## Description (optional)
Show unsupported modal in case that user is not eligible for adding a payment method

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

![image](https://user-images.githubusercontent.com/67264242/151352307-82ee813b-9641-49e5-be3d-7a70a6f6e349.png)

