### PR TITLE
EXAND-731 update asset links due to new signing keys

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -55,7 +55,7 @@
       "namespace": "android_app",
       "package_name": "com.blockchain.exchange",
       "sha256_cert_fingerprints":
-      ["23:FB:3D:61:B6:AF:B0:B9:4A:CD:8C:66:4E:35:F5:EB:66:68:F0:59:3D:29:69:9F:10:FB:CC:80:67:FD:E7:2D"]
+      ["8A:C7:6E:B4:9E:F7:C8:99:24:4A:E2:C5:42:47:CE:16:47:BD:34:5F:B6:DD:68:7A:C6:35:4E:D0:5A:14:F1:B6"]
     }
   },
   {
@@ -66,7 +66,7 @@
       "namespace": "android_app",
       "package_name": "com.blockchain.exchange.staging",
       "sha256_cert_fingerprints":
-      ["BD:F4:E9:C2:57:3F:06:27:C1:18:BF:18:EB:6A:29:72:E4:4D:D7:5D:D8:E8:03:71:E0:18:60:A8:18:8D:77:84"]
+      ["04:FE:E8:A3:63:24:B4:12:67:70:5B:D8:9D:E6:1B:DF:F6:9B:40:62:9A:0D:26:44:66:B5:4C:EB:81:40:56:9B"]
     }
   },
   {


### PR DESCRIPTION
## Description (optional)
We had to rotate our signing keys.  This enables deeplinks for the new keys.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

