### PR TITLE
feat(offers): move away from hardcoded weth

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/nfts/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/nfts/sagas.ts
@@ -22,11 +22,7 @@ import {
   getNftBuyOrders,
   getNftSellOrder
 } from '@core/redux/payment/nfts'
-import {
-  OPENSEA_SHARED_MARKETPLACE,
-  WETH_ADDRESS,
-  WETH_ADDRESS_RINKEBY
-} from '@core/redux/payment/nfts/utils'
+import { OPENSEA_SHARED_MARKETPLACE } from '@core/redux/payment/nfts/utils'
 import { Await } from '@core/types'
 import { errorHandler } from '@core/utils'
 import { getPrivateKey } from '@core/utils/eth'
@@ -373,7 +369,8 @@ export default ({ api }: { api: APIType }) => {
     try {
       yield put(A.setOrderFlowIsSubmitting(true))
       const signer = yield call(getEthSigner)
-      const { coinfig } = window.coins[action.payload.coin || 'WETH']
+      if (!action.payload.coin) throw new Error('No coin selected for offer.')
+      const { coinfig } = window.coins[action.payload.coin]
       // TODO: DONT DEFAULT TO 1 WEEK
       const expirationTime = moment().add(7, 'day').unix()
       const amount = convertCoinToCoin({
@@ -645,7 +642,7 @@ export default ({ api }: { api: APIType }) => {
           undefined,
           action.payload.offer.asset.asset_contract.address,
           action.payload.offer.asset.token_id,
-          IS_TESTNET ? WETH_ADDRESS_RINKEBY : WETH_ADDRESS,
+          action.payload.offer.payment_token.address,
           0,
           ethAddr
         )

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/nfts/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/nfts/sagas.ts
@@ -21,7 +21,7 @@ import {
   fulfillNftSellOrder,
   fulfillTransfer,
   getNftBuyOrder,
-  getNftBuyOrders,
+  getNftMatchingOrders,
   getNftSellOrder
 } from '@core/redux/payment/nfts'
 import { NULL_ADDRESS, OPENSEA_SHARED_MARKETPLACE } from '@core/redux/payment/nfts/utils'
@@ -239,8 +239,8 @@ export default ({ api }: { api: APIType }) => {
       if (action.payload.operation === GasCalculationOperations.Buy) {
         yield put(A.fetchMatchingOrderLoading())
         try {
-          const { buy, sell }: Await<ReturnType<typeof getNftBuyOrders>> = yield call(
-            getNftBuyOrders,
+          const { buy, sell }: Await<ReturnType<typeof getNftMatchingOrders>> = yield call(
+            getNftMatchingOrders,
             action.payload.order,
             signer,
             undefined,
@@ -283,8 +283,8 @@ export default ({ api }: { api: APIType }) => {
         const { order } = action.payload
         yield put(A.fetchMatchingOrderLoading())
         try {
-          const { buy, sell }: Await<ReturnType<typeof getNftBuyOrders>> = yield call(
-            getNftBuyOrders,
+          const { buy, sell }: Await<ReturnType<typeof getNftMatchingOrders>> = yield call(
+            getNftMatchingOrders,
             order,
             signer,
             undefined,

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/nfts/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/nfts/slice.ts
@@ -115,14 +115,14 @@ const nftsSlice = createSlice({
       state,
       action: PayloadAction<
         | {
-            operation: GasCalculationOperations.Accept
+            operation: GasCalculationOperations.AcceptOffer
             order: NftOrder
           }
         | {
             asset: NftAsset
             offer: string
             operation: GasCalculationOperations.CreateOffer
-            paymentTokenAddress?: string
+            paymentTokenAddress: string
           }
         | {
             operation: GasCalculationOperations.Buy

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/nfts/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/nfts/slice.ts
@@ -82,8 +82,8 @@ const nftsSlice = createSlice({
       state,
       action: PayloadAction<{
         amount?: string
+        asset: NftAsset
         coin?: string
-        order: NftOrder
       }>
     ) => {},
     createOrder: (
@@ -119,7 +119,12 @@ const nftsSlice = createSlice({
             order: NftOrder
           }
         | {
-            offer?: string
+            asset: NftAsset
+            offer: string
+            operation: GasCalculationOperations.CreateOffer
+            paymentTokenAddress?: string
+          }
+        | {
             operation: GasCalculationOperations.Buy
             order: NftOrder
             paymentTokenAddress?: string

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/CancelOffer/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/CancelOffer/index.tsx
@@ -70,7 +70,7 @@ const CancelOffer: React.FC<Props> = (props) => {
                   <Text size='14px' weight={600}>
                     <FormattedMessage
                       id='copy.no_active_offers'
-                      defaultMessage='Error. You may not have any active offers for this asset.'
+                      defaultMessage='Error. You may have already cancelled this offer, or it has expired.'
                     />
                   </Text>
                 ),
@@ -96,7 +96,7 @@ const CancelOffer: React.FC<Props> = (props) => {
                     <Text size='14px' weight={600}>
                       <FormattedMessage
                         id='copy.no_active_offers_listings'
-                        defaultMessage='Error. You may not have any active offers for this asset.'
+                        defaultMessage='Error. You may have already cancelled this offer, or it has expired.'
                       />
                     </Text>
                   )

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/fees.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/fees.tsx
@@ -15,7 +15,8 @@ const Fees: React.FC<Props> = (props) => {
   const { nftActions, orderFlow } = props
 
   // Default to WETH
-  const WETH = window.coins.WETH.coinfig.type.erc20Address
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const WETH = window.coins.WETH.coinfig.type.erc20Address!
 
   useEffect(() => {
     nftActions.fetchFees({

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/fees.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/fees.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import { FormattedMessage } from 'react-intl'
 import BigNumber from 'bignumber.js'
 
-import { GasCalculationOperations } from '@core/network/api/nfts/types'
+import { GasCalculationOperations, NftAsset } from '@core/network/api/nfts/types'
 import { SpinningLoader, TooltipHost, TooltipIcon } from 'blockchain-info-components'
 import CoinDisplay from 'components/Display/CoinDisplay'
 import FiatDisplay from 'components/Display/FiatDisplay'
@@ -21,9 +21,9 @@ const Fees: React.FC<Props> = (props) => {
   useEffect(() => {
     if (activeOrder) {
       nftActions.fetchFees({
-        offer: '10000',
-        operation: GasCalculationOperations.Buy,
-        order: activeOrder,
+        asset: props.asset,
+        offer: '0.0001',
+        operation: GasCalculationOperations.CreateOffer,
         paymentTokenAddress: WETH
       })
     }
@@ -73,6 +73,6 @@ const Fees: React.FC<Props> = (props) => {
   )
 }
 
-type Props = OwnProps
+type Props = OwnProps & { asset: NftAsset }
 
 export default Fees

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/fees.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/fees.tsx
@@ -13,23 +13,18 @@ import { Props as OwnProps } from '..'
 
 const Fees: React.FC<Props> = (props) => {
   const { nftActions, orderFlow } = props
-  const { activeOrder } = orderFlow
 
-  // User can only make an offer in WETH
+  // Default to WETH
   const WETH = window.coins.WETH.coinfig.type.erc20Address
 
   useEffect(() => {
-    if (activeOrder) {
-      nftActions.fetchFees({
-        asset: props.asset,
-        offer: '0.0001',
-        operation: GasCalculationOperations.CreateOffer,
-        paymentTokenAddress: WETH
-      })
-    }
+    nftActions.fetchFees({
+      asset: props.asset,
+      offer: '0.0001',
+      operation: GasCalculationOperations.CreateOffer,
+      paymentTokenAddress: WETH
+    })
   }, [])
-
-  if (!activeOrder) return null
 
   return (
     <>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/index.tsx
@@ -6,6 +6,7 @@ import { Field, reduxForm } from 'redux-form'
 
 import { Remote } from '@core'
 import { convertCoinToCoin } from '@core/exchange'
+import { GasCalculationOperations } from '@core/network/api/nfts/types'
 import { Button, HeartbeatLoader, Icon, SpinningLoader, Text } from 'blockchain-info-components'
 import CoinDisplay from 'components/Display/CoinDisplay'
 import FiatDisplay from 'components/Display/FiatDisplay'
@@ -82,6 +83,18 @@ const MakeOffer: React.FC<Props> = (props) => {
                 <Value>
                   <Field
                     name='coin'
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    onChange={(coin: any) => {
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                      const address = window.coins[coin].coinfig.type.erc20Address!
+
+                      nftActions.fetchFees({
+                        asset: val,
+                        offer: '0.0001',
+                        operation: GasCalculationOperations.CreateOffer,
+                        paymentTokenAddress: address
+                      })
+                    }}
                     component={SelectBox}
                     elements={[
                       {
@@ -89,6 +102,7 @@ const MakeOffer: React.FC<Props> = (props) => {
                         items: val.collection.payment_tokens
                           .map((token) => token.symbol)
                           .filter((symbol) => !!window.coins[symbol])
+                          .filter((symbol) => !!window.coins[symbol].coinfig.type.erc20Address)
                           .map((coin) => ({
                             text: window.coins[coin].coinfig.symbol,
                             value: window.coins[coin].coinfig.symbol

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/index.tsx
@@ -88,7 +88,7 @@ const MakeOffer: React.FC<Props> = (props) => {
                         group: '',
                         items: val.collection.payment_tokens
                           .map((token) => token.symbol)
-                          .filter((symbol) => symbol === 'WETH')
+                          .filter((symbol) => !!window.coins[symbol])
                           .map((coin) => ({
                             text: window.coins[coin].coinfig.symbol,
                             value: window.coins[coin].coinfig.symbol

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/index.tsx
@@ -150,14 +150,14 @@ const MakeOffer: React.FC<Props> = (props) => {
             </Form>
             {activeOrder ? (
               <StickyCTA>
-                <MakeOfferFees {...props} />
+                <MakeOfferFees {...props} asset={val} />
                 <Button
                   jumbo
                   nature='primary'
                   fullwidth
                   data-e2e='makeOfferNft'
                   disabled={disabled}
-                  onClick={() => nftActions.createOffer({ order: activeOrder, ...formValues })}
+                  onClick={() => nftActions.createOffer({ asset: val, ...formValues })}
                 >
                   {formValues.amount ? (
                     props.orderFlow.isSubmitting ? (

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/ShowAsset/ActiveOffers/cta.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/ShowAsset/ActiveOffers/cta.tsx
@@ -63,7 +63,7 @@ const CTA: React.FC<Props> = (props) => {
                     small
                     onClick={() => {
                       nftActions.fetchFees({
-                        operation: GasCalculationOperations.Accept,
+                        operation: GasCalculationOperations.AcceptOffer,
                         order: orderFromJSON(offer)
                       })
                       nftActions.setOrderFlowStep({

--- a/packages/blockchain-wallet-v4-frontend/src/store/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/store/index.js
@@ -88,8 +88,10 @@ const configuredStore = async function () {
   // TODO: remove this
   window.coins.XLM.coinfig.type.isMemoBased = true
 
+  // Switch up the erc20 addresses to support testnet (for opensea testing)
   if (options.domains.opensea && options.domains.opensea.includes('rinkeby')) {
     window.coins.WETH.coinfig.type.erc20Address = '0xc778417E063141139Fce010982780140Aa0cD5Ab'
+    window.coins.DAI.coinfig.type.erc20Address = '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45'
   }
 
   const apiKey = '1770d5d9-bcea-4d28-ad21-6cbd5be018a8'

--- a/packages/blockchain-wallet-v4/src/network/api/nfts/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/nfts/index.ts
@@ -16,7 +16,7 @@ export default ({ apiUrl, get, post }) => {
 
   const getAssetContract = (asset_contract_address: string) => {
     return get({
-      endPoint: `/asset_contract/${asset_contract_address}`,
+      endPoint: `/asset-contract/${asset_contract_address}`,
       ignoreQueryParams: true,
       url: `${explorerUrl}`
     })

--- a/packages/blockchain-wallet-v4/src/network/api/nfts/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/nfts/index.ts
@@ -11,8 +11,8 @@ import {
 export const NFT_ORDER_PAGE_LIMIT = 30
 
 export default ({ apiUrl, get, post }) => {
-  // const explorerUrl = 'http://localhost:8081/nft' // local testnet only
-  const explorerUrl = `${apiUrl}/explorer-gateway/nft`
+  const explorerUrl = 'http://localhost:8081/nft' // local testnet only
+  // const explorerUrl = `${apiUrl}/explorer-gateway/nft`
 
   const getAssetContract = (asset_contract_address: string) => {
     return get({

--- a/packages/blockchain-wallet-v4/src/network/api/nfts/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/nfts/index.ts
@@ -11,8 +11,8 @@ import {
 export const NFT_ORDER_PAGE_LIMIT = 30
 
 export default ({ apiUrl, get, post }) => {
-  const explorerUrl = 'http://localhost:8081/nft' // local testnet only
-  // const explorerUrl = `${apiUrl}/explorer-gateway/nft`
+  // const explorerUrl = 'http://localhost:8081/nft' // local testnet only
+  const explorerUrl = `${apiUrl}/explorer-gateway/nft`
 
   const getAssetContract = (asset_contract_address: string) => {
     return get({

--- a/packages/blockchain-wallet-v4/src/network/api/nfts/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/nfts/types.ts
@@ -399,7 +399,7 @@ export interface NftOrder extends UnsignedOrder, Partial<ECSignature> {
 }
 
 export enum GasCalculationOperations {
-  Accept = 'accept',
+  AcceptOffer = 'accept-offer',
   Buy = 'buy',
   Cancel = 'cancel',
   CreateOffer = 'create-offer',

--- a/packages/blockchain-wallet-v4/src/network/api/nfts/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/nfts/types.ts
@@ -402,6 +402,7 @@ export enum GasCalculationOperations {
   Accept = 'accept',
   Buy = 'buy',
   Cancel = 'cancel',
+  CreateOffer = 'create-offer',
   Sell = 'sell',
   Transfer = 'transfer'
 }

--- a/packages/blockchain-wallet-v4/src/redux/payment/nfts/index.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/nfts/index.ts
@@ -114,7 +114,7 @@ export const getNftBuyOrder = async (
   )
 }
 
-export const getNftBuyOrders = async (
+export const getNftMatchingOrders = async (
   order: NftOrder,
   signer: Signer,
   expirationTime = 0,

--- a/packages/blockchain-wallet-v4/src/redux/payment/nfts/index.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/nfts/index.ts
@@ -19,6 +19,7 @@ import {
   calculateProxyApprovalFees,
   calculateProxyFees,
   calculateTransferFees,
+  createBuyOrder,
   createMatchingOrders,
   createSellOrder,
   NULL_ADDRESS,
@@ -67,31 +68,50 @@ export const getNftSellOrder = async (
   )
 }
 
-// TODO: Be able to pass in custom value for price for making auction bids.
-export const fulfillNftOrder = async (
-  buy: NftOrder,
-  sell: NftOrder,
-  signer: Signer,
-  gasData: GasDataI,
-  acceptingOffer?: boolean
-) => {
+export const fulfillNftOrder = async ({
+  buy,
+  gasData,
+  sell,
+  signer
+}: {
+  buy: NftOrder
+  gasData: GasDataI
+  sell?: NftOrder
+  signer: Signer
+}) => {
   // Perform buy order validations (abstracted away from _atomicMatch because english auction bids don't hit that function)
   // await _buyOrderValidationAndApprovals({ order: buy, signer })
-  // Is an english auction sale
   if (
+    !sell ||
     sell.waitingForBestCounterOrder ||
-    (!sell.waitingForBestCounterOrder && buy.paymentToken !== NULL_ADDRESS && !acceptingOffer)
+    (!sell.waitingForBestCounterOrder && buy.paymentToken !== NULL_ADDRESS)
   ) {
     await _buyOrderValidationAndApprovals({ gasData, order: buy, signer })
     // eslint-disable-next-line no-console
-    console.log(
-      'Post buy order to OpenSea API because its an english auction or user is making an offer.'
-    )
-    // eslint-disable-next-line no-console
-    console.log(buy)
+    console.log('Post buy order to OpenSea API.')
     return buy
   }
   await _atomicMatch({ buy, gasData, sell, signer })
+}
+
+export const getNftBuyOrder = async (
+  asset: NftAsset,
+  signer: Signer,
+  expirationTime = 0,
+  startAmount: number,
+  paymentTokenAddress: string,
+  network: 'mainnet' | 'rinkeby'
+): Promise<NftOrder> => {
+  const accountAddress = await signer.getAddress()
+  return createBuyOrder(
+    asset,
+    accountAddress,
+    startAmount,
+    expirationTime,
+    paymentTokenAddress,
+    signer,
+    network
+  )
 }
 
 export const getNftBuyOrders = async (
@@ -99,17 +119,9 @@ export const getNftBuyOrders = async (
   signer: Signer,
   expirationTime = 0,
   network: string,
-  offer?: string,
   paymentTokenAddress?: string
 ): Promise<{ buy: NftOrder; sell: NftOrder }> => {
-  return createMatchingOrders(
-    expirationTime,
-    offer || null,
-    order,
-    signer,
-    network,
-    paymentTokenAddress || null
-  )
+  return createMatchingOrders(expirationTime, order, signer, network, paymentTokenAddress || null)
 }
 // Calculates all the fees a user will need to pay/encounter on their journey to either sell/buy an NFT
 // order and counterOrder needed for sell orders, only order needed for buy order calculations (May need to put a default value here in future / change the way these are called into two seperate functions?)
@@ -144,6 +156,12 @@ export const calculateGasFees = async (
       proxyFees.toString() === '0'
         ? (await calculateProxyApprovalFees(sellOrder, signer)).toNumber()
         : 300_000
+  } else if (operation === GasCalculationOperations.CreateOffer && buyOrder) {
+    // 1. Calculate gas cost of approvals (if needed) - possible with ethers
+    approvalFees =
+      buyOrder.paymentToken !== NULL_ADDRESS
+        ? (await calculatePaymentProxyApprovals(buyOrder, signer)).toNumber()
+        : 0
   }
   // Buy orders dont need any approval or proxy IF payment token is Ether.
   // However, if payment token is an ERC20 approval must be given to the payment proxy address

--- a/packages/blockchain-wallet-v4/src/redux/payment/nfts/utils.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/nfts/utils.ts
@@ -2138,7 +2138,7 @@ export async function _makeBuyOrder({
 
   const { calldata, replacementPattern, target } = encodeBuy(
     schema,
-    { address: asset.asset_contract.address, id: asset.id.toString() },
+    { address: asset.asset_contract.address, id: asset.token_id },
     accountAddress
   )
 

--- a/packages/blockchain-wallet-v4/src/redux/payment/nfts/utils.ts
+++ b/packages/blockchain-wallet-v4/src/redux/payment/nfts/utils.ts
@@ -2158,12 +2158,10 @@ export async function _makeBuyOrder({
   }
 
   return {
-    // @ts-ignore
     basePrice: new BigNumber(basePrice.toString()),
     calldata,
     exchange: network === 'rinkeby' ? WYVERN_CONTRACT_ADDR_RINKEBY : WYVERN_CONTRACT_ADDR_MAINNET,
     expirationTime: times.expirationTime,
-    // @ts-ignore
     extra: new BigNumber(extra.toString()),
     feeMethod,
     feeRecipient,


### PR DESCRIPTION
## Description (optional)
Allow offers to be made in any of asset's payment_token_contracts

Breaks:
~1. need to figure out why offers reverse maker/taker relayer fees, look at opensea-js @jmichel-bc, this was the issue that we fixed before then reverted because of _accepting_ offers, now there is an issue w/ _making_ offers.~
~2. frontend can no longer find orders on offers_made from user address~

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

