### PR TITLE
refactor(builds): remove non-english bip39 files from bundle

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/webpackBuilder.js
+++ b/packages/blockchain-wallet-v4-frontend/webpackBuilder.js
@@ -143,6 +143,10 @@ const buildWebpackConfig = (envConfig, extraPluginsList) => ({
         resourceRegExp: /^\.\/locale$/,
         contextRegExp: /moment$/
       }),
+      new Webpack.IgnorePlugin({
+        resourceRegExp: /^\.\/wordlists\/(?!english)/,
+        contextRegExp: /bip39$/,
+      }),
       new FaviconsWebpackPlugin({
         devMode: 'light',
         logo: CONFIG_PATH.src + '/assets/favicon.png',


### PR DESCRIPTION
## Description
- reduces app bundle size (~300b gzipped) by excluding non-english wordlist json files

