### PR TITLE
fix(OrderSummary): remove ghost element above OK button

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
@@ -279,7 +279,6 @@ const OrderSummary: React.FC<Props> = ({
             height='48px'
             nature='primary'
             onClick={handleOkButton}
-            style={{ marginBottom: '16px' }}
           >
             <FormattedMessage id='buttons.ok' defaultMessage='OK' />
           </Button>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/index.tsx
@@ -174,11 +174,6 @@ class OrderSummaryContainer extends PureComponent<Props> {
             paymentType={order.paymentType}
             frequencyText={frequencyText}
           >
-            {getOrderType(order) === OrderType.BUY &&
-              (order.paymentType === BSPaymentTypes.PAYMENT_CARD ||
-                order.paymentType === BSPaymentTypes.USER_CARD ||
-                order.paymentType === BSPaymentTypes.BANK_TRANSFER ||
-                order.paymentType === BSPaymentTypes.FUNDS)}
             {val.interestAfterTransaction.show ? (
               <InterestBanner handleClose={this.props.handleClose} />
             ) : null}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/index.tsx
@@ -405,7 +405,7 @@ type LinkStatePropsType =
       step: 'LINKED_PAYMENT_ACCOUNTS'
     }
 
-type Props = OwnProps & LinkStatePropsType & ConnectedProps<typeof connector>
+type Props = OwnProps & LinkStatePropsType & ConnectedProps<typeof connector> & { children: never }
 type State = { show: boolean }
 
 export default enhance(BuySell)


### PR DESCRIPTION
## Description
This removes an empty box that shows up above the OK button in the Order Summary flyout

## Before
<img width="1728" alt="Screen Shot 2022-04-20 at 4 45 58 PM" src="https://user-images.githubusercontent.com/99212903/164311728-e6ef2dff-4086-4a07-86db-c08ddcd935e6.png">

## After
<img width="516" alt="Screen Shot 2022-04-20 at 4 38 45 PM" src="https://user-images.githubusercontent.com/99212903/164311770-7f90123f-5309-4363-a7cd-7dd2a2fa381b.png">

Fixes: https://blockchain.atlassian.net/browse/FWN-1225