### PR TITLE
feat: removing autofocus for email and password

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Exchange/EnterEmail/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Exchange/EnterEmail/index.tsx
@@ -56,7 +56,6 @@ const EnterEmail = (props: Props) => {
               normalize={removeWhitespace}
               validate={[required, validEmail]}
               placeholder='Enter your email'
-              autoFocus
             />
           </FormItem>
         </FormGroup>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Exchange/EnterPassword/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Exchange/EnterPassword/index.tsx
@@ -57,7 +57,6 @@ const EnterPasswordExchange = (props: Props) => {
               <FormattedMessage id='scenes.login.your_password' defaultMessage='Your Password' />
             </FormLabel>
             <Field
-              autoFocus
               component={PasswordBox}
               data-e2e='exchangePassword'
               disabled={!isBrowserSupported}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
@@ -65,7 +65,6 @@ const EnterEmailOrGuid = (props: Props) => {
               normalize={removeWhitespace}
               validate={[required, validWalletIdOrEmail]}
               placeholder='Enter email or wallet ID'
-              autoFocus
             />
           </FormItem>
           {guidError && (

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterPassword/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterPassword/index.tsx
@@ -112,7 +112,6 @@ const EnterPasswordWallet = (props: Props) => {
                 <FormattedMessage id='scenes.login.your_password' defaultMessage='Your Password' />
               </FormLabel>
               <Field
-                autoFocus
                 component={PasswordBox}
                 data-e2e='loginPassword'
                 disabled={!isBrowserSupported}


### PR DESCRIPTION
## Description (optional)
Removing login inputs autofocus to avoid validation on focus out when switching products.

![nV5EpWlB8D](https://user-images.githubusercontent.com/97299628/156574887-58ca3a9b-adca-4773-8d85-ab2c4ac7fe3f.gif)

