### PR TITLE
feat(transactions): buy button improvement

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/index.tsx
@@ -186,6 +186,7 @@ class TransactionsContainer extends React.PureComponent<Props> {
                       width='100px'
                       onClick={() => {
                         this.props.buySellActions.showModal({
+                          cryptoCurrency: coin as CoinType,
                           orderType: OrderType.BUY,
                           origin: 'TransactionList'
                         })


### PR DESCRIPTION
## Description (optional)
The Buy button in the Transaction screen should go directly to the amount screen instead of the crypto selection screen in the modal.

![chrome-capture-2022-3-6](https://user-images.githubusercontent.com/97241711/161986406-e2e32304-a4d5-4083-b5a5-e5563f4c3bb3.gif)


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

