### PR TITLE
FWN-1261 add captcha support for legacy wallet import

### DIFF
--- a/legacy-pages/import-wallet.html
+++ b/legacy-pages/import-wallet.html
@@ -22,6 +22,14 @@
   <script nonce="**CSP_NONCE**">
     window.NONCE = '**CSP_NONCE**'
   </script>
+  <script nonce="**CSP_NONCE**">
+    window.CAPTCHA_KEY = '**RECAPTCHA_KEY**'
+  </script>
+  <script
+      nonce="**CSP_NONCE**"
+      rel="prefetch"
+      src="https://www.google.com/recaptcha/enterprise.js?render=**RECAPTCHA_KEY**"
+    ></script>
 </head>
 <body data-war-checksum="1e64a0eb9697314b" class="opaque-nav" id="home-container">
 <nav role="navigation">

--- a/legacy-pages/import-wallet.html
+++ b/legacy-pages/import-wallet.html
@@ -21,8 +21,6 @@
   <script src="js/import/wallet-import.js" nonce="**CSP_NONCE**" type="text/javascript"></script>
   <script nonce="**CSP_NONCE**">
     window.NONCE = '**CSP_NONCE**'
-  </script>
-  <script nonce="**CSP_NONCE**">
     window.CAPTCHA_KEY = '**RECAPTCHA_KEY**'
   </script>
   <script

--- a/legacy-pages/js/import/wallet-import.js
+++ b/legacy-pages/js/import/wallet-import.js
@@ -254,7 +254,7 @@
         if (!window.grecaptcha || !window.grecaptcha.enterprise) return
         window.grecaptcha.enterprise.ready(() => {
             window.grecaptcha.enterprise
-                .execute(window.CAPTCHA_KEY, { action: 'IMPORT_JSON_WALLET' })
+                .execute(window.CAPTCHA_KEY, { action: 'LEGACY_WALLET_IMPORT' })
                 .then((captchaToken) => {
                     console.log('Captcha success', captchaToken)
                     window.NEWRECAPCHA = captchaToken


### PR DESCRIPTION
## Description (optional)
Added the new captcha script and keys to the html and then use the client to get the validation in order to submit the wallet recovery.

## Testing Steps (optional)
One should be able to navigate into [the wallet recovery legacy page](https://login.blockchain.com/wallet/import-wallet) add the proper `json` file and set the new password.