### PR TITLE
fix(derivations): apply replenishDerivations fix whenever derivations array size is not 2.

### DIFF
--- a/packages/blockchain-wallet-v4/src/redux/wallet/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/wallet/sagas.ts
@@ -326,7 +326,7 @@ export default ({ api, networks }) => {
     const wallet = yield select(S.getWallet)
     const accounts = Wallet.selectHDAccounts(wallet)
     const accountsWithMissingDerivations = accounts
-      .filter((acct) => acct.derivations.size === 0)
+      .filter((acct) => acct.derivations.size !== 2)
       .toJS()
 
     return accountsWithMissingDerivations

--- a/packages/blockchain-wallet-v4/src/redux/wallet/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/wallet/sagas.ts
@@ -326,7 +326,7 @@ export default ({ api, networks }) => {
     const wallet = yield select(S.getWallet)
     const accounts = Wallet.selectHDAccounts(wallet)
     const accountsWithMissingDerivations = accounts
-      .filter((acct) => acct.derivations.size !== 2)
+      .filter((acct) => acct.derivations.size < DERIVATION_LIST.length)
       .toJS()
 
     return accountsWithMissingDerivations


### PR DESCRIPTION
##  Description (optional)

In addition to the fix implemented in #3966, we would like to also apply replenishDerivations fix whenever derivations array size is not 2.
This resolved an bug where there is only one derivation in the derivations array.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

