### PR TITLE
fix(auth-device): exchange only true also if intended product is exch…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -769,9 +769,9 @@ export default ({ api, coreSagas, networks }) => {
 
   const authorizeVerifyDevice = function* (action) {
     const confirmDevice = action.payload
-    const { session_id, wallet } = yield select(selectors.auth.getMagicLinkData)
+    const { product, session_id, wallet } = yield select(selectors.auth.getMagicLinkData)
     const magicLinkDataEncoded = yield select(selectors.auth.getMagicLinkDataEncoded)
-    const exchange_only_login = !wallet
+    const exchange_only_login = product === ProductAuthOptions.EXCHANGE || !wallet
     try {
       yield put(actions.auth.authorizeVerifyDeviceLoading())
       const data = yield call(


### PR DESCRIPTION
…ange

## Description (optional)
Passes `exchange_only_login: true` to auth device endpoint if base64 string tells us product is Exchange. 
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

