### PR TITLE
chore(@blockchain-com/icons): upgrade icons to v0.0.4

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/package.json
+++ b/packages/blockchain-wallet-v4-frontend/package.json
@@ -77,7 +77,7 @@
     "@babel/polyfill": "7.12.1",
     "@blockchain-com/components": "6.1.1",
     "@blockchain-com/constellation": "0.0.34",
-    "@blockchain-com/icons": "0.0.3",
+    "@blockchain-com/icons": "0.0.4",
     "@formatjs/intl-relativetimeformat": "7.2.10",
     "@graphql-codegen/cli": "2.5.0",
     "@reduxjs/toolkit": "1.6.0",

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/Trade.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/Trade.tsx
@@ -1,9 +1,16 @@
 import React, { ReactNode } from 'react'
 import { FormattedMessage } from 'react-intl'
-import { IconArrowDown, IconArrowUp, IconPlus, IconSwap } from '@blockchain-com/icons'
+import {
+  IconArrowDown,
+  IconArrowUp,
+  IconClose,
+  IconMinus,
+  IconPlus,
+  IconSwap
+} from '@blockchain-com/icons'
 import styled, { css } from 'styled-components'
 
-import { Icon, Text } from 'blockchain-info-components'
+import { Text } from 'blockchain-info-components'
 import { OptionRightActionRow } from 'components/Rows'
 
 const Column = styled.div`
@@ -28,6 +35,7 @@ const IconWrapper = styled.div`
   background-color: ${({ theme }) => theme.grey100};
   height: 32px;
   width: 32px;
+  cursor: pointer;
 `
 const ContentContainer = styled(Column)`
   display: flex;
@@ -69,7 +77,7 @@ const rows = ({
     header: <FormattedMessage id='buttons.buy' defaultMessage='Buy' />,
     icon: (
       <CustomIconWrapper>
-        <IconPlus style={{ fontSize: 18 }} />
+        <IconPlus fontSize={16} />
       </CustomIconWrapper>
     ),
     key: '0'
@@ -85,7 +93,7 @@ const rows = ({
     header: <FormattedMessage id='buttons.sell' defaultMessage='Sell' />,
     icon: (
       <CustomIconWrapper>
-        <Icon name='minus' color='blue600' size='20px' />
+        <IconMinus fontSize={12} />
       </CustomIconWrapper>
     ),
     key: '1'
@@ -101,7 +109,7 @@ const rows = ({
     header: <FormattedMessage id='buttons.swap' defaultMessage='Swap' />,
     icon: (
       <CustomIconWrapper>
-        <IconSwap fontSize={12} />
+        <IconSwap fontSize={16} />
       </CustomIconWrapper>
     ),
     key: '2'
@@ -154,7 +162,7 @@ const Trade = ({
         <FormattedMessage id='modals.trade.header' defaultMessage='Shortcuts' />
       </HeaderText>
       <IconWrapper onClick={handleClose}>
-        <Icon name='close' color='grey600' role='button' data-e2e='close' size='24px' cursor />
+        <IconClose />
       </IconWrapper>
 
       <ContentContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,10 +1732,10 @@
     "@radix-ui/react-tooltip" "0.1.3"
     stitches-nonce "1.2.7"
 
-"@blockchain-com/icons@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@blockchain-com/icons/-/icons-0.0.3.tgz#466c594087db28930c6823c063cf410cce578aa2"
-  integrity sha512-NyXBvBJ7b1f+Y/xA4wubLx/h/at6m/Pud3RWfRt5UBnxDgneE0Y27yDCU9nnIMR686YU5co2D8jZa1xeJt79cg==
+"@blockchain-com/icons@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@blockchain-com/icons/-/icons-0.0.4.tgz#fffc11c1b8a8feb668d9450c30c080b534d3ad7d"
+  integrity sha512-M8bXWNF2FBG2JZwvicL5NoAljLU1ITC3afnUD8bJZi8aEDMD43iIXP+ZGgFH6YP7chNb8kuIvMRHtjD8uey6OQ==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"


### PR DESCRIPTION
## Description
Upgrade @blokchain-com/icons@0.0.4

Before:
<img width="677" alt="Screen Shot 2022-04-29 at 9 28 07 AM" src="https://user-images.githubusercontent.com/99212903/165944293-10baa221-425f-43e8-b0fb-55534e8d0b76.png">


After:
<img width="611" alt="Screen Shot 2022-04-29 at 9 17 52 AM" src="https://user-images.githubusercontent.com/99212903/165943519-a7f29e83-2f01-460b-b007-49759aab47a7.png">



