### PR TITLE
fix: switching coin per displaySymbol to show pax and deso properly

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/DepositForm/template.success.tsx
@@ -324,7 +324,7 @@ const DepositForm: React.FC<InjectedFormProps<{ form: string }, Props> & Props> 
           <PrincipalCcyAbsolute>
             {displayCoin ? (
               <Text color='grey800' size='14px' weight={600}>
-                {coin}
+                {coinfig.displaySymbol}
               </Text>
             ) : (
               <Text color='grey800' size='14px' weight={600}>
@@ -437,7 +437,7 @@ const DepositForm: React.FC<InjectedFormProps<{ form: string }, Props> & Props> 
               <FormattedMessage
                 id='modals.interest.deposit.calcdesccoin'
                 defaultMessage='With {depositAmount} {coinTicker} in your Rewards Account you can earn:'
-                values={{ coinTicker: coin, depositAmount }}
+                values={{ coinTicker: coinfig.displaySymbol, depositAmount }}
               />
             ) : (
               <FormattedMessage


### PR DESCRIPTION
## Description (optional)

### PAX

![image](https://user-images.githubusercontent.com/97299628/165371110-b83dfd41-4654-4f0d-b8dd-b9c77f63e7bd.png)

### DeSo

![image](https://user-images.githubusercontent.com/97299628/165371191-8f4e9ad9-1001-49ac-8f3b-e224e3ae5ec7.png)

## Testing Steps (optional)

1. Enter the wallet.
2. Navigate to Rewards.
3. Search for DESO or PAX coins and hit “Earn Rewards”.
4. Click “Add DESO”.
5. Change the type of the unit (to DESO) under “Enter transfer amount”.

