### PR TITLE
fix(resubmit): re-order switch case to prioritize resubmission banner

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
@@ -161,6 +161,8 @@ export const getData = (state: RootState): { bannerToShow: BannerType } => {
   let bannerToShow: BannerType = null
   if (showTaxCenterBanner && taxCenterEnabled) {
     bannerToShow = 'taxCenter'
+  } else if (showDocResubmitBanner && !isKycPendingOrVerified) {
+    bannerToShow = 'resubmit'
   } else if (
     showCompleteYourProfileBanner &&
     !isProfileCompleted &&
@@ -168,8 +170,6 @@ export const getData = (state: RootState): { bannerToShow: BannerType } => {
     isUserDataLoaded
   ) {
     bannerToShow = 'completeYourProfile'
-  } else if (showDocResubmitBanner && !isKycPendingOrVerified) {
-    bannerToShow = 'resubmit'
   } else if (isServicePriceUnavailable) {
     bannerToShow = 'servicePriceUnavailable'
   } else if (isKycStateNone && isUserActive && !isFirstLogin && !isTier3SDD) {


### PR DESCRIPTION
## Description (optional)
Put 'resubmission' banner ahead of 'complete your profile.' This is because if a user recover their account, they will have both a resubmission flag in `/users` and have a kyc state of none. If 'Complete Your Profile' is before 'Resubmission', they will see the incorrect banner and could be confusing. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

