### PR TITLE
feat(CircularImage): adds a circular image component to components

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/CircularImage.spec.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/CircularImage.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { CircularImage } from '.'
+
+describe('CircularImage', () => {
+  describe('#radius', () => {
+    it('Should create a circular image when size is small', () => {
+      const component = shallow(<CircularImage radius='small' src='http://example.com/' />)
+
+      const imageTagStyle = component.get(0).props.style
+
+      expect(imageTagStyle.width).toEqual(24)
+      expect(imageTagStyle.height).toEqual(24)
+      expect(imageTagStyle.borderRadius).toEqual(12)
+    })
+
+    it('Should create a circular image when size is medium', () => {
+      const component = shallow(<CircularImage radius='medium' src='http://example.com/' />)
+
+      const imageTagStyle = component.get(0).props.style
+
+      expect(imageTagStyle.width).toEqual(40)
+      expect(imageTagStyle.height).toEqual(40)
+      expect(imageTagStyle.borderRadius).toEqual(20)
+    })
+
+    it('Should create a circular image when size is large', () => {
+      const component = shallow(<CircularImage radius='large' src='http://example.com/' />)
+
+      const imageTagStyle = component.get(0).props.style
+
+      expect(imageTagStyle.width).toEqual(48)
+      expect(imageTagStyle.height).toEqual(48)
+      expect(imageTagStyle.borderRadius).toEqual(24)
+    })
+
+    it('Should create a circular image with the custom radius', () => {
+      const component = shallow(<CircularImage radius={8} src='http://example.com/' />)
+
+      const imageTagStyle = component.get(0).props.style
+
+      expect(imageTagStyle.width).toEqual(16)
+      expect(imageTagStyle.height).toEqual(16)
+      expect(imageTagStyle.borderRadius).toEqual(8)
+    })
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/CircularImage.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/CircularImage.stories.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { CircularImage, CircularImageComponent, CircularImageRadius } from '.'
+
+const bitcoinImageSrc =
+  'https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/bitcoin/info/logo.png'
+
+const ethereumImageSrc =
+  'https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/info/logo.png'
+
+const circularImageStory: ComponentMeta<CircularImageComponent> = {
+  argTypes: {
+    radius: {
+      defaultValue: 'medium',
+      options: ['large', 'medium', 'small']
+    },
+    src: {
+      defaultValue: bitcoinImageSrc,
+      options: [bitcoinImageSrc, ethereumImageSrc]
+    }
+  },
+  component: CircularImage,
+  title: 'Components/CircularImage'
+}
+
+const Template: ComponentStory<CircularImageComponent> = (args) => <CircularImage {...args} />
+
+export const Default = Template.bind({})
+
+export const Sizes = () => {
+  const radius: CircularImageRadius[] = ['small', 'medium', 'large']
+
+  return (
+    <div style={{ alignItems: 'center', display: 'flex', gap: '12px' }}>
+      {radius.map((imageRadius) => (
+        <div
+          key={imageRadius}
+          style={{ alignItems: 'center', display: 'flex', flexDirection: 'column', gap: '4px' }}
+        >
+          <CircularImage radius={imageRadius} src={bitcoinImageSrc} />
+          <span>{imageRadius}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+Sizes.parameters = {
+  docs: {
+    storyDescription: 'The redius property also accepts a any number to size the circle image'
+  }
+}
+
+export const CustomRadius = Template.bind({})
+CustomRadius.argTypes = {
+  radius: {
+    control: { min: 0, step: 2, type: 'number' },
+    defaultValue: 10
+  }
+}
+CustomRadius.parameters = {
+  docs: {
+    storyDescription: 'The redius property also accepts a any number to size the circle image'
+  }
+}
+
+export default circularImageStory

--- a/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/CircularImage.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/CircularImage.tsx
@@ -1,0 +1,17 @@
+import React, { useMemo } from 'react'
+
+import { CircularImageComponent } from './types'
+import { convertRadiusToPixels } from './utils/convertRadiusToPixels'
+
+/**
+ - Use an CircularImage to display any image is a circular shape.
+ - This radius has 4 options: small, medium, large and number,
+* */
+export const CircularImage: CircularImageComponent = ({ alt = '', radius = 'medium', src }) => {
+  const radiusInPixels = useMemo(() => convertRadiusToPixels(radius), [radius])
+
+  const height = radiusInPixels * 2
+  const width = radiusInPixels * 2
+
+  return <img alt={alt} src={src} style={{ borderRadius: radiusInPixels, height, width }} />
+}

--- a/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/index.ts
@@ -1,0 +1,2 @@
+export { CircularImage } from './CircularImage'
+export type { CircularImageComponent, CircularImageProps, CircularImageRadius } from './types'

--- a/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/types.ts
@@ -1,0 +1,11 @@
+import { FC } from 'react'
+
+export type CircularImageRadius = 'small' | 'medium' | 'large' | number
+
+export type CircularImageProps = {
+  alt?: string
+  radius?: CircularImageRadius
+  src: string
+}
+
+export type CircularImageComponent = FC<CircularImageProps>

--- a/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/utils/convertRadiusToPixels.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/CircularImage/utils/convertRadiusToPixels.ts
@@ -1,0 +1,11 @@
+import { CircularImageRadius } from '../types'
+
+export const convertRadiusToPixels = (size: CircularImageRadius): number => {
+  const mapImageSizeToPizels: Record<CircularImageRadius, number> = {
+    large: 24,
+    medium: 20,
+    small: 12
+  }
+
+  return mapImageSizeToPizels[size] ?? size
+}


### PR DESCRIPTION
This adds a new component to render circular images
like avatars, badges and symbols
<img width="1728" alt="Screen Shot 2022-02-21 at 5 01 06 PM" src="https://user-images.githubusercontent.com/99212903/155019799-9001676f-7629-4d74-8124-9c0b01c6a53d.png">

