### PR TITLE
feat(CoinView): add holdings card

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/HoldingsCard.spec.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/HoldingsCard.spec.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+import { render } from 'enzyme'
+
+import { HoldingsCard } from '.'
+
+describe('HoldingsCard', () => {
+  describe('BTC', () => {
+    const createBtcScene = () =>
+      render(
+        <IntlProvider locale='en'>
+          <HoldingsCard
+            coinCode='BTC'
+            total='$7,926.43'
+            coinTotal='0.00039387'
+            actions={[<span key={1}>buy</span>, <span key={2}>receive</span>]}
+          />
+        </IntlProvider>
+      )
+
+    it('Should display the title', () => {
+      const wrapper = createBtcScene()
+
+      expect(wrapper.text()).toContain('Your Total BTC')
+    })
+
+    it('Should display the total amount', () => {
+      const wrapper = createBtcScene()
+
+      expect(wrapper.text()).toContain('$7,926.43')
+    })
+
+    it('Should display the total amoint in the coin value', () => {
+      const wrapper = createBtcScene()
+
+      expect(wrapper.text()).toContain('0.00039387 BTC')
+    })
+
+    it('Should display the actions', () => {
+      const wrapper = createBtcScene()
+
+      expect(wrapper.text()).toContain('buy')
+      expect(wrapper.text()).toContain('receive')
+    })
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/HoldingsCard.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/HoldingsCard.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+import { Icon } from '@blockchain-com/constellation'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { Button } from 'blockchain-info-components'
+import { Flex } from 'components/Flex'
+
+import { HoldingsCard, HoldingsCardComponent } from '.'
+
+const holdingsCardStoriesMeta: ComponentMeta<HoldingsCardComponent> = {
+  argTypes: {
+    actions: {
+      defaultValue: [
+        <Button nature='primary' key={1} data-e2e='' fullwidth>
+          <Flex gap={10} alignItems='center'>
+            <Icon name='cart' color='white900' size='sm' />
+            Buy
+          </Flex>
+        </Button>,
+        <Button nature='dark-grey' key={2} data-e2e='' fullwidth>
+          <Flex gap={10} alignItems='center'>
+            <Icon color='white900' name='qrCode' size='sm' />
+            Receive
+          </Flex>
+        </Button>
+      ]
+    },
+    coinCode: {
+      defaultValue: 'BTC'
+    },
+    coinTotal: {
+      defaultValue: '0.0'
+    },
+    total: {
+      defaultValue: '$0.00'
+    }
+  },
+  component: HoldingsCard,
+  decorators: [(Story) => <IntlProvider locale='en'>{Story()}</IntlProvider>],
+  title: 'Pages/CoinPage/HoldingsCard'
+}
+
+export const Template: ComponentStory<HoldingsCardComponent> = (args) => <HoldingsCard {...args} />
+
+export const Bitcoin = Template.bind({})
+Bitcoin.args = {
+  coinCode: 'BTC',
+  coinTotal: '0.00039387',
+  total: '$7,926.43'
+}
+
+export default holdingsCardStoriesMeta

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/HoldingsCard.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/HoldingsCard.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+
+import { Text } from 'blockchain-info-components'
+
+import { Card } from '../../../../components/Card'
+import { Flex } from '../../../../components/Flex'
+import { Padding } from '../../../../components/Padding'
+import { HoldingsCardComponent } from './types'
+
+export const HoldingsCard: HoldingsCardComponent = ({ actions, coinCode, coinTotal, total }) => {
+  return (
+    <Card>
+      <Padding.All size={16}>
+        <Flex flexDirection='column' gap={16}>
+          <Text color='grey600' size='14px' weight={500} lineHeight='20px'>
+            <FormattedMessage
+              id='CoinPage.HoldingsCard.totalBalanceTitle'
+              defaultMessage='Your Total {coinCode}'
+              values={{
+                coinCode
+              }}
+            />
+          </Text>
+
+          <Flex flexDirection='column'>
+            <Text
+              color='grey900'
+              weight={600}
+              size='24px'
+              lineHeight='32px'
+              style={{
+                fontFeatureSettings: "'ss01' on, 'zero' on"
+              }}
+            >
+              {total}
+            </Text>
+
+            <Text
+              color='grey600'
+              size='14px'
+              lineHeight='20px'
+              weight={500}
+              style={{
+                fontFeatureSettings: "'ss01' on, 'zero' on"
+              }}
+            >
+              {coinTotal} {coinCode}
+            </Text>
+          </Flex>
+
+          <Flex gap={8}>{actions}</Flex>
+        </Flex>
+      </Padding.All>
+    </Card>
+  )
+}

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/index.ts
@@ -1,0 +1,2 @@
+export { HoldingsCard } from './HoldingsCard'
+export type { HoldingsCardComponent, HoldingsCardProps } from './types'

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/HoldingsCard/types.ts
@@ -1,0 +1,10 @@
+import { FC, ReactElement } from 'react'
+
+export type HoldingsCardProps = {
+  actions: ReactElement[]
+  coinCode: string
+  coinTotal: string
+  total: string
+}
+
+export type HoldingsCardComponent = FC<HoldingsCardProps>


### PR DESCRIPTION
This adds the visual component for
coin view to use

Story at: http://localhost:6006/?path=/story/pages-coinpage-holdingscard--bitcoin
![Screen Shot 2022-03-02 at 4 13 12 PM](https://user-images.githubusercontent.com/99212903/156434955-4a513bf4-94d9-4434-90f0-46b26e5918c9.png)

