### PR TITLE
feat(wallet): adding behavior to checkout warning buttons

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/EnterAmount.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/EnterAmount.tsx
@@ -242,7 +242,6 @@ const debounceValidate = (
     if (limitError) {
       dispatch(stopAsyncValidation('brokerageTx', limitError))
     }
-    return
 
     const error = minMaxAmount(limits, orderType, fiatCurrency, newValue, bankText, formActions)
     if (error) {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/EnterAmount.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/EnterAmount.tsx
@@ -220,7 +220,15 @@ const LimitSection = ({ fee = '0', fiatCurrency, limitAmount, orderType }: Limit
 // to type without running validation on every keystroke. It waits 750 ms after
 // the user has stopped typing to run validation and manually dispatches the error
 // if needed. This makes for a nice error UX when typing
-const debounceValidate = (limits, crossBorderLimits, orderType, fiatCurrency, bankText, dispatch) =>
+const debounceValidate = (
+  limits,
+  crossBorderLimits,
+  orderType,
+  fiatCurrency,
+  bankText,
+  formActions,
+  dispatch
+) =>
   debounce((event, newValue) => {
     // check cross border limits
     const limitError = checkCrossBorderLimit(
@@ -228,13 +236,15 @@ const debounceValidate = (limits, crossBorderLimits, orderType, fiatCurrency, ba
       newValue,
       orderType,
       fiatCurrency,
-      bankText
+      bankText,
+      formActions
     )
     if (limitError) {
       dispatch(stopAsyncValidation('brokerageTx', limitError))
     }
+    return
 
-    const error = minMaxAmount(limits, orderType, fiatCurrency, newValue, bankText)
+    const error = minMaxAmount(limits, orderType, fiatCurrency, newValue, bankText, formActions)
     if (error) {
       dispatch(stopAsyncValidation('brokerageTx', error))
     }
@@ -244,6 +254,7 @@ type AmountProps = {
   bankText: string
   crossBorderLimits: Props['crossBorderLimits']
   fiatCurrency: Props['fiatCurrency']
+  formActions: typeof actions.form
   limits: Props['paymentMethod']['limits']
   orderType: Props['orderType']
   showError: boolean
@@ -307,6 +318,7 @@ const Amount = memoizer((props: AmountProps) => {
             props.orderType,
             props.fiatCurrency,
             props.bankText,
+            props.formActions,
             dispatch
           )}
           normalize={normalizeAmount}
@@ -435,6 +447,7 @@ const EnterAmount = ({
               orderType={orderType}
               crossBorderLimits={crossBorderLimits}
               showError={showError}
+              formActions={formActions}
               bankText={
                 orderType === BrokerageOrderType.DEPOSIT ? renderBankFullName(paymentAccount) : ''
               }

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/validation.tsx
@@ -14,7 +14,8 @@ export const minMaxAmount = (
   orderType: BrokerageOrderType,
   fiatCurrency: FiatType,
   amount: string,
-  bankText: string
+  bankText: string,
+  formActions
 ) => {
   const max = convertBaseToStandard('FIAT', limits.max)
   const min = convertBaseToStandard('FIAT', limits.min)
@@ -40,7 +41,11 @@ export const minMaxAmount = (
     return {
       amount: (
         <>
-          <AlertButton>
+          <AlertButton
+            onClick={() => {
+              formActions.change('brokerageTx', 'amount', max)
+            }}
+          >
             {orderType === BrokerageOrderType.DEPOSIT ? (
               <FormattedMessage
                 id='copy.above_max'
@@ -103,7 +108,11 @@ export const minMaxAmount = (
     return {
       amount: (
         <>
-          <AlertButton>
+          <AlertButton
+            onClick={() => {
+              formActions.change('brokerageTx', 'amount', min)
+            }}
+          >
             <FormattedMessage
               id='copy.below_min'
               defaultMessage='{amount} Minimum'
@@ -133,7 +142,8 @@ export const checkCrossBorderLimit = (
   amount: string,
   orderType: BrokerageOrderType,
   fiatCurrency: FiatType,
-  bankText: string
+  bankText: string,
+  formActions
 ) => {
   if (!crossBorderLimits?.current) {
     return false
@@ -153,7 +163,11 @@ export const checkCrossBorderLimit = (
     return {
       amount: (
         <>
-          <AlertButton>
+          <AlertButton
+            onClick={() => {
+              formActions.change('brokerageTx', 'amount', effectiveLimit?.limit.value.toString())
+            }}
+          >
             <FormattedMessage id='copy.over_your_limit' defaultMessage='Over Your Limit' />
           </AlertButton>
           <Text

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/validation.tsx
@@ -5,6 +5,7 @@ import { AlertButton } from 'blockchain-wallet-v4-frontend/src/modals/components
 import { fiatToString } from '@core/exchange/utils'
 import { CrossBorderLimits, FiatType } from '@core/types'
 import { Text } from 'blockchain-info-components'
+import { BROKERAGE_FORM } from 'data/components/brokerage/model'
 import { convertBaseToStandard } from 'data/components/exchange/services'
 import { BrokerageOrderType } from 'data/types'
 import { getEffectiveLimit, getEffectivePeriod } from 'services/custodial'
@@ -43,7 +44,7 @@ export const minMaxAmount = (
         <>
           <AlertButton
             onClick={() => {
-              formActions.change('brokerageTx', 'amount', max)
+              formActions.change(BROKERAGE_FORM, 'amount', max)
             }}
           >
             {orderType === BrokerageOrderType.DEPOSIT ? (
@@ -110,7 +111,7 @@ export const minMaxAmount = (
         <>
           <AlertButton
             onClick={() => {
-              formActions.change('brokerageTx', 'amount', min)
+              formActions.change(BROKERAGE_FORM, 'amount', min)
             }}
           >
             <FormattedMessage
@@ -165,7 +166,7 @@ export const checkCrossBorderLimit = (
         <>
           <AlertButton
             onClick={() => {
-              formActions.change('brokerageTx', 'amount', effectiveLimit?.limit.value.toString())
+              formActions.change(BROKERAGE_FORM, 'amount', effectiveLimit?.limit.value.toString())
             }}
           >
             <FormattedMessage id='copy.over_your_limit' defaultMessage='Over Your Limit' />

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/model.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/model.ts
@@ -9,3 +9,5 @@ export const POLLING = {
   RETRY_AMOUNT: 30,
   SECONDS: 10
 }
+
+export const BROKERAGE_FORM = 'brokerageTx'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/template.success.tsx
@@ -324,6 +324,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
       }
     }
   }
+
   const handleMaxClick = () => {
     const maxMin: string = getMaxMin(
       'max',
@@ -341,6 +342,14 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
       props.limits
     )[fix]
     const value = convertStandardToBase(conversionCoinType, maxMin)
+    if (props.orderType === OrderType.SELL) {
+      props.buySellActions.handleSellMaxAmountClick({ amount: value, coin: conversionCoinType })
+    } else if (props.orderType === OrderType.BUY) {
+      props.buySellActions.handleBuyMaxAmountClick({ amount: value, coin: conversionCoinType })
+    }
+  }
+
+  const handleCustomMinMaxClick = (value) => {
     if (props.orderType === OrderType.SELL) {
       props.buySellActions.handleSellMaxAmountClick({ amount: value, coin: conversionCoinType })
     } else if (props.orderType === OrderType.BUY) {
@@ -653,7 +662,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
             <ButtonContainer>
               {props.orderType === OrderType.BUY ? (
                 amtError === 'BELOW_MIN' ? (
-                  <AlertButton>
+                  <AlertButton onClick={handleMinMaxClick}>
                     <FormattedMessage
                       id='copy.below_min'
                       defaultMessage='{amount} Minimum'
@@ -667,11 +676,11 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                   </AlertButton>
                 ) : amtError === 'ABOVE_LIMIT' ||
                   (amtError === 'ABOVE_BALANCE' && !isFundsMethod) ? (
-                  <AlertButton>
+                  <AlertButton onClick={handleMaxClick}>
                     <FormattedMessage id='copy.over_your_limit' defaultMessage='Over Your Limit' />
                   </AlertButton>
                 ) : amtError === 'ABOVE_BALANCE' && isFundsMethod ? (
-                  <AlertButton>
+                  <AlertButton onClick={handleMaxClick}>
                     <FormattedMessage
                       id='copy.not_enough_coin'
                       defaultMessage='Not Enough {coin}'
@@ -681,7 +690,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                     />
                   </AlertButton>
                 ) : (
-                  <AlertButton>
+                  <AlertButton onClick={handleMaxClick}>
                     <FormattedMessage
                       id='copy.above_max'
                       defaultMessage='{amount} Maximum'
@@ -696,17 +705,28 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                 )
               ) : null}
 
-              {props.orderType === OrderType.SELL && (
-                <AlertButton>
-                  <FormattedMessage
-                    id='copy.not_enough_coin'
-                    defaultMessage='Not Enough {coin}'
-                    values={{
-                      coin: cryptoCurrency
-                    }}
-                  />
-                </AlertButton>
-              )}
+              {props.orderType === OrderType.SELL &&
+                (amtError === 'BELOW_MIN' ? (
+                  <AlertButton onClick={handleMinMaxClick}>
+                    <FormattedMessage
+                      id='copy.below_min'
+                      defaultMessage='{amount} Minimum'
+                      values={{
+                        amount: `${getValue(min)} ${cryptoCurrency}`
+                      }}
+                    />
+                  </AlertButton>
+                ) : (
+                  <AlertButton onClick={handleMaxClick}>
+                    <FormattedMessage
+                      id='copy.not_enough_coin'
+                      defaultMessage='Not Enough {coin}'
+                      values={{
+                        coin: cryptoCurrency
+                      }}
+                    />
+                  </AlertButton>
+                ))}
 
               <Text
                 size='14px'
@@ -821,7 +841,11 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
             effectiveLimit &&
             (props.orderType === OrderType.BUY ? (
               <>
-                <AlertButton>
+                <AlertButton
+                  onClick={() => {
+                    handleCustomMinMaxClick(effectiveLimit.limit.value.toString())
+                  }}
+                >
                   <FormattedMessage id='copy.over_your_limit' defaultMessage='Over Your Limit' />
                 </AlertButton>
                 <FormattedMessage
@@ -834,7 +858,11 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
               </>
             ) : (
               <>
-                <AlertButton>
+                <AlertButton
+                  onClick={() => {
+                    handleCustomMinMaxClick(effectiveLimit.limit.value.toString())
+                  }}
+                >
                   <FormattedMessage
                     id='copy.not_enough_coin'
                     defaultMessage='Not Enough {coin}'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/EnterAmount/Checkout/index.tsx
@@ -452,8 +452,8 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
 
         {!showLimitError && !showBalanceError && showError && (
           <ButtonContainer>
-            <AlertButton>
-              {amtError === 'BELOW_MIN' ? (
+            {amtError === 'BELOW_MIN' ? (
+              <AlertButton onClick={handleMinMaxClick}>
                 <FormattedMessage
                   id='copy.below_min'
                   defaultMessage='{amount} Minimum'
@@ -464,7 +464,9 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                         : `${min} ${baseCoinfig.displaySymbol}`
                   }}
                 />
-              ) : (
+              </AlertButton>
+            ) : (
+              <AlertButton onClick={handleMinMaxClick}>
                 <FormattedMessage
                   id='copy.above_max'
                   defaultMessage='{amount} Maximum'
@@ -475,8 +477,8 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                         : `${max} ${baseCoinfig.displaySymbol}`
                   }}
                 />
-              )}
-            </AlertButton>
+              </AlertButton>
+            )}
 
             <Text
               size='14px'
@@ -516,7 +518,16 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
 
         {showLimitError && effectiveLimit && (
           <>
-            <AlertButton>
+            <AlertButton
+              onClick={() => {
+                props.swapActions.handleSwapMinAmountClick({
+                  amount: convertBaseToStandard(
+                    'FIAT',
+                    crossBorderLimits.current?.available?.value || 0
+                  )
+                })
+              }}
+            >
               <FormattedMessage id='copy.over_your_limit' defaultMessage='Over Your Limit' />
             </AlertButton>
             <Text
@@ -543,7 +554,13 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
 
         {showBalanceError && !showLimitError && (
           <ButtonContainer>
-            <AlertButton>
+            <AlertButton
+              onClick={() =>
+                props.swapActions.handleSwapMinAmountClick({
+                  amount: fix === 'FIAT' ? fiatMax : max
+                })
+              }
+            >
               <FormattedMessage
                 id='copy.not_enough_coin'
                 defaultMessage='Not Enough {coin}'
@@ -565,7 +582,7 @@ const Checkout: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                   amount:
                     fix === 'FIAT'
                       ? fiatToString({ unit: walletCurrency, value: fiatMax })
-                      : `${min} ${baseCoinfig.displaySymbol}`,
+                      : `${max} ${baseCoinfig.displaySymbol}`,
                   coin: BASE.coin
                 }}
               />


### PR DESCRIPTION
## Description (optional)
Adding behavior to the warning buttons in the Buy, Sell, Swap, Deposit and Withdraw flows. If the user sees the minimum/maximum warning on the CTA button, they should be able to click on it and the amount will be populated in the amount field.
![159382207-259e61db-0e16-4ecc-bd96-e7f48ad5d9d0](https://user-images.githubusercontent.com/97241711/161329365-aa6c346e-9195-41d9-8b43-f8fdf5bd5846.gif)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

