### PR TITLE
fix(OrderSummary): remove extra currency sign in recurrent buy

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.stories.tsx
@@ -39,6 +39,24 @@ Default.args = {
   paymentType: BSPaymentTypes.PAYMENT_CARD
 }
 
+export const WillBuyMonthly = Template.bind({})
+WillBuyMonthly.args = {
+  baseAmount: '0.001',
+  baseCurrency: 'BTC',
+  counterAmount: '100',
+  currencySymbol: '$',
+  frequencyText: <span>Monthly</span>,
+  handleClose: () => {},
+  handleCompleteButton: () => {},
+  handleOkButton: () => {},
+  lockTime: 604800,
+  orderState: 'FINISHED',
+  orderType: OrderType.BUY,
+  outputCurrency: 'BTC',
+  paymentState: null,
+  paymentType: BSPaymentTypes.PAYMENT_CARD
+}
+
 export const FundsSuccess = Template.bind({})
 FundsSuccess.args = {
   baseAmount: '0.001',

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/index.tsx
@@ -161,7 +161,7 @@ class OrderSummaryContainer extends PureComponent<Props> {
           <OrderSummary
             baseAmount={getBaseAmount(order)}
             baseCurrency={getBaseCurrency(order)}
-            counterAmount={`${currencySymbol}${getCounterAmount(order)}`}
+            counterAmount={getCounterAmount(order)}
             currencySymbol={currencySymbol}
             handleClose={this.props.handleClose}
             handleCompleteButton={this.handleCompleteButton}


### PR DESCRIPTION
The OrderSummary component was rendering a duplicated currency sign
because the parent component was already adding the currency sign to
the label

## Testing Steps
* create a recurring buy in staging
* in the order summary should display the currency sign duplicated

