### PR TITLE
FWN-1375 - fix: adding 'notranslate' class to avoid seed words being translated

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Settings/RecoveryPhrase/ShowRecoveryWords/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Settings/RecoveryPhrase/ShowRecoveryWords/template.tsx
@@ -67,7 +67,7 @@ const WordsList = ({ handleBackArrow, handleNextButton, step, words }) => {
         words.map((word, index) => {
           if (index < 6) {
             return (
-              <WordBox>
+              <WordBox className='notranslate'>
                 <WordText data-e2e='backupWords'>
                   <Title>{index + 1}</Title>
                   <Value>{word}</Value>
@@ -75,12 +75,13 @@ const WordsList = ({ handleBackArrow, handleNextButton, step, words }) => {
               </WordBox>
             )
           }
+          return null
         })}
       {step === 'SECOND_SET_WORDS' &&
         words.map((word, index) => {
           if (index >= 6) {
             return (
-              <WordBox>
+              <WordBox className='notranslate'>
                 <WordText data-e2e='backupWords'>
                   <Title>{index + 1}</Title>
                   <Value>{word}</Value>
@@ -88,6 +89,7 @@ const WordsList = ({ handleBackArrow, handleNextButton, step, words }) => {
               </WordBox>
             )
           }
+          return null
         })}
       <Bottom>
         <Button


### PR DESCRIPTION
## Description (optional)
Adding `className='notranslate'` attribute to the parent wrappers to avoid google translate services to translate the wallet's "magic words" (or "seed words"). Better description inside [the ticket](https://blockchain.atlassian.net/browse/FWN-1375).