### PR TITLE
fix: fixing checkbox tick color for using with dark mode theme

### DIFF
--- a/packages/blockchain-info-components/src/Form/CheckBoxInput.js
+++ b/packages/blockchain-info-components/src/Form/CheckBoxInput.js
@@ -55,7 +55,7 @@ const Label = styled.label`
     content: '\\e910';
     font-family: 'icomoon', sans-serif;
     position: absolute;
-    color: ${(props) => props.theme.white};
+    color: ${(props) => props.theme.alwaysWhite};
     font-weight: 600;
     font-size: 8px;
     left: 2px;


### PR DESCRIPTION
## Description (optional)
Using permanently the `alwaysWhite` color for the checkbox tick to avoid color change.

![kzDfkm3J7b](https://user-images.githubusercontent.com/97299628/167441352-72a27ded-5cff-4602-954f-bb9f1cb3734f.gif)

