### PR TITLE
feat(applepay): adding internal tester as check for apple pay

### DIFF
--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -32,7 +32,7 @@
         }
       },
       "featureFlags": {
-        "applePayPaymentMethod": true,
+        "applePayPaymentMethod": false,
         "addCheckoutPaymentProvider": true,
         "addStripePaymentProvider": false,
         "cEURRewards": true,

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/selectors.ts
@@ -41,6 +41,7 @@ export const getTags = compose(lift(path(['tags'])), getUserData)
 export const getSunRiverTag = compose(lift(path(['tags', 'SUNRIVER'])), getUserData)
 export const getPowerPaxTag = compose(lift(hasPath(['tags', 'POWER_PAX'])), getUserData)
 export const getBlockstackTag = compose(lift(path(['tags', 'BLOCKSTACK'])), getUserData)
+export const isInternalTester = compose(lift(hasPath(['tags', 'INTERNAL_TESTING'])), getUserData)
 export const isUserCreated = compose(
   lift(equals(USER_ACTIVATION_STATES.CREATED)),
   getUserActivationState

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/LinkedPaymentAccounts/Accounts/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/LinkedPaymentAccounts/Accounts/index.tsx
@@ -259,10 +259,10 @@ const Accounts = (props: Props) => {
   const availableMethods = funds.length || cardMethods.length || bankMethods.length || !!applePay
 
   useEffect(() => {
-    if ((window as any).ApplePaySession && props.applePayEnabled) {
+    if ((window as any).ApplePaySession && (props.applePayEnabled || props.isInternalTester)) {
       setApplePayAvailable(true)
     }
-  }, [props.applePayEnabled])
+  }, [props.applePayEnabled, props.isInternalTester])
 
   return (
     <Wrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/LinkedPaymentAccounts/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/LinkedPaymentAccounts/selectors.ts
@@ -10,6 +10,7 @@ export const getData = (state) => {
   const paymentMethodsR = selectors.components.buySell.getBSPaymentMethods(state)
   const walletCurrencyR = selectors.core.settings.getCurrency(state)
   const applePayEnabledR = selectors.core.walletOptions.getApplePayAsNewPaymentMethod(state)
+  const isInternalTesterR = selectors.modules.profile.isInternalTester(state)
 
   return lift(
     (
@@ -17,6 +18,7 @@ export const getData = (state) => {
       balances: ExtractSuccess<typeof balancesR>,
       bankTransferAccounts: ExtractSuccess<typeof bankTransferAccountsR>,
       cards: ExtractSuccess<typeof cardsR>,
+      isInternalTester: ExtractSuccess<typeof isInternalTesterR>,
       paymentMethods: ExtractSuccess<typeof paymentMethodsR>,
       walletCurrency: FiatType
     ) => ({
@@ -24,8 +26,17 @@ export const getData = (state) => {
       balances,
       bankTransferAccounts,
       cards,
+      isInternalTester,
       paymentMethods,
       walletCurrency
     })
-  )(applePayEnabledR, balancesR, bankTransferAccountsR, cardsR, paymentMethodsR, walletCurrencyR)
+  )(
+    applePayEnabledR,
+    balancesR,
+    bankTransferAccountsR,
+    cardsR,
+    isInternalTesterR,
+    paymentMethodsR,
+    walletCurrencyR
+  )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/index.tsx
@@ -203,10 +203,10 @@ const Methods = (props: Props) => {
     funds.length || cardMethods.length || !!paymentCard || !!bankAccount || !!applePay
 
   useEffect(() => {
-    if ((window as any).ApplePaySession && props.applePayEnabled) {
+    if ((window as any).ApplePaySession && (props.applePayEnabled || props.isInternalTester)) {
       setApplePayAvailable(true)
     }
-  }, [props.applePayEnabled])
+  }, [props.applePayEnabled, props.isInternalTester])
 
   return (
     <Wrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/selectors.ts
@@ -16,6 +16,7 @@ const getData = (state) => {
   } as InvitationsType)
   const walletCurrencyR = selectors.core.settings.getCurrency(state)
   const applePayEnabledR = selectors.core.walletOptions.getApplePayAsNewPaymentMethod(state)
+  const isInternalTesterR = selectors.modules.profile.isInternalTester(state)
 
   return lift(
     (
@@ -24,6 +25,7 @@ const getData = (state) => {
       bankTransferAccounts: ExtractSuccess<typeof bankTransferAccountsR>,
       cards: ExtractSuccess<typeof cardsR>,
       eligibility: ExtractSuccess<typeof eligibilityR>,
+      isInternalTester: ExtractSuccess<typeof isInternalTesterR>,
       pairs: ExtractSuccess<typeof pairsR>,
       paymentMethods: ExtractSuccess<typeof paymentMethodsR>,
       walletCurrency: FiatType
@@ -33,6 +35,7 @@ const getData = (state) => {
       bankTransferAccounts,
       cards,
       eligibility,
+      isInternalTester,
       pairs,
       paymentMethods:
         (!invitations.openBanking && {
@@ -53,6 +56,7 @@ const getData = (state) => {
     bankTransferAccountsR,
     cardsR,
     eligibilityR,
+    isInternalTesterR,
     pairsR,
     paymentMethodsR,
     walletCurrencyR


### PR DESCRIPTION
This PR creates the ability to use the tag `INTERNAL_TESTER` from the user to allow it to see features or not.

In this case, I need it to enable `Apple Pay` only for certain users on prod (because it's the only place where it can be tested ATM)

