### PR TITLE
fix(Brokerage): position icons and button correct in order summary

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,23 +1,22 @@
-import React from 'react';
-import { ThemeProvider } from 'styled-components';
-import { addDecorator } from '@storybook/react';
+import React from 'react'
+import { ThemeProvider } from 'styled-components'
+import { addDecorator } from '@storybook/react'
 
 import { Palette } from '../packages/blockchain-info-components/src/Colors/index'
 import { FontGlobalStyles, IconGlobalStyles } from '../packages/blockchain-info-components/src'
+import { addIconsToWindow } from './utils/addIconsToWindow'
 
 const withTheme = () => (story, context) => {
-  const theme1= Palette('default')
+  const theme1 = Palette('default')
   const theme2 = Palette('darkmode')
   const theme3 = Palette('compliment')
   const theme4 = Palette('greyscale')
   const theme5 = Palette('invert')
   const theme = context.args.theme ? Palette(context.args.theme) : theme1
 
-  return (
-    <ThemeProvider theme={theme}>
-      {story()}
-    </ThemeProvider>
-  )
+  addIconsToWindow()
+
+  return <ThemeProvider theme={theme}>{story()}</ThemeProvider>
 }
 
 const withIconsAndFonts = () => (story) => {
@@ -33,11 +32,11 @@ addDecorator(withTheme())
 addDecorator(withIconsAndFonts())
 
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
       color: /(background|color)$/i,
-      date: /Date$/,
-    },
-  },
+      date: /Date$/
+    }
+  }
 }

--- a/.storybook/utils/addIconsToWindow.ts
+++ b/.storybook/utils/addIconsToWindow.ts
@@ -1,0 +1,50 @@
+declare global {
+    interface Window { coins: {[key: string]: unknown}; }
+}
+
+export const addIconsToWindow = () => {
+  window.coins = {
+    BTC: {
+      coinfig: {
+        symbol: "WBTC",
+        displaySymbol: "WBTC",
+        name: "Wrapped Bitcoin",
+        type: {
+          logoPngUrl: "https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",  
+        },
+      }
+    },
+    AAVE: {
+      coinfig: {
+        symbol: 'AAVE',
+        name: 'Aave',
+        type: {
+          logoPngUrl:
+            'https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png',
+        },
+      }
+    },
+    XLM: {
+      coinfig: {
+        name: 'Stellar',
+        precision: 7,
+        products: ['PrivateKey'],
+        symbol: 'XLM',
+        type: {
+          logoPngUrl: 'https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/stellar/info/logo.png'
+        }
+      }
+    },
+    ETH: {
+      coinfig: {
+        name: 'Stellar',
+        precision: 7,
+        products: ['PrivateKey'],
+        symbol: 'XLM',
+        type: {
+          logoPngUrl: 'https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/ethereum/info/logo.png'
+        }
+      }
+    }
+  }
+}

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
@@ -33,7 +33,7 @@ const IconWrapper = styled.div`
   justify-content: center;
 `
 const TitleWrapper = styled(Text)`
-  margin: 32px 0 24px 0;
+  padding: 32px 0 24px 0;
   width: 100%;
 `
 const BottomInfo = styled(Bottom)`
@@ -73,13 +73,16 @@ const OrderSummary: React.FC<Props> = ({
   const isTransactionPending = isPendingDeposit && paymentState === 'WAITING_FOR_3DS_RESPONSE'
 
   const days = moment.duration(lockTime, 'seconds').days()
+
   return (
     <Container>
       <Header data-e2e='sbCloseModalIcon' mode='close' onClick={handleClose} />
       <Content mode='middle'>
         <div style={{ padding: '0 77px', textAlign: 'center' }}>
           <IconWrapper>
-            <Icon color={outputCurrency} name={outputCurrency} size='64px' />
+            <div style={{ height: 64, width: 64 }}>
+              <Icon name={outputCurrency} size='64px' />
+            </div>
 
             {orderState === 'FINISHED' ? (
               <IconBackground color='white'>
@@ -254,7 +257,7 @@ const OrderSummary: React.FC<Props> = ({
             )}
         </div>
       </Content>
-      <Footer>
+      <Footer collapsed>
         {children && <BottomPromo>{children}</BottomPromo>}
 
         {orderType === 'BUY' && orderState !== 'FAILED' && (


### PR DESCRIPTION
This changes the footer height how the icons are positioned in the
the order summary, so all elements are aligned

Before:
<img width="494" alt="Screen Shot 2022-03-01 at 11 13 43 AM" src="https://user-images.githubusercontent.com/99212903/156185200-7e724803-9bfc-42c3-b474-2aa6ba48a71a.png">

After:
<img width="786" alt="Screen Shot 2022-03-04 at 5 41 18 PM" src="https://user-images.githubusercontent.com/99212903/156838480-e9b45c07-b047-4170-a84a-72a8deb1d275.png">

