### PR TITLE
feat(CoinView): add chart balance panel

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/ChartBalancePanel.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/ChartBalancePanel.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { ChartBalancePanel } from '.'
+import { ChartBalancePanelComponent } from './types'
+
+const chartBalancePanelComponentMeta: ComponentMeta<ChartBalancePanelComponent> = {
+  component: ChartBalancePanel,
+  decorators: [(Story) => <IntlProvider locale='en'>{Story()}</IntlProvider>],
+  title: 'Pages/CoinPage/ChartBalancePanel'
+}
+
+const Template: ComponentStory<ChartBalancePanelComponent> = (args) => (
+  <ChartBalancePanel {...args} />
+)
+
+export const BitcoinUp = Template.bind({})
+BitcoinUp.args = {
+  coinCode: 'BTC',
+  pastHourDelta: 0.3453908,
+  pastHourPrice: '$95.23',
+  price: '$31,928.19'
+}
+
+export const BitcoinDown = Template.bind({})
+BitcoinDown.args = {
+  coinCode: 'BTC',
+  pastHourDelta: -0.34538978979,
+  pastHourPrice: '$95.23',
+  price: '$31,928.19'
+}
+
+export default chartBalancePanelComponentMeta

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/ChartBalancePanel.test.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/ChartBalancePanel.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+import { Icon } from '@blockchain-com/constellation'
+import { mount, shallow } from 'enzyme'
+
+import { ChartBalancePanel } from '.'
+
+describe('ChartBalancePanel', () => {
+  describe('When balance is positive', () => {
+    it('Should see the positive balance', () => {
+      const component = mount(
+        <IntlProvider locale='en'>
+          <ChartBalancePanel
+            coinCode='BTC'
+            pastHourDelta={0.3469}
+            pastHourPrice='$9.95'
+            price='$30.000'
+          />
+        </IntlProvider>
+      )
+
+      expect(component.contains('$9.95')).toBe(true)
+      expect(component.contains('$30.000')).toBe(true)
+      expect(component.contains('(34.69%)')).toBe(true)
+      expect(component.contains('BTC Price')).toBe(true)
+      expect(component.contains('Past Hour')).toBe(true)
+    })
+
+    it('Should display the green arrow up', () => {
+      const component = shallow(
+        <ChartBalancePanel
+          coinCode='BTC'
+          pastHourDelta={0.3469}
+          pastHourPrice='$9.95'
+          price='$30.000'
+        />
+      )
+
+      expect(component.contains(<Icon name='arrowUp' size='sm' color='green600' />)).toBe(true)
+    })
+  })
+
+  describe('When balance is negative', () => {
+    it('Should display the red arrow down', () => {
+      const component = shallow(
+        <ChartBalancePanel
+          coinCode='BTC'
+          pastHourDelta={-0.3469}
+          pastHourPrice='$9.95'
+          price='$30.000'
+        />
+      )
+
+      expect(component.contains(<Icon name='arrowDown' size='sm' color='red600' />)).toBe(true)
+    })
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/ChartBalancePanel.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/ChartBalancePanel.tsx
@@ -1,0 +1,76 @@
+import React, { ReactNode, useMemo } from 'react'
+import { FormattedMessage } from 'react-intl'
+import { Icon } from '@blockchain-com/constellation'
+
+import { Text } from 'blockchain-info-components'
+import { Flex } from 'components/Flex'
+
+import { ChartBalancePanelComponent } from './types'
+
+export const ChartBalancePanel: ChartBalancePanelComponent = ({
+  coinCode,
+  pastHourDelta,
+  pastHourPrice,
+  price
+}) => {
+  const isPositive: boolean = useMemo(() => {
+    return pastHourDelta > 0
+  }, [pastHourDelta])
+
+  const arrowIcon: ReactNode = useMemo(() => {
+    if (isPositive) {
+      return <Icon name='arrowUp' size='sm' color='green600' />
+    }
+
+    return <Icon name='arrowDown' size='sm' color='red600' />
+  }, [isPositive])
+
+  const textColor: 'green600' | 'red600' = useMemo(() => {
+    if (isPositive) {
+      return 'green600'
+    }
+
+    return 'red600'
+  }, [isPositive])
+
+  const formattedPercentage = useMemo(() => {
+    return (pastHourDelta * 100).toFixed(2)
+  }, [pastHourDelta])
+
+  return (
+    <Flex gap={8} flexDirection='column'>
+      <Text color='grey900' weight={600} size='12px' lineHeight='16px'>
+        <FormattedMessage
+          id='chart-view.chart-balance-panel.price'
+          defaultMessage='{coinCode} Price'
+          values={{
+            coinCode
+          }}
+        />
+      </Text>
+
+      <Text color='grey900' weight={600} size='40px' lineHeight='50px'>
+        {price}
+      </Text>
+
+      <Flex gap={8} alignItems='center'>
+        {arrowIcon}
+
+        <Text color={textColor} weight={600} size='16px' lineHeight='24px'>
+          {pastHourPrice}
+        </Text>
+
+        <Text color={textColor} weight={600} size='16px' lineHeight='24px'>
+          {`(${formattedPercentage}%)`}
+        </Text>
+
+        <Text color='grey400' weight={600} size='16px' lineHeight='24px'>
+          <FormattedMessage
+            id='chart-view.chart-balance-panel.past-hour'
+            defaultMessage='Past Hour'
+          />
+        </Text>
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/index.ts
@@ -1,0 +1,2 @@
+export { ChartBalancePanel } from './ChartBalancePanel'
+export type { ChartBalancePanelComponent, ChartBalancePanelProps } from './types'

--- a/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/pages/CoinPage/components/ChartBalancePanel/types.ts
@@ -1,0 +1,10 @@
+import { FC } from 'react'
+
+export type ChartBalancePanelProps = {
+  coinCode: string
+  pastHourDelta: number
+  pastHourPrice: string
+  price: string
+}
+
+export type ChartBalancePanelComponent = FC<ChartBalancePanelProps>


### PR DESCRIPTION
Adds the chart balance panel to the coin view
list of components

<img width="315" alt="Screen Shot 2022-03-08 at 10 05 16 PM" src="https://user-images.githubusercontent.com/99212903/157352427-c8596c8b-abfa-4ca5-bf04-eb0375e5d76e.png">
<img width="328" alt="Screen Shot 2022-03-08 at 10 05 20 PM" src="https://user-images.githubusercontent.com/99212903/157352433-569d8c1d-ff18-4c67-b1f6-09d17b3d9eb9.png">
