### PR TITLE
EXIOS-1064 update association files to include alpha paths

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -55,19 +55,11 @@
       },
       {
         "appID": "NZ6PH75U7K.com.blockchain.exchangeapp",
-        "paths": ["/exchange*"]
+        "paths": ["NOT /exchange/alpha*", "/exchange*"]
       },
       {
         "appID": "NZ6PH75U7K.com.blockchain.exchangeapp.alpha",
-        "paths": ["/exchange*"]
-      },
-      {
-        "appID": "NZ6PH75U7K.com.blockchain.exchangeapp",
-        "paths": ["/exchange*"]
-      },
-      {
-        "appID": "NZ6PH75U7K.com.blockchain.exchangeapp.alpha",
-        "paths": ["/exchange*"]
+        "paths": ["/exchange/alpha*"]
       }
     ]
   },
@@ -80,8 +72,3 @@
     ]
   }
 }
-
-      "NZ6PH75U7K.com.rainydayapps.Blockchain",
-      "NZ6PH75U7K.com.rainydayapps.Blockchain.staging",
-      "NZ6PH75U7K.com.rainydayapps.Blockchain.dev",
-      "NZ6PH75U7K.com.rainydayapps.Blockchain.alpha"


### PR DESCRIPTION
## Description (optional)
Exclude /exchange/alpha* paths for prod

Also cleaned up what looked to be a bad merge.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

