### PR TITLE
fix(receive crypto): removes check for canDepositFiat when listing crypto accounts to receive

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/RequestCrypto/CoinSelect/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/RequestCrypto/CoinSelect/selectors.ts
@@ -49,9 +49,7 @@ export const getData = createDeepEqualSelector(
     } as ProductEligibilityForUser)
 
     const includeCustodialWallets =
-      products.custodialWallets?.enabled &&
-      products.custodialWallets?.canDepositFiat &&
-      products.custodialWallets?.canDepositCrypto
+      products.custodialWallets?.enabled && products.custodialWallets?.canDepositCrypto
 
     const showSilverRevamp = showSilverRevampR.getOrElse(false)
 


### PR DESCRIPTION
## Description (optional)
We're currently doing a check for `canDepositFiat === true` when displaying the list of crypto wallets a user can select to receive to. Fiat eligibility shouldn't have an affect receiving crypto wallets so i'm removing it.
![image](https://user-images.githubusercontent.com/57680122/165820035-89999d50-f80d-4a76-bcd2-1c72ec472987.png)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

