### PR TITLE
fix(BankList): remove min Withdrawal on bank account

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/BankList/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/Deposit/BankList/template.success.tsx
@@ -16,7 +16,6 @@ type OwnProps = {
   account: BankTransferAccountType | undefined
   bankTransferAccounts: BankTransferAccountType[]
   beneficiaries: BeneficiaryType[]
-  minAmount: NabuSymbolNumberType
 }
 type Props = _P & OwnProps
 
@@ -86,7 +85,6 @@ const BankList = (props: Props) => {
           <BankWire
             key={beneficiary.id}
             beneficiary={beneficiary}
-            minAmount={props.minAmount}
             onClick={() => {
               props.brokerageActions.setDWStep({
                 dwStep: BankDWStepType.WIRE_INSTRUCTIONS


### PR DESCRIPTION
This removes the min Withdrawal from the bank account
item in the beneficiaries list page

## Testing Steps (optional)
* Go to Deposit page
* Open the list of beneficiaries
* Then verify that any bank option will not show the "Min Withdrawal" chip


### Before:
<img width="433" alt="Screen Shot 2022-02-14 at 6 24 55 PM" src="https://user-images.githubusercontent.com/99212903/153948882-38d2b1d6-175f-43a7-ab94-7e091aaf7d38.png">


### After:
<img width="467" alt="Screen Shot 2022-02-14 at 6 25 55 PM" src="https://user-images.githubusercontent.com/99212903/153949009-20a6acd9-84f7-4b9f-a342-568a0f22c735.png">



