### PR TITLE
fix(authorize-device): confirm device true for all exchange logins

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.utils.ts
@@ -76,7 +76,7 @@ export const parseMagicLink = function* () {
     if (productAuth === ProductAuthOptions.WALLET) {
       if (session !== session_id && shouldPollForMagicLinkData) {
         // TODO: question for merge, do we need the next line?
-        yield put(actions.auth.authorizeVerifyDevice())
+        yield put(actions.auth.authorizeVerifyDevice(undefined))
         yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.VERIFY_MAGIC_LINK))
       } else {
         // grab all the data from the JSON wallet data
@@ -101,7 +101,7 @@ export const parseMagicLink = function* () {
     if (productAuth === ProductAuthOptions.EXCHANGE) {
       if (session !== session_id && shouldPollForMagicLinkData) {
         // TODO: question for merge, do we need the next line?
-        yield put(actions.auth.authorizeVerifyDevice())
+        yield put(actions.auth.authorizeVerifyDevice(true))
         yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.VERIFY_MAGIC_LINK))
       } else {
         // set state with all exchange login information

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/slice.ts
@@ -77,7 +77,7 @@ const authSlice = createSlice({
     authenticate: (state) => {
       state.isAuthenticated = true
     },
-    authorizeVerifyDevice: () => {},
+    authorizeVerifyDevice: (state, action?) => {},
     authorizeVerifyDeviceFailure: (state, action) => {
       state.authorizeVerifyDevice = Remote.Failure(action.payload)
     },


### PR DESCRIPTION
## Description (optional)
Another potential fix for the `payload: none` errors we're seeing with authorize verify device calls. 
## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

