### PR TITLE
fix(recovery): skip email verification if metadata recovery

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmail/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmail/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { connect, ConnectedProps } from 'react-redux'
-import { is } from 'ramda'
 import { bindActionCreators } from 'redux'
 
 import { Remote } from '@core'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmail/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/VerifyEmail/template.tsx
@@ -21,7 +21,7 @@ const IconWrapper = styled.div`
   border-radius: 50%;
 `
 
-const VerifyEmail = ({ email, resendEmail }: Props) => {
+const VerifyEmail = ({ email, isMetadataRecovery, resendEmail, skipVerification }: Props) => {
   return (
     <>
       <Wrapper>
@@ -69,6 +69,21 @@ const VerifyEmail = ({ email, resendEmail }: Props) => {
               />
             </Text>
           </Button>
+          {isMetadataRecovery && (
+            <Link
+              onClick={skipVerification}
+              size='14px'
+              style={{ marginTop: '16px' }}
+              weight={600}
+              data-e2e='verifyEmailLater'
+              color='blue600'
+            >
+              <FormattedMessage
+                id='scenes.verifyemail.do_it_later'
+                defaultMessage='I’ll Do This Later.'
+              />
+            </Link>
+          )}
         </ContentWrapper>
       </Wrapper>
     </>
@@ -77,7 +92,9 @@ const VerifyEmail = ({ email, resendEmail }: Props) => {
 
 type Props = {
   email: string
+  isMetadataRecovery: boolean
   resendEmail: () => void
+  skipVerification: () => void
 }
 
 export default VerifyEmail


### PR DESCRIPTION
## Description (optional)
Fixes issue where there's no email address after metadata recovery, and user can't proceed to wallet after mnemonic recovery. 

https://www.loom.com/share/becd850128e640e1b80a27ad77ea6ba6

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

