### PR TITLE
fix(cache): set exchange email on device verification

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -835,7 +835,7 @@ export default ({ api, coreSagas, networks }) => {
   const authorizeVerifyDevice = function* (action) {
     const confirmDevice = action.payload
     const magicLinkDataEncoded = yield select(selectors.auth.getMagicLinkDataEncoded)
-    const { product, session_id, wallet } = yield select(selectors.auth.getMagicLinkData)
+    const { exchange, product, session_id, wallet } = yield select(selectors.auth.getMagicLinkData)
     const exchange_only_login = product === ProductAuthOptions.EXCHANGE || !wallet
 
     try {
@@ -850,6 +850,9 @@ export default ({ api, coreSagas, networks }) => {
       )
       if (data.success) {
         yield put(actions.auth.authorizeVerifyDeviceSuccess({ deviceAuthorized: true }))
+        if (product === ProductAuthOptions.EXCHANGE) {
+          yield put(actions.cache.exchangeEmail(exchange?.email))
+        }
         yield put(actions.auth.analyticsAuthorizeVerifyDeviceSuccess())
       }
       // @ts-ignore


### PR DESCRIPTION
## Description (optional)
Explicitly caches exchange email when user opens 'verify your device' email link.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

