### PR TITLE
refactor(BuySell): use record to map error messages

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardEverypay/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/AddCardEverypay/model.tsx
@@ -1,54 +1,41 @@
-import React from 'react'
+import React, { FC, ReactElement } from 'react'
 import { FormattedMessage } from 'react-intl'
-import { InjectedFormProps } from 'redux-form'
 
-import { ErrorType, Props as OwnProps } from './template.success'
+import { ErrorType } from './template.success'
 
-export const Error = ({ error }: { error: Props['error'] }) => {
-  switch (error) {
-    case 'CARD_ALREADY_SAVED':
-      return (
-        <FormattedMessage
-          id='modals.simplebuy.card_already_saved'
-          defaultMessage='This card has already been saved.'
-        />
-      )
-
-    case 'CARD_CREATION_FAILED':
-      return (
-        <FormattedMessage
-          id='modals.simplebuy.card_creation_failed'
-          defaultMessage='We could not save your card. Please contact support.'
-        />
-      )
-
-    case 'CARD_ACTIVATION_FAILED':
-      return (
-        <FormattedMessage
-          id='modals.simplebuy.card_activation_failed'
-          defaultMessage='We could not activate your card. Please contact support.'
-        />
-      )
-
-    case 'PENDING_CARD_AFTER_POLL':
-      return (
-        <FormattedMessage
-          id='modals.simplebuy.card_pending_after_poll'
-          defaultMessage='We waited one minute and did not receive an update from our card provider. Your card may still be approved later. Please contact support if you have any questions.'
-        />
-      )
-
-    case 'LINK_CARD_FAILED':
-      return (
-        <FormattedMessage
-          id='modals.simplebuy.link_card_failed'
-          defaultMessage='Card failed to link. Please try again or contact support if you believe this occured in error.'
-        />
-      )
-
-    default:
-      return <>{`System Error: ${JSON.stringify(error)}`}</>
-  }
+const mapErrorStateToMessage: Record<ErrorType, ReactElement> = {
+  CARD_ACTIVATION_FAILED: (
+    <FormattedMessage
+      id='modals.simplebuy.card_activation_failed'
+      defaultMessage='We could not activate your card. Please contact support.'
+    />
+  ),
+  CARD_ALREADY_SAVED: (
+    <FormattedMessage
+      id='modals.simplebuy.card_already_saved'
+      defaultMessage='This card has already been saved.'
+    />
+  ),
+  CARD_CREATION_FAILED: (
+    <FormattedMessage
+      id='modals.simplebuy.card_creation_failed'
+      defaultMessage='We could not save your card. Please contact support.'
+    />
+  ),
+  LINK_CARD_FAILED: (
+    <FormattedMessage
+      id='modals.simplebuy.link_card_failed'
+      defaultMessage='Card failed to link. Please try again or contact support if you believe this occured in error.'
+    />
+  ),
+  PENDING_CARD_AFTER_POLL: (
+    <FormattedMessage
+      id='modals.simplebuy.card_pending_after_poll'
+      defaultMessage='We waited one minute and did not receive an update from our card provider. Your card may still be approved later. Please contact support if you have any questions.'
+    />
+  )
 }
 
-type Props = InjectedFormProps<{}, Props, ErrorType> & OwnProps
+type ErrorProps = { error: ErrorType }
+
+export const Error: FC<ErrorProps> = ({ error }) => mapErrorStateToMessage[error]


### PR DESCRIPTION
This replaces the switch statement in the Bay Sell error card by a Typescript `Record` utility type, so the code is type safe.