### PR TITLE
fix(verify-device): verify device link should just approve, login con…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.utils.ts
@@ -83,14 +83,15 @@ export const determineAuthenticationFlow = function* (skipSessionCheck?: boolean
       case productAuthenticatingInto === ProductAuthOptions.EXCHANGE:
         // determine if we need to verify the login attempt from another device or
         // continue login from the same device
-        if (currentLoginSession !== authMagicLink.session_id && !skipSessionCheck) {
+        if (!skipSessionCheck) {
           // EXCHANGE DEVICE VERIFICATION
           // Exchange only logins don't require any challenges and passing
           // `true` means we can confirm device verification right away
           yield put(actions.auth.authorizeVerifyDevice(true))
           yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.VERIFY_MAGIC_LINK))
-        } else {
-          // EXCHANGE AUTHENTICATION
+        }
+        if (skipSessionCheck) {
+          // This is the tab that is polling for wallet data
           // set state with all exchange login information
           yield put(actions.cache.exchangeEmail(exchangeData?.email))
           yield put(actions.form.change(LOGIN_FORM, 'exchangeEmail', exchangeData?.email))
@@ -109,30 +110,37 @@ export const determineAuthenticationFlow = function* (skipSessionCheck?: boolean
         }
         break
       // WALLET DEVICE VERIFICATION
-      case productAuthenticatingInto === ProductAuthOptions.WALLET &&
-        currentLoginSession !== authMagicLink.session_id:
-        yield put(actions.auth.authorizeVerifyDevice(undefined))
-        yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.VERIFY_MAGIC_LINK))
+      case productAuthenticatingInto === ProductAuthOptions.WALLET:
+        if (
+          currentLoginSession !== authMagicLink.session_id ||
+          (currentLoginSession === authMagicLink.session_id && !skipSessionCheck)
+        ) {
+          yield put(actions.auth.authorizeVerifyDevice(undefined))
+          yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.VERIFY_MAGIC_LINK))
+        }
+        if (currentLoginSession === authMagicLink.session_id && skipSessionCheck) {
+          // grab all the data from the JSON wallet data
+          // store data in the cache and update form values to be used to submit login
+          yield put(actions.cache.emailStored(walletData?.email))
+          yield put(actions.cache.guidStored(walletData?.guid))
+          yield put(actions.cache.mobileConnectedStored(walletData?.is_mobile_setup))
+          yield put(actions.cache.hasCloudBackup(walletData?.has_cloud_backup))
+          yield put(actions.form.change(LOGIN_FORM, 'emailToken', walletData?.email_code))
+          yield put(actions.form.change(LOGIN_FORM, 'guid', walletData?.guid))
+          yield put(actions.form.change(LOGIN_FORM, 'email', walletData?.email))
+          yield put(actions.auth.setMagicLinkInfo(authMagicLink))
+          yield put(
+            actions.auth.setProductAuthMetadata({
+              platform: PlatformTypes.WEB, // TODO: probably dont hardcode the platform
+              product: ProductAuthOptions.WALLET
+            })
+          )
+          yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.ENTER_PASSWORD_WALLET))
+        }
         break
-      // WALLET AUTHENTICATION FLOW
+      // Default to send user back to enter email screen
       default:
-        // grab all the data from the JSON wallet data
-        // store data in the cache and update form values to be used to submit login
-        yield put(actions.cache.emailStored(walletData?.email))
-        yield put(actions.cache.guidStored(walletData?.guid))
-        yield put(actions.cache.mobileConnectedStored(walletData?.is_mobile_setup))
-        yield put(actions.cache.hasCloudBackup(walletData?.has_cloud_backup))
-        yield put(actions.form.change(LOGIN_FORM, 'emailToken', walletData?.email_code))
-        yield put(actions.form.change(LOGIN_FORM, 'guid', walletData?.guid))
-        yield put(actions.form.change(LOGIN_FORM, 'email', walletData?.email))
-        yield put(actions.auth.setMagicLinkInfo(authMagicLink))
-        yield put(
-          actions.auth.setProductAuthMetadata({
-            platform: PlatformTypes.WEB, // TODO: probably dont hardcode the platform
-            product: ProductAuthOptions.WALLET
-          })
-        )
-        yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.ENTER_PASSWORD_WALLET))
+        yield put(actions.form.change(LOGIN_FORM, 'step', LoginSteps.ENTER_EMAIL_GUID))
         break
     }
     yield put(actions.auth.analyticsMagicLinkParsed())


### PR DESCRIPTION
…tinues from original tab

[This commit](https://github.com/blockchain/blockchain-wallet-v4-frontend/commit/a82343c3ba9258675478dc3aa056dd32d909e2cb) with these changes were overwritten, maybe during merging? 

Verify device link should always open a separate 'approve' window, even if email link is opened in same browser. Should prevent any redux store cache issues.
## Description (optional)
Add a concise explanation of the changes.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

