### PR TITLE
fix: remove nonworking command from deploy storybook

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - name: Deploy storybook - base components
-        run: yarn storybook:base
+#     Non-working command
+#      - name: Deploy storybook - base components
+#        run: yarn storybook:base
 
       - name: Deploy storybook - wallet
         run: yarn storybook:deploy-wallet


### PR DESCRIPTION
## Description 
Commented non-working command for deploy-storybook to prevent build failure
