### PR TITLE
add coin page scaffold

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
 module.exports = {
-  stories: ['../packages/blockchain-wallet-v4-frontend/src/components/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../packages/blockchain-wallet-v4-frontend/src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flex/Flex.spec.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flex/Flex.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { Flex } from '.'
+
+describe('Flex', () => {
+  it('Should create the flex element with the correct flex parameters', () => {
+    const component = shallow(
+      <Flex gap={12} flexDirection='column' alignItems='center' justifyContent='space-between' />
+    )
+
+    const flexElementStyle = component.get(0).props.style
+
+    expect(flexElementStyle.display).toEqual('flex')
+    expect(flexElementStyle.gap).toEqual('12px')
+    expect(flexElementStyle.flexDirection).toEqual('column')
+    expect(flexElementStyle.alignItems).toEqual('center')
+    expect(flexElementStyle.justifyContent).toEqual('space-between')
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flex/Flex.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flex/Flex.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { Flex, FlexComponent } from '.'
+
+const flexStory: ComponentMeta<FlexComponent> = {
+  component: Flex,
+  title: 'Components/Flex'
+}
+
+const Template: ComponentStory<FlexComponent> = (args) => <Flex {...args} />
+
+const GreyCircle = () => (
+  <div style={{ background: 'grey', borderRadius: 12, height: 24, width: 24 }} />
+)
+
+export const IconListItemExample = () => {
+  return (
+    <Flex gap={6}>
+      <Flex alignItems='center' justifyContent='center'>
+        <GreyCircle />
+      </Flex>
+
+      <Flex gap={6} flexDirection='column'>
+        <span style={{ background: 'grey' }}>Title</span>
+
+        <span style={{ background: 'grey' }}>Subtitle</span>
+      </Flex>
+    </Flex>
+  )
+}
+
+export const AppBarExample = () => {
+  return (
+    <Flex justifyContent='space-between'>
+      <Flex gap={6} alignItems='center'>
+        <GreyCircle />
+
+        <span>Title</span>
+      </Flex>
+
+      <Flex gap={4}>
+        <GreyCircle />
+        <GreyCircle />
+        <GreyCircle />
+        <GreyCircle />
+      </Flex>
+    </Flex>
+  )
+}
+
+export default flexStory

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flex/Flex.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flex/Flex.tsx
@@ -1,0 +1,23 @@
+import React, { CSSProperties, useMemo } from 'react'
+
+import { FlexComponent } from './types'
+
+export const Flex: FlexComponent = ({
+  alignItems,
+  children,
+  flexDirection,
+  gap,
+  justifyContent
+}) => {
+  const style: CSSProperties = useMemo(() => {
+    return {
+      alignItems,
+      display: 'flex',
+      flexDirection,
+      gap: gap ? `${gap}px` : undefined,
+      justifyContent
+    }
+  }, [alignItems, justifyContent, gap, flexDirection])
+
+  return <div style={style}>{children}</div>
+}

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flex/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flex/index.ts
@@ -1,0 +1,2 @@
+export { Flex } from './Flex'
+export type { FlexComponent, FlexProps } from './types'

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flex/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flex/types.ts
@@ -1,0 +1,29 @@
+import { FC } from 'react'
+
+export type FlexAlignItems =
+  | 'stretch'
+  | 'flex-start'
+  | 'flex-end'
+  | 'center'
+  | 'baseline'
+  | 'start'
+  | 'end'
+
+export type FlexJustifyContent =
+  | 'flex-start'
+  | 'flex-end'
+  | 'center'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly'
+
+export type FlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse'
+
+export type FlexProps = {
+  alignItems?: FlexAlignItems
+  flexDirection?: FlexDirection
+  gap?: number
+  justifyContent?: FlexJustifyContent
+}
+
+export type FlexComponent = FC<FlexProps>

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/CoinPage.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/CoinPage.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { CoinPage, CoinPageComponent } from '.'
+
+const coinPageStory: ComponentMeta<CoinPageComponent> = {
+  component: CoinPage,
+  title: 'Pages/CoinPage'
+}
+
+const Template: ComponentStory<CoinPageComponent> = (args) => <CoinPage {...args} />
+
+export const Default = Template.bind({})
+Default.args = {}
+
+export default coinPageStory

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/CoinPage.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/CoinPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import { IconButton } from 'blockchain-info-components'
+
+import { CoinHeader, PageScaffold } from './components'
+import { CoinPageComponent } from './types'
+
+export const CoinPage: CoinPageComponent = () => {
+  return (
+    <PageScaffold
+      header={
+        <CoinHeader
+          coinCode='BTC'
+          coinName='Bitcoin'
+          coinDescription='The internet’s first and largest crypto currency.'
+        />
+      }
+      favoriteButton={<span>favoriteButton</span>}
+      chart={<span>chart</span>}
+      about={<span>about</span>}
+      activity={<span>activity</span>}
+      alertCard={<span>alertCard</span>}
+      holdings={<span>holding</span>}
+      promoCard={<span>promoCard</span>}
+      recurringBuys={<span>recurringBuys</span>}
+    />
+  )
+}

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/CoinHeader/CoinHeader.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/CoinHeader/CoinHeader.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { CoinHeader, CoinHeaderComponent } from '.'
+
+const coinHeaderStory: ComponentMeta<CoinHeaderComponent> = {
+  component: CoinHeader,
+  title: 'Pages/CoinCiew/CoinHeader'
+}
+
+const Template: ComponentStory<CoinHeaderComponent> = (args) => <CoinHeader {...args} />
+
+export const Bitcoin = Template.bind({})
+Bitcoin.args = {
+  coinCode: 'BTC',
+  coinDescription: 'The internet’s first and largest crypto currency.',
+  coinName: 'Bitcoin'
+}
+
+export const Ethereum = Template.bind({})
+Ethereum.args = {
+  coinCode: 'ETH',
+  coinDescription: 'The internet’s first and largest crypto currency.',
+  coinName: 'Ethereum'
+}
+
+export default coinHeaderStory

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/CoinHeader/CoinHeader.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/CoinHeader/CoinHeader.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import { Image, Text } from 'blockchain-info-components'
+
+import { Flex } from '../../../../components/Flex'
+import { CoinHeaderComponent } from './types'
+
+export const CoinHeader: CoinHeaderComponent = ({ coinCode, coinDescription, coinName }) => {
+  return (
+    <Flex gap={16}>
+      <Image name='btc' style={{ height: '48px', width: '48px' }} />
+
+      <Flex flexDirection='column' gap={4} justifyContent='center'>
+        <Flex gap={4}>
+          <Text color='grey900' weight={600} size='20px'>
+            {coinName}
+          </Text>
+
+          <Text color='grey600' weight={600} size='20px'>
+            {coinCode}
+          </Text>
+        </Flex>
+
+        <Text color='grey900' weight={500} size='16px'>
+          {coinDescription}
+        </Text>
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/CoinHeader/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/CoinHeader/index.ts
@@ -1,0 +1,8 @@
+export {
+    CoinHeader,
+} from "./CoinHeader"
+
+export type {
+    CoinHeaderComponent,
+    CoinHeaderProps
+} from "./types"

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/CoinHeader/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/CoinHeader/types.ts
@@ -1,0 +1,9 @@
+import { FC } from 'react'
+
+export type CoinHeaderProps = {
+  coinCode: string
+  coinDescription?: string
+  coinName: string
+}
+
+export type CoinHeaderComponent = FC<CoinHeaderProps>

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/PageScaffold/PageScaffold.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/PageScaffold/PageScaffold.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { Flex } from 'components/Flex'
+
+import { Container, Grid } from './styles'
+import { PageScaffoldComponent } from './types'
+
+export const PageScaffold: PageScaffoldComponent = ({
+  about,
+  activity,
+  alertCard,
+  chart,
+  favoriteButton,
+  header,
+  holdings,
+  promoCard,
+  recurringBuys,
+  wallets
+}) => {
+  return (
+    <Container>
+      <Grid>
+        <Flex flexDirection='column' gap={48}>
+          <Flex alignItems='center' gap={16} justifyContent='space-between'>
+            {header}
+            {favoriteButton}
+          </Flex>
+
+          {chart}
+          {about}
+          {activity}
+        </Flex>
+
+        <Flex flexDirection='column' gap={24}>
+          {alertCard} {holdings} {wallets} {recurringBuys} {promoCard}
+        </Flex>
+      </Grid>
+    </Container>
+  )
+}

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/PageScaffold/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/PageScaffold/index.ts
@@ -1,0 +1,1 @@
+export { PageScaffold } from './PageScaffold'

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/PageScaffold/styles.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/PageScaffold/styles.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: center;
+`
+
+export const Grid = styled.div`
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  column-gap: 32px;
+  padding: 40px 64px;
+  width: 100%;
+  max-width: 1280px;
+`

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/PageScaffold/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/PageScaffold/types.ts
@@ -1,0 +1,16 @@
+import { FC, ReactNode } from 'react'
+
+export type PageScaffoldProps = {
+  about?: ReactNode
+  activity?: ReactNode
+  alertCard?: ReactNode
+  chart: ReactNode
+  favoriteButton?: ReactNode
+  header: ReactNode
+  holdings?: ReactNode
+  promoCard?: ReactNode
+  recurringBuys?: ReactNode
+  wallets?: ReactNode
+}
+
+export type PageScaffoldComponent = FC<PageScaffoldProps>

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/index.ts
@@ -1,0 +1,7 @@
+export {
+    PageScaffold,
+} from "./PageScaffold"
+
+export {
+    CoinHeader,
+} from "./CoinHeader"

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/index.ts
@@ -1,0 +1,2 @@
+export { CoinPage } from './CoinPage'
+export { CoinPageComponent, CoinPageProps } from './types'

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/types.ts
@@ -1,0 +1,5 @@
+import { FC } from 'react'
+
+export type CoinPageProps = {}
+
+export type CoinPageComponent = FC<CoinPageProps>


### PR DESCRIPTION
This PR adds the coin page component and the inner layout of the page
with the page header displaying the coin name, code, logo and description
<img width="1089" alt="Screen Shot 2022-02-22 at 12 29 16 PM" src="https://user-images.githubusercontent.com/99212903/155164784-32ae8f0d-b0ff-42a8-baab-87d485744352.png">

