### PR TITLE
Fix/fwn 1120/tb recive copy bch

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/RequestCrypto/ShowAddress/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/RequestCrypto/ShowAddress/index.tsx
@@ -137,14 +137,18 @@ class RequestShowAddress extends React.PureComponent<Props> {
               Failure: () => <></>,
               Loading: () => <></>,
               NotAsked: () => <></>,
-              Success: (val) => (
-                <CopyClipboardButton
-                  onClick={() => this.props.requestActions.setAddressCopied()}
-                  textToCopy={val.address}
-                  color='blue600'
-                  size='24px'
-                />
-              )
+              Success: (val) => {
+                const parsedAddress = val.address.match(/[^:]+$/g)?.[0]
+                const textToCopy = typeof parsedAddress === 'string' ? parsedAddress : val.address
+                return (
+                  <CopyClipboardButton
+                    color='blue600'
+                    onClick={() => this.props.requestActions.setAddressCopied()}
+                    size='24px'
+                    textToCopy={textToCopy}
+                  />
+                )
+              }
             })}
           </ClipboardWrapper>
         </AddressWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/RequestCrypto/ShowAddress/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/RequestCrypto/ShowAddress/index.tsx
@@ -128,7 +128,10 @@ class RequestShowAddress extends React.PureComponent<Props> {
                 ),
                 Loading: () => <SkeletonRectangle width='280px' height='24px' />,
                 NotAsked: () => <SkeletonRectangle width='280px' height='24px' />,
-                Success: (val) => val.address
+                Success: (val) => {
+                  const parsedAddress = val.address.match(/[^:]+$/g)?.[0]
+                  return typeof parsedAddress === 'string' ? parsedAddress : val.address
+                }
               })}
             </Text>
           </AddressDisplay>


### PR DESCRIPTION
## Description (optional)
Remove `bitcoincash:` from address and copy address
<img width="515" alt="Screen Shot 2022-03-16 at 9 29 05 AM" src="https://user-images.githubusercontent.com/39777266/158600718-36391b93-98bb-4484-85a1-88a1fc1f17b2.png">



## Testing Steps (optional)
Open receive modal, make sure when you click the copy address icon the copied address does not include `bitcoincash:`

