### PR TITLE
fix(Swap/CoinSelection): display the correct selected account

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/CoinSelection/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/CoinSelection/index.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { connect, ConnectedProps } from 'react-redux'
+import { equals } from 'ramda'
 
 import { Icon, Text } from 'blockchain-info-components'
 import { StickyHeaderFlyoutWrapper } from 'components/Flyout'
@@ -29,8 +30,8 @@ class CoinSelection extends PureComponent<Props> {
     account: SwapAccountType
   ) => {
     if (
-      (side === 'BASE' && values?.BASE?.label === account.label) ||
-      (side === 'COUNTER' && values?.COUNTER?.label === account.label)
+      (side === 'BASE' && !!values?.BASE && equals(values.BASE, account)) ||
+      (side === 'COUNTER' && !!values?.COUNTER && equals(values?.COUNTER, account))
     ) {
       return true
     }
@@ -128,7 +129,6 @@ class CoinSelection extends PureComponent<Props> {
             const isAccountSelected = this.checkAccountSelected(this.props.side, values, account)
             const isCoinSelected = this.checkCoinSelected(this.props.side, values, account)
             const hideCustodialToAccount = this.checkBaseCustodial(this.props.side, values, account)
-
             const isBaseAccountZero = this.checkBaseAccountZero(this.props.side, account)
             const isCustodialEligible = this.checkCustodialEligibility(
               custodialEligibility,


### PR DESCRIPTION
The coin selection page was using only the account name to check
if it is the select account, but that is a problem when multiple
accounts have the same name. This improves the selection check by
doing a deep comparison on the account to check for the selected
account

## After fix:
https://user-images.githubusercontent.com/99212903/154145161-05daa4c5-65fb-4f1a-870a-2a4e4115144f.mov


