### PR TITLE
feat(buyer hand hold): only in case that user is eligible to do payment method allow them to add new card

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardCheckoutDotCom/index.tsx
@@ -79,7 +79,8 @@ const AddCardCheckoutDotCom = (props: Props) => {
       const isUserEligible =
         val.paymentMethods.methods.length &&
         val.paymentMethods.methods.find(
-          (method) => method.limits?.max !== '0' && method.currency === props.fiatCurrency
+          (method) =>
+            method.limits?.max !== '0' && method.currency === props.fiatCurrency && method.eligible
         )
 
       return isUserEligible ? (

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/selectors.ts
@@ -6,6 +6,11 @@ import { RootState } from 'data/rootReducer'
 export const getData = (state: RootState) => {
   const cardsR = selectors.components.buySell.getBSCards(state)
   const paymentMethodsR = selectors.components.buySell.getBSPaymentMethods(state)
+  const userDataR = selectors.modules.profile.getUserData(state)
 
-  return lift((cards, paymentMethods) => ({ cards, paymentMethods }))(cardsR, paymentMethodsR)
+  return lift((cards, paymentMethods, userData) => ({ cards, paymentMethods, userData }))(
+    cardsR,
+    paymentMethodsR,
+    userDataR
+  )
 }


### PR DESCRIPTION
## Description (optional)
Prevent fresh new users to see add new card screen in case that they are still not eligible

## Testing Steps (optional)
- Create a new wallet
- go over to settings > general
- click on add card
- should not be able to add new card since new user is not eligible yet for that action 

