### PR TITLE
feat(FWN-1134): make modals bigger to prevent address from being cutoff

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Bch/SendBch/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Bch/SendBch/template.js
@@ -15,7 +15,7 @@ const SendHeader = styled(ModalHeader)`
 `
 
 const SendBch = (props) => (
-  <Modal size='medium' position={props.position} total={props.total}>
+  <Modal size='large' position={props.position} total={props.total}>
     <SendHeader icon='send' onClose={props.closeAll}>
       <FormattedMessage id='modals.sendbch.title' defaultMessage='Send Bitcoin Cash' />
     </SendHeader>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Btc/SendBtc/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Btc/SendBtc/template.tsx
@@ -14,7 +14,7 @@ const SendHeader = styled(ModalHeader)`
 `
 
 const SendBtc = (props) => (
-  <Modal size='medium' position={props.position} total={props.total}>
+  <Modal size='large' position={props.position} total={props.total}>
     <SendHeader icon='send' onClose={props.closeAll}>
       <FormattedMessage id='modals.sendbitcoin.title' defaultMessage='Send Bitcoin' />
     </SendHeader>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Eth/SendEth/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Eth/SendEth/template.js
@@ -15,7 +15,7 @@ const SendHeader = styled(ModalHeader)`
 `
 
 const SendEth = (props) => (
-  <Modal size='medium' position={props.position} total={props.total}>
+  <Modal size='large' position={props.position} total={props.total}>
     <SendHeader icon='send' onClose={props.closeAll}>
       <FormattedMessage
         id='modals.sendeth.cointitle'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Xlm/SendXlm/template.js
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Xlm/SendXlm/template.js
@@ -15,7 +15,7 @@ const SendHeader = styled(ModalHeader)`
 `
 
 const SendXlm = (props) => (
-  <Modal size='medium' position={props.position} total={props.total}>
+  <Modal size='large' position={props.position} total={props.total}>
     <SendHeader icon='send' onClose={props.closeAll}>
       <FormattedMessage id='modals.sendxlm.title' defaultMessage='Send Stellar' />
     </SendHeader>


### PR DESCRIPTION
## Description (optional)
Prevent the address from being clipped
![Screen Shot 2022-02-24 at 6 01 07 PM](https://user-images.githubusercontent.com/39777266/155622071-23d61c9f-0055-4735-8772-6ae9afa72340.png)


## Testing Steps (optional)
Open the send modal and checked that a BCH/btc address isnt clipped

