### PR TITLE
FWN-1370 instrument maintenance errors on segment

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/index.js
@@ -6,6 +6,8 @@ import ReactDOM from 'react-dom'
 import { BrowserRouter } from 'react-router-dom'
 import styled from 'styled-components'
 
+import { analyticsTrackingNoStore } from 'utils/helpers'
+
 import {
   FontGlobalStyles,
   IconGlobalStyles,
@@ -81,5 +83,29 @@ configureStore()
       </ErrorWrapper>,
       document.getElementById('app')
     )
+    const getErrorMessage = (errorMsg) => {
+      const WALLET_OPTIONS_ERROR = 'SyntaxError: Unexpected token < in JSON at position 0'
+      const WALLET_CURRENCIES_ERROR =
+        "TypeError: Cannot read properties of undefined (reading 'reduce')"
+
+      if (errorMsg === WALLET_OPTIONS_ERROR) {
+        return `wallet-options failed to load. ${errorMsg}`
+      }
+      if (errorMsg === WALLET_CURRENCIES_ERROR) {
+        return `currencies assets failed to load. ${errorMsg}`
+      }
+    }
+    const data = {
+      events: [
+        {
+          name: 'Wallet Load Failure',
+          originalTimestamp: new Date(),
+          properties: {
+            error_message: getErrorMessage(e.toString())
+          }
+        }
+      ]
+    }
+    analyticsTrackingNoStore(data)
     console.error(e)
   })

--- a/packages/blockchain-wallet-v4-frontend/src/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/index.js
@@ -81,6 +81,5 @@ configureStore()
       </ErrorWrapper>,
       document.getElementById('app')
     )
-    // eslint-disable-next-line no-console
-    console.info(e)
+    console.error(e)
   })

--- a/packages/blockchain-wallet-v4-frontend/src/utils/helpers.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/utils/helpers.ts
@@ -1,5 +1,7 @@
 import { prop } from 'ramda'
 
+import { UTM } from 'middleware/analyticsMiddleware/constants'
+
 export const debounce = (func, wait) => {
   let timeout
   return (...args) => {
@@ -72,5 +74,33 @@ export const toBase64 = (file: File): Promise<string> => {
     // @ts-ignore
     reader.onload = () => resolve(reader?.result?.toString())
     reader.onerror = (error) => reject(error)
+  })
+}
+
+/*
+  Analytics usage without redux store coupling.
+*/
+export const analyticsTrackingNoStore = async (data) => {
+  const res = await fetch('/wallet-options-v4.json')
+  const options = await res.json()
+  const analyticsURL = `${options.domains.api}/events/publish`
+  const rawCampaign = sessionStorage.getItem(UTM)
+  const campaign = rawCampaign ? JSON.parse(rawCampaign) : {}
+
+  await fetch(analyticsURL, {
+    body: JSON.stringify({
+      context: campaign,
+      device: 'WEB',
+      events: [],
+      platform: 'WALLET',
+      // Just pass in a data object to re-write
+      // any of the body params
+      ...data
+    }),
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    method: 'POST'
   })
 }


### PR DESCRIPTION
## Description (optional)
I had to add a manual call to the `/event/publish` endpoint for tracking events on segment as the issue that happened was redux store not being instanced. Without that regular library for using segment wouldn't work as the library is coupled to the store.

## Testing Steps (optional)
To test this fix the user needs to check Segment debug page in the right env that the crash occurs.

The user should be able to see something like the following

### Wallet Options not loading
![image](https://user-images.githubusercontent.com/97299628/160179942-84a6c0ef-98b5-44ea-b90a-f420a40d92fc.png)

### Wallet currencies not loading
![image](https://user-images.githubusercontent.com/97299628/160180096-41b29569-c9ce-4afd-a7d3-f0753d270e1d.png)

