### PR TITLE
feat(price chart): improvements on buy button in price chart component

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Actions/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Actions/template.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import styled from 'styled-components'
 
-import { CoinType } from '@core/types'
+import { OrderType } from '@core/types'
 import { Button, Text } from 'blockchain-info-components'
 import { media } from 'services/styles'
 
@@ -24,7 +24,7 @@ const BuyTradeButton = styled(Button)`
   }
 `
 
-const Actions = ({ buySellActions, coinName, swapActions }: Props) => {
+const Actions = ({ buySellActions, coinName, cryptoCurrency, swapActions }: Props) => {
   return (
     <Wrapper>
       <BuyTradeButton
@@ -33,7 +33,8 @@ const Actions = ({ buySellActions, coinName, swapActions }: Props) => {
         nature='primary'
         onClick={() =>
           buySellActions.showModal({
-            orderType: 'BUY',
+            cryptoCurrency,
+            orderType: OrderType.BUY,
             origin: 'PriceChart'
           })
         }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Actions/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Actions/template.tsx
@@ -33,7 +33,7 @@ const Actions = ({ buySellActions, coinName, cryptoCurrency, swapActions }: Prop
         nature='primary'
         onClick={() =>
           buySellActions.showModal({
-            cryptoCurrency,
+            cryptoCurrency: cryptoCurrency,
             orderType: OrderType.BUY,
             origin: 'PriceChart'
           })


### PR DESCRIPTION
## Description (optional)
The Buy button in the Price Chart component of the home page should go directly to the amount screen instead of the crypto selection screen in the modal.

![chrome-capture-2022-3-5](https://user-images.githubusercontent.com/97241711/161793554-755668fb-e92c-4e47-977d-3c6f9d5fc392.gif)


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

