### PR TITLE
fix(swap): fix padding issue with coin selection header

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Header.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Header.stories.tsx
@@ -40,3 +40,13 @@ export const HeaderWithChildren: Story<Props> = (args) => (
     />
   </Header>
 )
+
+export const StickyHeader: Story<Props> = (args) => (
+  <Header {...args} sticky onClick={action('back arrow clicked')}>
+    <FormattedMessage
+      id='modals.recurringbuys.get_started.buy_amount_of_currency'
+      defaultMessage='Buy {amount} of {currency}'
+      values={{ amount: '0.005', currency: 'BTC' }}
+    />
+  </Header>
+)

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Header.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Header.tsx
@@ -1,9 +1,9 @@
 import React, { memo } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Icon, Text } from 'blockchain-info-components'
 
-const Header = styled.div`
+const Header = styled.div<{ sticky: boolean }>`
   width: 100%;
   box-sizing: border-box;
   padding: 40px;
@@ -12,6 +12,14 @@ const Header = styled.div`
   @media (max-width: 767px) {
     padding: 20px;
   }
+
+  ${(p) =>
+    p.sticky &&
+    css`
+      position: sticky;
+      top: 0;
+      z-index: 99;
+    `}
 `
 const TopText = styled(Text)`
   display: flex;
@@ -26,7 +34,7 @@ const LeftTopCol = styled.div`
 const FlyoutHeader = memo(
   (props: Props) => {
     return (
-      <Header>
+      <Header sticky={props.sticky || false}>
         <TopText color='grey800' size='20px' weight={600}>
           <LeftTopCol>
             {props.mode === 'back' && (
@@ -46,7 +54,7 @@ const FlyoutHeader = memo(
           {props.mode === 'close' && (
             <Icon
               cursor
-              data-e2e='RecurringBuysCloseButton'
+              data-e2e='close'
               name='close'
               size='20px'
               color='grey600'
@@ -66,6 +74,7 @@ export type Props = {
   'data-e2e': string
   mode: 'close' | 'back'
   onClick: () => void
+  sticky?: true
 }
 
 export default FlyoutHeader

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/SubHeader.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/SubHeader.stories.tsx
@@ -5,6 +5,7 @@ import SubHeader from './SubHeader'
 export default {
   args: {
     'data-e2e': 'foooo',
+    sticky: true,
     subTitle: '$100',
     title: '10.0000 BTC'
   },

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/SubHeader.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/SubHeader.tsx
@@ -1,21 +1,29 @@
 import React, { memo } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Text } from 'blockchain-info-components'
 
-const SubHeaderContainer = styled.div`
+const SubHeaderContainer = styled.div<{ sticky: boolean }>`
   display: flex;
   flex-direction: column;
   padding: 0 40px 24px;
   > div {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
   }
+
+  ${(p) =>
+    p.sticky &&
+    css`
+      position: sticky;
+      top: 0;
+      z-index: 99;
+    `}
 `
 
 const SubHeader = (props: Props) => {
   return (
-    <SubHeaderContainer data-e2e={props['data-e2e']}>
+    <SubHeaderContainer data-e2e={props['data-e2e']} sticky={props.sticky || false}>
       <div>
         <Text size='32px' weight={600} color='grey800'>
           {props.title}
@@ -32,6 +40,7 @@ const SubHeader = (props: Props) => {
 
 export type Props = {
   'data-e2e': string
+  sticky?: true
   subTitle: string | React.ReactNode
   title: string | React.ReactNode
 }

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/index.tsx
@@ -104,14 +104,6 @@ export const AmountFieldContainer = styled.div<{ isCrypto?: boolean }>`
   }
 `
 
-export const StickyHeaderWrapper = styled.div`
-  background-color: ${(props) => props.theme.white};
-  position: sticky;
-  top: 0;
-  z-index: 99;
-  padding: 40px;
-`
-
 class Flyout extends React.Component<Props> {
   shouldComponentUpdate = (nextProps) => !equals(this.props, nextProps)
 

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/index.tsx
@@ -109,6 +109,7 @@ export const StickyHeaderWrapper = styled.div`
   position: sticky;
   top: 0;
   z-index: 99;
+  padding: 40px;
 `
 
 class Flyout extends React.Component<Props> {

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/Buy/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/Buy/index.tsx
@@ -15,7 +15,7 @@ import { getEthBalances } from 'components/Balances/selectors'
 import CoinDisplay from 'components/Display/CoinDisplay'
 import FiatDisplay from 'components/Display/FiatDisplay'
 import { Flex } from 'components/Flex'
-import { StickyHeaderWrapper, Title } from 'components/Flyout'
+import { Title } from 'components/Flyout'
 import FlyoutHeader from 'components/Flyout/Header'
 import { Row, Value } from 'components/Flyout/model'
 import SelectBox from 'components/Form/SelectBox'
@@ -86,11 +86,9 @@ const Buy: React.FC<Props> = (props) => {
         NotAsked: () => null,
         Success: (val) => (
           <>
-            <StickyHeaderWrapper>
-              <FlyoutHeader data-e2e='wrapEthHeader' mode='back' onClick={() => close()}>
-                Buy
-              </FlyoutHeader>
-            </StickyHeaderWrapper>
+            <FlyoutHeader sticky data-e2e='wrapEthHeader' mode='back' onClick={() => close()}>
+              Buy
+            </FlyoutHeader>
             <div
               style={{
                 display: 'flex',

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MakeOffer/index.tsx
@@ -26,7 +26,7 @@ import {
 import { getEthBalances } from 'components/Balances/selectors'
 import CoinDisplay from 'components/Display/CoinDisplay'
 import FiatDisplay from 'components/Display/FiatDisplay'
-import { StickyHeaderWrapper, Title } from 'components/Flyout'
+import { Title } from 'components/Flyout'
 import FlyoutHeader from 'components/Flyout/Header'
 import { Row, Value } from 'components/Flyout/model'
 import AmountFieldInput from 'components/Form/AmountFieldInput'
@@ -142,11 +142,9 @@ const MakeOffer: React.FC<Props> = (props) => {
 
   return (
     <>
-      <StickyHeaderWrapper>
-        <FlyoutHeader data-e2e='wrapEthHeader' mode='back' onClick={() => close()}>
-          Make Offer
-        </FlyoutHeader>
-      </StickyHeaderWrapper>
+      <FlyoutHeader sticky data-e2e='wrapEthHeader' mode='back' onClick={() => close()}>
+        Make Offer
+      </FlyoutHeader>
       <div
         style={{
           display: 'flex',

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MarkForSale/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/MarkForSale/index.tsx
@@ -14,7 +14,7 @@ import { GasCalculationOperations } from '@core/network/api/nfts/types'
 import { getRatesSelector } from '@core/redux/data/misc/selectors'
 import { RatesType } from '@core/types'
 import { Button, HeartbeatLoader, Icon, Link, Text } from 'blockchain-info-components'
-import { StickyHeaderWrapper, Title } from 'components/Flyout'
+import { Title } from 'components/Flyout'
 import FlyoutHeader from 'components/Flyout/Header'
 import { Row, Value } from 'components/Flyout/model'
 import AmountFieldInput from 'components/Form/AmountFieldInput'
@@ -119,11 +119,9 @@ const MarkForSale: React.FC<Props> = (props) => {
         NotAsked: () => <NftFlyoutLoader />,
         Success: (val) => (
           <>
-            <StickyHeaderWrapper>
-              <FlyoutHeader data-e2e='wrapEthHeader' mode='back' onClick={() => close()}>
-                Sell Item
-              </FlyoutHeader>
-            </StickyHeaderWrapper>
+            <FlyoutHeader sticky data-e2e='wrapEthHeader' mode='back' onClick={() => close()}>
+              Sell Item
+            </FlyoutHeader>
             <AssetDesc>
               <img
                 style={{

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/Transfer/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Nfts/NftOrder/Transfer/index.tsx
@@ -7,7 +7,7 @@ import { Field, reduxForm } from 'redux-form'
 
 import { GasCalculationOperations } from '@core/network/api/nfts/types'
 import { Button, HeartbeatLoader, Text } from 'blockchain-info-components'
-import { StickyHeaderWrapper, Title } from 'components/Flyout'
+import { Title } from 'components/Flyout'
 import FlyoutHeader from 'components/Flyout/Header'
 import { Row, Value } from 'components/Flyout/model'
 import TextBox from 'components/Form/TextBox'
@@ -32,11 +32,9 @@ const Transfer: React.FC<Props> = (props) => {
         NotAsked: () => <NftFlyoutLoader />,
         Success: (val) => (
           <>
-            <StickyHeaderWrapper>
-              <FlyoutHeader data-e2e='wrapEthHeader' mode='back' onClick={() => close()}>
-                Transfer Item
-              </FlyoutHeader>
-            </StickyHeaderWrapper>
+            <FlyoutHeader sticky data-e2e='wrapEthHeader' mode='back' onClick={() => close()}>
+              Transfer Item
+            </FlyoutHeader>
             <Row>
               <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                 <div style={{ display: 'flex' }}>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/RequestCrypto/CoinSelect/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/RequestCrypto/CoinSelect/index.tsx
@@ -8,8 +8,12 @@ import { Field } from 'redux-form'
 import styled from 'styled-components'
 
 import { Icon, Text } from 'blockchain-info-components'
-import { FlyoutWrapper, StickyHeaderWrapper } from 'components/Flyout'
-import { StepHeader } from 'components/Flyout/SendRequestCrypto'
+import {
+  FlyoutContainer,
+  FlyoutContent,
+  FlyoutHeader,
+  FlyoutSubHeader
+} from 'components/Flyout/Layout'
 import CoinAccountListOption from 'components/Form/CoinAccountListOption'
 import TextBox from 'components/Form/TextBox'
 import { actions } from 'data'
@@ -20,17 +24,6 @@ import { REQUEST_FORM } from '../model'
 import { RequestSteps } from '../types'
 import { getData } from './selectors'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  .coin-account-option {
-    border-top: ${(props) => `1px solid ${props.theme.grey000}`};
-  }
-`
-const Header = styled(StepHeader)`
-  margin-bottom: 40px;
-`
 const HeaderContent = styled.div`
   position: relative;
 `
@@ -100,28 +93,22 @@ class RequestCoinSelect extends React.PureComponent<Props> {
     }
 
     return (
-      <Wrapper>
-        <StickyHeaderWrapper>
-          <FlyoutWrapper>
-            <Header spaceBetween>
-              <Icon name='arrow-bottom-right' color='blue600' size='24px' />
-              <Icon
-                name='close'
-                color='grey600'
-                role='button'
-                data-e2e='close'
-                size='24px'
-                cursor
-                onClick={handleClose}
+      <FlyoutContainer>
+        <FlyoutHeader onClick={handleClose} data-e2e='ReceiveCryptoFlyout' mode='close'>
+          <Icon name='arrow-bottom-right' color='blue600' size='24px' />
+        </FlyoutHeader>
+        <FlyoutSubHeader
+          data-e2e='receiveCryptoSubHeader'
+          title={
+            <Text size='24px' color='grey900' weight={600}>
+              <FormattedMessage
+                id='modals.requestcrypto.coinselect.title'
+                defaultMessage='Receive Crypto'
               />
-            </Header>
+            </Text>
+          }
+          subTitle={
             <HeaderContent>
-              <Text size='24px' color='grey900' weight={600}>
-                <FormattedMessage
-                  id='modals.requestcrypto.coinselect.title'
-                  defaultMessage='Receive Crypto'
-                />
-              </Text>
               <Text size='16px' color='grey600' weight={500}>
                 <FormattedMessage
                   id='modals.requestcrypto.coinselect.subtitle'
@@ -145,57 +132,59 @@ class RequestCoinSelect extends React.PureComponent<Props> {
                 </ResultsText>
               )}
             </HeaderContent>
-          </FlyoutWrapper>
-        </StickyHeaderWrapper>
-        {data.accounts.length ? (
-          <AutoSizer>
-            {({ height, width }) => (
-              <List
-                className='List'
-                height={height}
-                itemData={data.accounts}
-                itemCount={data.accounts.length}
-                itemSize={74}
-                width={width}
-              >
-                {Row}
-              </List>
-            )}
-          </AutoSizer>
-        ) : (
-          <NoAccounts
-            role='button'
-            onClick={() => {
-              formActions.change(REQUEST_FORM, 'selectedAccount', data.ethAccount)
-              formActions.change(REQUEST_FORM, 'step', RequestSteps.SHOW_ADDRESS)
-            }}
-          >
-            <div>
-              <PlusIconContainer>
-                <Icon name='plus-in-circle-filled' color='green600' size='24px' />
-              </PlusIconContainer>
+          }
+        />
+        <FlyoutContent mode='top'>
+          {data.accounts.length ? (
+            <AutoSizer>
+              {({ height, width }) => (
+                <List
+                  className='List'
+                  height={height}
+                  itemData={data.accounts}
+                  itemCount={data.accounts.length}
+                  itemSize={74}
+                  width={width}
+                >
+                  {Row}
+                </List>
+              )}
+            </AutoSizer>
+          ) : (
+            <NoAccounts
+              role='button'
+              onClick={() => {
+                formActions.change(REQUEST_FORM, 'selectedAccount', data.ethAccount)
+                formActions.change(REQUEST_FORM, 'step', RequestSteps.SHOW_ADDRESS)
+              }}
+            >
               <div>
-                <Text size='16px' color='grey900' weight={600}>
-                  <FormattedMessage
-                    id='copy.receive_any_erc20'
-                    defaultMessage='Receive Any Erc20 Token'
-                  />
-                </Text>
-                <Text size='14px' color='grey800' weight={500} style={{ marginTop: '2px' }}>
-                  <FormattedMessage
-                    id='copy.view_eth_addr'
-                    defaultMessage='View Your {eth} Address'
-                    values={{
-                      eth: ethCoinfig.name
-                    }}
-                  />
-                </Text>
+                <PlusIconContainer>
+                  <Icon name='plus-in-circle-filled' color='green600' size='24px' />
+                </PlusIconContainer>
+                <div>
+                  <Text size='16px' color='grey900' weight={600}>
+                    <FormattedMessage
+                      id='copy.receive_any_erc20'
+                      defaultMessage='Receive Any Erc20 Token'
+                    />
+                  </Text>
+                  <Text size='14px' color='grey800' weight={500} style={{ marginTop: '2px' }}>
+                    <FormattedMessage
+                      id='copy.view_eth_addr'
+                      defaultMessage='View Your {eth} Address'
+                      values={{
+                        eth: ethCoinfig.name
+                      }}
+                    />
+                  </Text>
+                </div>
               </div>
-            </div>
-            <Icon name='chevron-right' size='32px' color='grey400' />
-          </NoAccounts>
-        )}
-      </Wrapper>
+              <Icon name='chevron-right' size='32px' color='grey400' />
+            </NoAccounts>
+          )}
+        </FlyoutContent>
+      </FlyoutContainer>
     )
   }
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/SendCrypto/CoinSelect/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/SendCrypto/CoinSelect/index.tsx
@@ -7,8 +7,12 @@ import reduxForm, { InjectedFormProps } from 'redux-form/lib/reduxForm'
 import styled from 'styled-components'
 
 import { Icon, Text } from 'blockchain-info-components'
-import { FlyoutWrapper, StickyHeaderWrapper } from 'components/Flyout'
-import { StepHeader } from 'components/Flyout/SendRequestCrypto'
+import {
+  FlyoutContainer,
+  FlyoutContent,
+  FlyoutHeader,
+  FlyoutSubHeader
+} from 'components/Flyout/Layout'
 import CoinAccountListOption from 'components/Form/CoinAccountListOption'
 import SelectBoxCoin from 'components/Form/SelectBoxCoin'
 import { actions } from 'data'
@@ -18,13 +22,6 @@ import { Props as OwnProps } from '..'
 import { SEND_FORM } from '../model'
 import { getData } from './selectors'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-`
-const Header = styled(StepHeader)`
-  margin-bottom: 40px;
-`
 const SelectCoinWrapper = styled.div`
   margin-top: 24px;
   width: 40%;
@@ -40,28 +37,22 @@ class SendCoinSelect extends React.PureComponent<InjectedFormProps<{}, Props> & 
     const { close, data, formActions, sendCryptoActions, walletCurrency } = this.props
 
     return (
-      <Wrapper>
-        <StickyHeaderWrapper>
-          <FlyoutWrapper>
-            <Header spaceBetween>
-              <Icon name='arrow-top-right' color='blue600' size='48px' />
-              <Icon
-                name='close'
-                color='grey600'
-                role='button'
-                data-e2e='close'
-                size='24px'
-                cursor
-                onClick={close}
+      <FlyoutContainer>
+        <FlyoutHeader onClick={close} data-e2e='SendCryptoFlyout' mode='close'>
+          <Icon name='arrow-top-right' color='blue600' size='48px' />
+        </FlyoutHeader>
+        <FlyoutSubHeader
+          data-e2e='sendCryptoSubHeader'
+          title={
+            <Text size='24px' color='grey900' weight={600}>
+              <FormattedMessage
+                id='modals.sendcrypto.coinselect.title'
+                defaultMessage='Send Crypto'
               />
-            </Header>
-            <div>
-              <Text size='24px' color='grey900' weight={600}>
-                <FormattedMessage
-                  id='modals.sendcrypto.coinselect.title'
-                  defaultMessage='Send Crypto'
-                />
-              </Text>
+            </Text>
+          }
+          subTitle={
+            <>
               <Text size='16px' color='grey600' weight={500} style={{ marginTop: '10px' }}>
                 <FormattedMessage
                   id='modals.sendcrypto.coinselect.subtitle'
@@ -71,33 +62,35 @@ class SendCoinSelect extends React.PureComponent<InjectedFormProps<{}, Props> & 
               <SelectCoinWrapper>
                 <Field component={SelectBoxCoin} height='32px' name='coin' type='send' />
               </SelectCoinWrapper>
-            </div>
-          </FlyoutWrapper>
-        </StickyHeaderWrapper>
-        {data.accounts.map((account) => (
-          <CoinAccountListOption
-            key={account.coin + account.address}
-            account={account}
-            coin={account.coin}
-            onClick={() => {
-              formActions.change(SEND_FORM, 'selectedAccount', account)
-              sendCryptoActions.setStep({ step: SendCryptoStepType.ENTER_TO })
-              sendCryptoActions.fetchSendLimits({ account })
-            }}
-            walletCurrency={walletCurrency}
-          />
-        ))}
-        {data.accounts.length === 0 && (
-          <NoAccountsText>
-            <Text size='16px' color='grey900' weight={500} style={{ marginTop: '10px' }}>
-              <FormattedMessage
-                id='modals.sendcrypto.coinselect.noaccounts'
-                defaultMessage='Currently there are no accounts for the selected crypto.'
-              />
-            </Text>
-          </NoAccountsText>
-        )}
-      </Wrapper>
+            </>
+          }
+        />
+        <FlyoutContent mode='top'>
+          {data.accounts.map((account) => (
+            <CoinAccountListOption
+              key={account.coin + account.address}
+              account={account}
+              coin={account.coin}
+              onClick={() => {
+                formActions.change(SEND_FORM, 'selectedAccount', account)
+                sendCryptoActions.setStep({ step: SendCryptoStepType.ENTER_TO })
+                sendCryptoActions.fetchSendLimits({ account })
+              }}
+              walletCurrency={walletCurrency}
+            />
+          ))}
+          {data.accounts.length === 0 && (
+            <NoAccountsText>
+              <Text size='16px' color='grey900' weight={500} style={{ marginTop: '10px' }}>
+                <FormattedMessage
+                  id='modals.sendcrypto.coinselect.noaccounts'
+                  defaultMessage='Currently there are no accounts for the selected crypto.'
+                />
+              </Text>
+            </NoAccountsText>
+          )}
+        </FlyoutContent>
+      </FlyoutContainer>
     )
   }
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Swap/CoinSelection/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Swap/CoinSelection/index.tsx
@@ -5,8 +5,13 @@ import AutoSizer from 'react-virtualized-auto-sizer'
 import { FixedSizeList as List } from 'react-window'
 import { equals } from 'ramda'
 
-import { Icon, Text } from 'blockchain-info-components'
-import { StickyHeaderWrapper } from 'components/Flyout'
+import { Text } from 'blockchain-info-components'
+import {
+  FlyoutContainer,
+  FlyoutContent,
+  FlyoutHeader,
+  FlyoutSubHeader
+} from 'components/Flyout/Layout'
 import CoinAccountListOption from 'components/Form/CoinAccountListOption'
 import { selectors } from 'data'
 import { InitSwapFormValuesType, SwapSideType } from 'data/components/swap/types'
@@ -14,7 +19,6 @@ import { RootState } from 'data/rootReducer'
 import { SwapAccountType } from 'data/types'
 
 import { Props as BaseProps, SuccessStateType } from '..'
-import { TopText } from '../components'
 import { getData } from './selectors'
 
 class CoinSelection extends PureComponent<Props> {
@@ -70,59 +74,60 @@ class CoinSelection extends PureComponent<Props> {
     }
 
     return (
-      <>
-        <StickyHeaderWrapper>
-          <TopText spaceBetween={false} marginBottom>
-            <Icon
-              role='button'
-              data-e2e='backToInitSwap'
-              name='arrow-back'
-              cursor
-              size='24px'
-              color='grey600'
-              onClick={() =>
-                this.props.swapActions.setStep({
-                  step: 'INIT_SWAP'
-                })
-              }
-            />{' '}
-            <Text size='20px' color='grey900' weight={600} style={{ marginLeft: '24px' }}>
+      <FlyoutContainer>
+        <FlyoutHeader
+          mode='back'
+          data-e2e='backToInitSwap'
+          onClick={() =>
+            this.props.swapActions.setStep({
+              step: 'INIT_SWAP'
+            })
+          }
+        />
+        <FlyoutSubHeader
+          data-e2e='sendReceiveSubHeader'
+          title={
+            <Text size='24px' color='grey900' weight={600}>
               {this.props.side === 'BASE' ? (
                 <FormattedMessage id='copy.swap_from' defaultMessage='Swap from' />
               ) : (
                 <FormattedMessage id='copy.receive_to' defaultMessage='Receive to' />
               )}
             </Text>
-          </TopText>
-          <Text size='16px' color='grey600' weight={500} style={{ margin: '10px 0 0 48px' }}>
-            {this.props.side === 'BASE' ? (
-              <FormattedMessage
-                id='copy.swap_from_origin'
-                defaultMessage='Which wallet do you want to Swap from?'
-              />
-            ) : (
-              <FormattedMessage
-                id='copy.swap_for_destination'
-                defaultMessage='Which crypto do you want to Swap for?'
-              />
+          }
+          subTitle={
+            <Text size='16px' color='grey600' weight={500} style={{ margin: '10px 0 0' }}>
+              {this.props.side === 'BASE' ? (
+                <FormattedMessage
+                  id='copy.swap_from_origin'
+                  defaultMessage='Which wallet do you want to Swap from?'
+                />
+              ) : (
+                <FormattedMessage
+                  id='copy.swap_for_destination'
+                  defaultMessage='Which crypto do you want to Swap for?'
+                />
+              )}
+            </Text>
+          }
+        />
+        <FlyoutContent mode='top'>
+          <AutoSizer>
+            {({ height, width }) => (
+              <List
+                className='List'
+                height={height}
+                itemData={filteredAccounts}
+                itemCount={filteredAccounts?.length}
+                itemSize={74}
+                width={width}
+              >
+                {Row}
+              </List>
             )}
-          </Text>
-        </StickyHeaderWrapper>
-        <AutoSizer>
-          {({ height, width }) => (
-            <List
-              className='List'
-              height={height}
-              itemData={filteredAccounts}
-              itemCount={filteredAccounts?.length}
-              itemSize={74}
-              width={width}
-            >
-              {Row}
-            </List>
-          )}
-        </AutoSizer>
-      </>
+          </AutoSizer>
+        </FlyoutContent>
+      </FlyoutContainer>
     )
   }
 }


### PR DESCRIPTION
## Description (optional)
from 
![image](https://user-images.githubusercontent.com/57680122/168124362-07edde6d-e890-4f6f-9dbf-7dc15f2f621e.png)
to this which is more inline with the "New Swap" layout on the previous step.
![image](https://user-images.githubusercontent.com/57680122/168152838-c2384d62-b8ec-4964-9565-7bc515ff9839.png)

I also removed the `StickyHeaderWrapper` component that was being used in several places and converted swap coin selection and send/receive coin selection screens to use the `/components/Flyout/Layout` components (Container, Header, SubHeader, Content) and added an optional `sticky` param to the header and sub header components if they're needed.


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

