### PR TITLE
feat(exchange-login): cache exchange data

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagaRegister.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagaRegister.ts
@@ -20,6 +20,5 @@ export default ({ api, coreSagas, networks }) => {
     yield takeLatest(actions.exchangeLogin.type, authSagas.exchangeLogin)
     yield takeLatest(actions.exchangeResetPassword.type, authSagas.exchangeResetPassword)
     yield takeLatest(actions.continueLoginProcess, authSagas.continueLoginProcess)
-    yield takeLatest(actions.setCachedWalletData.type, authSagas.setCachedWalletData)
   }
 }

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.utils.ts
@@ -108,7 +108,7 @@ export const parseMagicLink = function* () {
         yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.VERIFY_MAGIC_LINK))
       } else {
         // set state with all exchange login information
-        yield put(actions.cache.emailStored(exchangeData?.email))
+        yield put(actions.cache.exchangeEmail(exchangeData?.email))
         yield put(actions.form.change(LOGIN_FORM, 'email', userEmail))
         if (walletData) {
           yield put(actions.form.change(LOGIN_FORM, 'emailToken', walletData?.email_code))

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/slice.ts
@@ -198,7 +198,6 @@ const authSlice = createSlice({
     setAuthType: (state, action) => {
       state.auth_type = action.payload
     },
-    setCachedWalletData: () => {},
     setFirstLogin: (state, action: PayloadAction<AuthStateType['firstLogin']>) => {
       state.firstLogin = action.payload
     },

--- a/packages/blockchain-wallet-v4-frontend/src/data/cache/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/cache/selectors.ts
@@ -1,10 +1,13 @@
-import { path } from 'ramda'
+import { path, prop } from 'ramda'
 
 import { crypto as wCrypto } from '@core'
 
 export const getLastAnnouncementState = (state): string | undefined =>
   path(['cache', 'announcements'], state)
+export const getCache = (state) => prop('cache', state)
 export const getEmail = (state): string | undefined => path(['cache', 'lastEmail'], state)
+export const getExchangeEmail = (state): string | undefined =>
+  path(['cache', 'exchangeEmail'], state)
 export const getStoredGuid = (state): string | undefined => path(['cache', 'guidStored'], state)
 export const getMobileConnected = (state): string | undefined =>
   path(['cache', 'mobileConnected'], state)

--- a/packages/blockchain-wallet-v4-frontend/src/data/cache/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/cache/slice.ts
@@ -5,6 +5,7 @@ const initialState = {
   channelChannelId: undefined,
   channelPhonePubkey: undefined,
   channelPrivKey: undefined,
+  exchangeEmail: undefined,
   guidStored: undefined,
   hasCloudBackup: undefined,
   lastEmail: undefined,
@@ -40,6 +41,9 @@ const cacheSlice = createSlice({
     emailStored: (state, action) => {
       state.lastEmail = action.payload
     },
+    exchangeEmail: (state, action) => {
+      state.exchangeEmail = action.payload
+    },
     guidEntered: (state, action) => {
       state.lastGuid = action.payload
     },
@@ -56,6 +60,7 @@ const cacheSlice = createSlice({
       state.mobileConnected = action.payload
     },
     removedStoredLogin: (state) => {
+      state.exchangeEmail = undefined
       state.guidStored = undefined
       state.lastEmail = undefined
       state.lastGuid = undefined

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Exchange/EnterEmail/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Exchange/EnterEmail/index.tsx
@@ -26,14 +26,19 @@ const LoginWrapper = styled(Wrapper)`
 `
 
 const EnterEmail = (props: Props) => {
-  const { authActions, busy, formValues, invalid, isBrowserSupported, submitting } = props
+  const {
+    authActions,
+    busy,
+    formValues,
+    invalid,
+    isBrowserSupported,
+    submitting,
+    walletTabClicked
+  } = props
 
   return (
     <LoginWrapper>
-      <ProductTabMenu
-        active={ProductAuthOptions.EXCHANGE}
-        onWalletTabClick={authActions.setCachedWalletData}
-      />
+      <ProductTabMenu active={ProductAuthOptions.EXCHANGE} onWalletTabClick={walletTabClicked} />
       <WrapperWithPadding>
         <FormGroup>
           <UnsupportedBrowser isSupportedBrowser={isBrowserSupported} />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Exchange/EnterPassword/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Exchange/EnterPassword/index.tsx
@@ -34,16 +34,14 @@ const EnterPasswordExchange = (props: Props) => {
     handleBackArrowClick,
     invalid,
     isBrowserSupported,
-    submitting
+    submitting,
+    walletTabClicked
   } = props
   const passwordError = exchangeError && exchangeError === ExchangeErrorCodes.INVALID_CREDENTIALS
 
   return (
     <LoginWrapper>
-      <ProductTabMenu
-        active={ProductAuthOptions.EXCHANGE}
-        onWalletTabClick={authActions.setCachedWalletData}
-      />
+      <ProductTabMenu active={ProductAuthOptions.EXCHANGE} onWalletTabClick={walletTabClicked} />
       <WrapperWithPadding>
         <BackArrowHeader
           {...props}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
@@ -32,6 +32,7 @@ const EnterEmailOrGuid = (props: Props) => {
   const {
     authActions,
     busy,
+    exchangeTabClicked,
     formActions,
     formValues,
     invalid,
@@ -41,15 +42,10 @@ const EnterEmailOrGuid = (props: Props) => {
     walletError
   } = props
   const guidError = walletError && walletError.toLowerCase().includes('unknown wallet id')
-  const onExchangeTabClick = () => {
-    routerActions.push('/login?product=exchange')
-    formActions.clearFields(LOGIN_FORM, false, false, 'email')
-    authActions.setProductAuthMetadata({ product: ProductAuthOptions.EXCHANGE })
-  }
 
   return (
     <LoginWrapper>
-      <ProductTabMenu active={ProductAuthOptions.WALLET} onExchangeTabClick={onExchangeTabClick} />
+      <ProductTabMenu active={ProductAuthOptions.WALLET} onExchangeTabClick={exchangeTabClicked} />
       <WrapperWithPadding>
         <FormGroup>
           <UnsupportedBrowser isSupportedBrowser={isBrowserSupported} />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterPassword/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterPassword/index.tsx
@@ -75,6 +75,7 @@ const EnterPasswordWallet = (props: Props) => {
   const {
     authActions,
     busy,
+    exchangeTabClicked,
     formValues,
     handleBackArrowClick,
     invalid,
@@ -83,12 +84,6 @@ const EnterPasswordWallet = (props: Props) => {
     submitting,
     walletError
   } = props
-
-  const onExchangeTabClick = () => {
-    props.routerActions.push('/login?product=exchange')
-    authActions.setProductAuthMetadata({ product: ProductAuthOptions.EXCHANGE })
-    props.setStep(LoginSteps.ENTER_EMAIL_GUID)
-  }
 
   const passwordError = walletError && walletError.toLowerCase().includes('wrong_wallet_password')
   const accountLocked =
@@ -102,7 +97,7 @@ const EnterPasswordWallet = (props: Props) => {
       <FormWrapper>
         <ProductTabMenu
           active={ProductAuthOptions.WALLET}
-          onExchangeTabClick={onExchangeTabClick}
+          onExchangeTabClick={exchangeTabClicked}
         />
         <WrapperWithPadding>
           <BackArrowHeader

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/index.tsx
@@ -77,6 +77,33 @@ class Login extends PureComponent<InjectedFormProps<{}, Props> & Props, StatePro
     this.initCaptcha()
   }
 
+  exchangeTabClicked = () => {
+    const { exchangeEmail } = this.props.cache
+    const { authActions, formActions, routerActions } = this.props
+    authActions.setProductAuthMetadata({ product: ProductAuthOptions.EXCHANGE })
+    routerActions.push('/login?product=exchange')
+    if (exchangeEmail) {
+      formActions.change(LOGIN_FORM, 'email', exchangeEmail)
+      formActions.change(LOGIN_FORM, 'step', LoginSteps.ENTER_PASSWORD_EXCHANGE)
+    } else {
+      formActions.change(LOGIN_FORM, 'step', LoginSteps.ENTER_EMAIL_GUID)
+    }
+  }
+
+  walletTabClicked = () => {
+    const { email, lastGuid, storedGuid } = this.props.cache
+    const { authActions, formActions, routerActions } = this.props
+    authActions.setProductAuthMetadata({ product: ProductAuthOptions.WALLET })
+    routerActions.push('/login?product=wallet')
+    if (storedGuid || lastGuid) {
+      formActions.change(LOGIN_FORM, 'guid', lastGuid || storedGuid)
+      formActions.change(LOGIN_FORM, 'email', email)
+      formActions.change(LOGIN_FORM, 'step', LoginSteps.ENTER_PASSWORD_WALLET)
+    } else {
+      formActions.change(LOGIN_FORM, 'step', LoginSteps.ENTER_EMAIL_GUID)
+    }
+  }
+
   handleSubmit = (e) => {
     e.preventDefault()
     // sometimes captcha doesnt mount correctly (race condition?)
@@ -118,12 +145,14 @@ class Login extends PureComponent<InjectedFormProps<{}, Props> & Props, StatePro
     const loginProps = {
       busy, // TODO see if we still need busy
       exchangeError,
+      exchangeTabClicked: this.exchangeTabClicked,
       isMobileViewLogin: platform === PlatformTypes.ANDROID || platform === PlatformTypes.IOS,
       walletError,
       ...this.props,
       handleBackArrowClick: this.handleBackArrowClick,
       isBrowserSupported: isBrowserSupported(),
-      setStep: this.setStep
+      setStep: this.setStep,
+      walletTabClicked: this.walletTabClicked
     }
 
     return (
@@ -173,6 +202,7 @@ class Login extends PureComponent<InjectedFormProps<{}, Props> & Props, StatePro
 const mapStateToProps = (state) => ({
   accountUnificationFlow: selectors.auth.getAccountUnificationFlowType(state),
   authType: selectors.auth.getAuthType(state) as Number,
+  cache: selectors.cache.getCache(state),
   data: getData(state),
   exchangeLoginData: selectors.auth.getExchangeLogin(state) as RemoteDataType<any, any>,
   formValues: selectors.form.getFormValues(LOGIN_FORM)(state) as LoginFormType,
@@ -197,6 +227,7 @@ const connector = connect(mapStateToProps, mapDispatchToProps)
 type OwnProps = {
   busy?: boolean
   exchangeError?: ExchangeErrorCodes
+  exchangeTabClicked?: () => void
   handleBackArrowClick: () => void
   invalid: boolean
   isBrowserSupported: boolean | undefined
@@ -205,6 +236,7 @@ type OwnProps = {
   setStep: (step: LoginSteps) => void
   submitting: boolean
   walletError?: any
+  walletTabClicked?: () => void
 }
 
 type StateProps = {


### PR DESCRIPTION
## Description (optional)
1. Saves exchange login data in cache, so user doesn't have to go through device verification every time
2. Moves the tab clicking functions into the main login index file

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

