### PR TITLE
Feat/fwn 690/tb remove buysell cancel button

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
@@ -525,17 +525,6 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
             )}
           </Button>
 
-          <Button
-            data-e2e='sbCancelCheckout'
-            disabled={props.submitting}
-            size='16px'
-            height='48px'
-            nature='light-red'
-            onClick={handleCancel}
-            style={{ marginTop: '16px' }}
-          >
-            <FormattedMessage id='buttons.cancel' defaultMessage='Cancel' />
-          </Button>
           {props.error && (
             <ErrorCartridge style={{ marginTop: '16px' }} data-e2e='checkoutError'>
               <Icon name='alert-filled' color='red600' style={{ marginRight: '4px' }} />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PreviewSell/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PreviewSell/index.tsx
@@ -544,28 +544,6 @@ class PreviewSell extends PureComponent<
                     </Text>
                   )}
                 </Button>
-                <Button
-                  nature='light-red'
-                  data-e2e='swapCancelBtn'
-                  type='button'
-                  disabled={this.props.submitting}
-                  fullwidth
-                  height='48px'
-                  color='red400'
-                  style={{ marginTop: '16px' }}
-                  onClick={() => {
-                    this.props.buySellActions.setStep({
-                      cryptoCurrency: BASE,
-                      fiatCurrency,
-                      orderType: this.props.orderType,
-                      pair: this.props.pair,
-                      step: 'ENTER_AMOUNT',
-                      swapAccount: this.props.account
-                    })
-                  }}
-                >
-                  <FormattedMessage id='buttons.cancel' defaultMessage='Cancel' />
-                </Button>
                 <Text
                   size='12px'
                   weight={500}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/ThreeDSHandlerCheckoutDotCom/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/ThreeDSHandlerCheckoutDotCom/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators } from 'redux'
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/ThreeDSHandlerCheckoutDotCom/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/ThreeDSHandlerCheckoutDotCom/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators } from 'redux'
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/PreviewSwap/index.tsx
@@ -268,19 +268,6 @@ class PreviewSwap extends PureComponent<InjectedFormProps<{}, Props> & Props, St
                 <FormattedMessage id='buttons.swap_now' defaultMessage='Swap Now' />
               )}
             </Button>
-            <Button
-              nature='light-red'
-              data-e2e='swapCancelBtn'
-              type='button'
-              disabled={this.props.submitting}
-              fullwidth
-              height='48px'
-              color='red400'
-              style={{ marginTop: '16px' }}
-              onClick={() => swapActions.setStep({ step: 'ENTER_AMOUNT' })}
-            >
-              <FormattedMessage id='buttons.cancel' defaultMessage='Cancel' />
-            </Button>
             {this.props.error && (
               <ErrorCartridge style={{ marginTop: '16px' }} data-e2e='checkoutError'>
                 <Icon name='alert-filled' color='red600' style={{ marginRight: '4px' }} />

--- a/packages/blockchain-wallet-v4-frontend/src/providers/ModalEnhancer/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/providers/ModalEnhancer/index.tsx
@@ -55,7 +55,8 @@ export default (type: ModalNameType, options: OptionsType = {}) =>
           const { buySellOrder, buySellStep, cancelBSOrder } = this.props
           if (
             (buySellOrder?.paymentType === BSPaymentTypes.FUNDS ||
-              buySellOrder?.paymentType === BSPaymentTypes.PAYMENT_CARD) &&
+              buySellOrder?.paymentType === BSPaymentTypes.PAYMENT_CARD ||
+              buySellOrder?.paymentType === BSPaymentTypes.BANK_TRANSFER) &&
             buySellStep !== 'ORDER_SUMMARY'
           ) {
             cancelBSOrder(buySellOrder)


### PR DESCRIPTION
## Description (optional)
Removed Cancel Button From:

- Cash Wallet Buys, Sells and Swaps
- Card Buys
- Open Banking Buys
- ACH Buys

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

