### PR TITLE
fix(prices): pass correct options to date-fns sub function

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/index.tsx
@@ -8,15 +8,7 @@ import { reduxForm } from 'redux-form'
 import styled from 'styled-components'
 
 import { Exchange } from '@core'
-import {
-  CoinfigType,
-  CoinType,
-  FiatType,
-  OrderType,
-  TimeRange,
-  WalletCurrencyType,
-  WalletFiatType
-} from '@core/types'
+import { CoinType, FiatType, OrderType, TimeRange, WalletFiatType } from '@core/types'
 import { Button, Icon, Text } from 'blockchain-info-components'
 import { SavedRecurringBuy } from 'components/Box'
 import EmptyResults from 'components/EmptyResults'

--- a/packages/blockchain-wallet-v4/src/redux/data/misc/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/data/misc/sagas.ts
@@ -35,18 +35,18 @@ export default ({ api }: { api: APIType }) => {
       if (base in FiatTypeEnum) return
       yield put(A.fetchPriceChangeLoading(base, range))
 
-      const time =
+      const startTime =
         range === TimeRange.ALL
           ? getUnixTime(start[base] || 0)
-          : getTime(sub(new Date(), { [range]: 1 }))
+          : getTime(sub(new Date(), { [`${range}s`]: 1 }))
 
-      const previous: ReturnType<typeof api.getPriceIndex> = yield call(
+      const startData: ReturnType<typeof api.getPriceIndex> = yield call(
         api.getPriceIndex,
         base,
         quote,
-        time
+        startTime
       )
-      const current: ReturnType<typeof api.getPriceIndex> = yield call(
+      const currentData: ReturnType<typeof api.getPriceIndex> = yield call(
         api.getPriceIndex,
         base,
         quote,
@@ -54,18 +54,18 @@ export default ({ api }: { api: APIType }) => {
       )
 
       // Overall coin price movement
-      const overallChange = getPercentChange(current.price, previous.price)
+      const overallChange = getPercentChange(currentData.price, startData.price)
       // User's position, if given an amount will provide the
       // change for that amount or else will fallback to 0
-      const currentPosition = new BigNumber(positionAmt).times(current.price).toNumber()
-      const previousPosition = new BigNumber(positionAmt).times(previous.price).toNumber()
+      const currentPosition = new BigNumber(positionAmt).times(currentData.price).toNumber()
+      const previousPosition = new BigNumber(positionAmt).times(startData.price).toNumber()
       const positionChange = getPercentChange(currentPosition, previousPosition)
 
       yield put(
         A.fetchPriceChangeSuccess(
           base,
-          previous.price,
-          current.price,
+          startData.price,
+          currentData.price,
           range,
           overallChange,
           positionChange


### PR DESCRIPTION
## Description (optional)
the `sub` function of date-fns expects the options modifier to look as below.  [Adding an `s`](https://github.com/blockchain/blockchain-wallet-v4-frontend/pull/4774/files#diff-5f486d527b7b30cb5556590f7c7f42137890e717689c9b7260a77c45e0b13d7aR41) onto our `TimeRange` enums fixes the function call.

```
const result = sub(new Date(2017, 5, 15, 15, 29, 20), {
  years: 2,
  months: 9,
  weeks: 1,
  days: 7,
  hours: 5,
  minutes: 9,
  seconds: 30
})
```

