### PR TITLE
fix(institutional-portal): need help link and stop form submit

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -779,16 +779,16 @@ export default ({ api, coreSagas, networks }) => {
       } else {
         yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.CHECK_EMAIL))
       }
+      yield put(actions.auth.triggerWalletMagicLinkSuccess())
+      yield put(stopSubmit(LOGIN_FORM))
       // poll for session from auth payload if feature flag enabled
       if (shouldPollForMagicLinkData) {
         yield call(pollForSessionFromAuthPayload, api, sessionToken)
       }
-      yield put(actions.auth.triggerWalletMagicLinkSuccess())
     } catch (e) {
       yield put(actions.auth.triggerWalletMagicLinkFailure())
       yield put(actions.logs.logErrorMessage(logLocation, 'triggerWalletMagicLink', e))
       yield put(actions.alerts.displayError(C.VERIFY_EMAIL_SENT_ERROR))
-    } finally {
       yield put(stopSubmit(LOGIN_FORM))
     }
   }

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Public/components/Footer/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Public/components/Footer/index.tsx
@@ -15,7 +15,7 @@ const FooterInner = styled.div`
 const Footer = (props) => (
   <>
     {props.authProduct === ProductAuthOptions.EXCHANGE &&
-      props.formValues.step !== LoginSteps.INSTITUTIONAL_PORTAL && (
+      props.formValues?.step !== LoginSteps.INSTITUTIONAL_PORTAL && (
         <FooterInner>
           <InstitutionalPortal />
         </FooterInner>


### PR DESCRIPTION
## Description (optional)
1) Fixes issue where `finally` of the triggerWalletMagicLink function would never run, because `yield call(pollForSessionFromAuthPayload, api, sessionToken)` doesn't resolve until device is verified or after 50 attempts. This would cause login form to remain in loading state when it shouldn't. 
2) 'Need Help' link in Exchange login form could sometimes cause the app to blow up because form values could be undefined. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

