### PR TITLE
Feat/refresh quote confirm

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
@@ -442,22 +442,62 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
         }
       }
 
-      const buyOrder: BSOrderType = yield call(
-        api.createBSOrder,
-        pair.pair,
-        orderType,
-        true,
-        input,
-        output,
-        paymentType,
-        period,
-        paymentMethodId,
-        buyQuote?.quote?.quoteId
-      )
+      let buyOrder: BSOrderType
 
-      yield put(actions.form.stopSubmit(FORM_BS_CHECKOUT))
-      yield put(A.fetchOrders())
-      yield put(A.setStep({ order: buyOrder, step: 'CHECKOUT_CONFIRM' }))
+      // TODO: WIP
+      if (isFlexiblePricingModel) {
+        while (true) {
+          // get the current order, if any
+          const oldBuyOrder = S.getBSOrder(yield select())
+
+          buyOrder = yield call(
+            api.createBSOrder,
+            pair.pair,
+            orderType,
+            true,
+            input,
+            output,
+            paymentType,
+            period,
+            paymentMethodId,
+            buyQuote?.quote?.quoteId
+          )
+
+          // first time creating the order
+          if (!oldBuyOrder) {
+            yield put(actions.form.stopSubmit(FORM_BS_CHECKOUT))
+            yield put(A.fetchOrders())
+            yield put(A.setStep({ order: buyOrder, step: 'CHECKOUT_CONFIRM' }))
+          }
+
+          // create a new order when the quote expires and cancel the existing order and
+          if (oldBuyOrder) {
+            yield put(A.fetchOrders())
+            yield put(A.setStep({ order: buyOrder, step: 'CHECKOUT_CONFIRM' }))
+            yield put(A.cancelOrder(oldBuyOrder))
+          }
+
+          // execute while loop when quote expires and successfully fetches the new quote
+          yield take(A.fetchBuyQuoteSuccess)
+        }
+      } else {
+        buyOrder = yield call(
+          api.createBSOrder,
+          pair.pair,
+          orderType,
+          true,
+          input,
+          output,
+          paymentType,
+          period,
+          paymentMethodId,
+          buyQuote?.quote?.quoteId
+        )
+
+        yield put(actions.form.stopSubmit(FORM_BS_CHECKOUT))
+        yield put(A.fetchOrders())
+        yield put(A.setStep({ order: buyOrder, step: 'CHECKOUT_CONFIRM' }))
+      }
     } catch (e) {
       // After CC has been activated we try to create an order
       // If order creation fails go back to ENTER_AMOUNT step

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
@@ -938,8 +938,6 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
   const fetchBuyQuote = function* ({ payload }: ReturnType<typeof A.fetchBuyQuote>) {
     while (true) {
       try {
-        yield put(A.fetchBuyQuoteLoading())
-
         const { amount, pair, paymentMethod, paymentMethodId } = payload
         const pairReversed = reversePair(pair)
 


### PR DESCRIPTION
## Description (optional)
This PR adds the ability to refresh the buy order for a new buy order when the user sits on the order confirmation screen past the quote's expiration time (currently 2 minutes)

## Testing Steps (optional)
Create a buy order, submit the enter amount screen, do not confirm the order on the confirm screen, but sit there for two minutes. You should see a new quote fetched, then immediately a new order fetched and the UI updated. Now you can submit the order successfully.

