### PR TITLE
feat(silver revamp): transactions left banner

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/assets/locales/index.d.ts
@@ -2214,6 +2214,8 @@ type MessagesType = {
   'scenes.home.banners.interestpromo.button': 'Deposit Now'
   'scenes.home.banners.recurringbuys.title': 'Recurring buys are now available'
   'scenes.home.banners.recurringbuys.description': 'It’s really hard to time the market, which is why many investors use dollar cost averaging.'
+  'scenes.home.banners.transactions_left.title': 'Transactions Left'
+  'scenes.home.banners.transactions_left.description': 'Unlimited trades and higher limits'
   'scenes.home.pricechart.coincurrentprice.currentprice': 'Current Price'
   'scenes.home.pricechart.coinperformance.all': 'all time'
   'scenes.home.pricechart.coinperformance.day': 'today'

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Banners/TransactionsLeft.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Banners/TransactionsLeft.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+import { Provider } from 'react-redux'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { combineReducers, createStore } from 'redux'
+
+import TransactionsLeft from './TransactionsLeft'
+
+const store = createStore(combineReducers({}))
+
+export default {
+  args: {
+    current: 0,
+    limit: 1
+  },
+  component: TransactionsLeft,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <IntlProvider locale='en'>
+          <div style={{ display: 'flex', height: '100vh', width: '480px' }}>{Story()}</div>
+        </IntlProvider>
+      </Provider>
+    )
+  ],
+  title: 'Flyouts/Banners/TransactionsLeft'
+} as ComponentMeta<typeof TransactionsLeft>
+
+export const Template: ComponentStory<typeof TransactionsLeft> = (args) => (
+  <TransactionsLeft {...args} />
+)
+
+export const Default = Template.bind({})

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Banners/TransactionsLeft.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Banners/TransactionsLeft.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import styled from 'styled-components'
+
+import { Text } from 'blockchain-info-components'
+import CircularProgressBar from 'components/CircularProgressBar'
+import { media } from 'services/styles'
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+  border: 1px solid ${(props) => props.theme.grey000};
+  border-radius: 12px;
+  padding: 16px 18px;
+  margin: 10px 0;
+  cursor: pointer;
+
+  ${media.atLeastLaptop`
+    height: 72px;
+    padding: 0 20px;
+  `}
+  ${media.mobile`
+    padding: 12px;
+    flex-direction: column;
+  `}
+`
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 20px;
+  flex: 1;
+`
+
+const ProgressRow = styled.div`
+  display: flex;
+  justify-content: center;
+`
+
+const ProgressWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 40px;
+  width: 40px;
+  min-width: 40px;
+  border-radius: 20px;
+`
+
+const TransactionsLeft = ({ current, limit }: Props) => {
+  const percentage = (current * 100) / limit
+  return (
+    <Wrapper>
+      <ProgressRow>
+        <ProgressWrapper>
+          <CircularProgressBar percentage={percentage} strokeWidth={12}>
+            <Text size='16px' color='blue600' weight={600}>
+              {`${current}/${limit}`}
+            </Text>
+          </CircularProgressBar>
+        </ProgressWrapper>
+      </ProgressRow>
+      <Column>
+        <Text size='16px' weight={600} color='grey900'>
+          <FormattedMessage
+            id='scenes.home.banners.transactions_left.title'
+            defaultMessage='Transactions Left'
+          />
+        </Text>
+        <Text size='12px' weight={500} color='grey600' style={{ marginTop: '8px' }}>
+          <FormattedMessage
+            id='scenes.home.banners.transactions_left.description'
+            defaultMessage='Unlimited trades and higher limits'
+          />
+        </Text>
+      </Column>
+    </Wrapper>
+  )
+}
+
+type Props = { current: number; limit: number }
+
+export default TransactionsLeft


### PR DESCRIPTION
## Description (optional)
New transactions left banner
<img width="491" alt="image" src="https://user-images.githubusercontent.com/67264242/156601483-16c170d9-11e5-4c8a-98b9-09588cf584b1.png">


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

