### PR TITLE
fix(BuySell): format order fee using the input currency

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
@@ -387,8 +387,8 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
                     ? displayFiat(props.order, props.order.fee)
                     : props.order.fee && props.formValues?.fix === 'CRYPTO'
                     ? coinToString({
-                        unit: { symbol: props.order.outputCurrency },
-                        value: convertBaseToStandard(props.order.outputCurrency, props.order.fee)
+                        unit: { symbol: props.order.inputCurrency },
+                        value: convertBaseToStandard(props.order.inputCurrency, props.order.fee)
                       })
                     : `${displayFiat(props.order, props.quote.fee)} ${props.order.inputCurrency}`}
                 </RowText>


### PR DESCRIPTION
## Testing Steps
* Open Buy flyout
* select some value in the payment method currency
* Click preview
* the fee should be formatted with the payment method currency format
* go back
* change payment method to coin
* click preview
* The fee format should not have changed

<img width="494" alt="Screen Shot 2022-03-31 at 5 52 11 PM" src="https://user-images.githubusercontent.com/99212903/161147597-54dd23b7-4cee-47b7-9dc8-9fc9ed909a53.png">


