### PR TITLE
fix(FWN-1331): remove next buttons and replace with appropriate cta

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/EnterAmount.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/EnterAmount.tsx
@@ -354,26 +354,28 @@ const Account = ({
   )
 }
 
-const NextButton = ({ invalid, orderType, paymentAccount, pristine, submitting }) => {
-  return (
-    <Button
-      data-e2e={orderType === BrokerageOrderType.DEPOSIT ? 'submitDepositAmount' : 'withdrawNext'}
-      height='48px'
-      size='16px'
-      nature='primary'
-      type='submit'
-      fullwidth
-      disabled={invalid || pristine || submitting || !paymentAccount}
-      onClick={() => {}}
-    >
-      {submitting ? (
-        <HeartbeatLoader height='16px' width='16px' color='white' />
-      ) : (
-        <FormattedMessage id='buttons.next' defaultMessage='Next' />
-      )}
-    </Button>
-  )
-}
+const PreviewButton = ({ invalid, orderType, paymentAccount, pristine, submitting }) => (
+  <Button
+    data-e2e={orderType === BrokerageOrderType.DEPOSIT ? 'submitDepositAmount' : 'withdrawNext'}
+    height='48px'
+    size='16px'
+    nature='primary'
+    type='submit'
+    fullwidth
+    disabled={invalid || pristine || submitting || !paymentAccount}
+    onClick={() => {}}
+  >
+    {submitting ? (
+      <HeartbeatLoader height='16px' width='16px' color='white' />
+    ) : (
+      <FormattedMessage
+        id='buttons.preview_buysell'
+        defaultMessage='Preview {orderType}'
+        values={{ orderType: orderType === BrokerageOrderType.DEPOSIT ? 'Deposit' : 'Withdrawal' }}
+      />
+    )}
+  </Button>
+)
 
 const EnterAmount = ({
   crossBorderLimits,
@@ -461,7 +463,7 @@ const EnterAmount = ({
             paymentMethod={paymentMethod}
           />
           {!showError && (
-            <NextButton
+            <PreviewButton
               paymentAccount={paymentAccount}
               invalid={invalid}
               orderType={orderType}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
@@ -201,17 +201,6 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
     props.buySellActions.cancelOrder(props.order)
   }
 
-  const paymentPartnerButton =
-    paymentPartner === BankPartners.YAPILY ? (
-      <FormattedMessage id='copy.next' defaultMessage='Next' />
-    ) : (
-      <FormattedMessage
-        id='buttons.buy_sell_now'
-        defaultMessage='{orderType} Now'
-        values={{ orderType: orderType === OrderType.BUY ? 'Buy' : 'Sell' }}
-      />
-    )
-
   return (
     <CustomForm onSubmit={props.handleSubmit}>
       <FlyoutWrapper>
@@ -529,7 +518,11 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
             {props.submitting ? (
               <HeartbeatLoader height='16px' width='16px' color='white' />
             ) : (
-              paymentPartnerButton
+              <FormattedMessage
+                id='buttons.buy_sell_now'
+                defaultMessage='{orderType} Now'
+                values={{ orderType: orderType === OrderType.BUY ? 'Buy' : 'Sell' }}
+              />
             )}
           </Button>
 


### PR DESCRIPTION
## Description (optional)
Change CTA buttons: Buy Now/ Withdraw Now
<img width="541" alt="Screen Shot 2022-03-24 at 2 19 58 PM" src="https://user-images.githubusercontent.com/39777266/159984394-5dac3de7-8915-4f82-bdce-8a4cb58d94fa.png">


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

