### PR TITLE
feat(PricesPage): sort coins by market cap instead of price

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/prices/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/prices/sagas.ts
@@ -2,6 +2,7 @@ import { getUnixTime, subDays } from 'date-fns'
 import { call, put, select } from 'redux-saga/effects'
 
 import { APIType } from '@core/network/api'
+import { IndexMultiResponseType } from '@core/network/api/coin/types'
 import { selectors } from 'data'
 
 import { actions as A } from './slice'
@@ -23,7 +24,7 @@ export default ({ api }: { api: APIType }) => {
         base: coin,
         quote: fiatCurrency || defaultFiat
       }))
-      const data = yield call(api.getCoinPrices, request, timestamp)
+      const data: IndexMultiResponseType = yield call(api.getCoinPrices, request, timestamp)
       yield put(A.fetchCoinPricesSuccess(data))
     } catch (e) {
       yield put(A.fetchCoinPricesFailure(e.message))

--- a/packages/blockchain-wallet-v4-frontend/src/data/prices/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/prices/slice.ts
@@ -1,20 +1,22 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { keys, map, mergeAll } from 'ramda'
 
 import Remote from '@core/remote'
 
 import { CoinPricesRequestType, PricesStateType } from './types'
 
 const createPricesKvPairs = (prices) => {
-  return mergeAll(
-    map(
-      (x) => ({
-        // @ts-ignore
-        [x.split('-')[0]]: prices[x] ? prices[x].price : 0
-      }),
-      keys(prices)
-    )
-  )
+  return Object.keys(prices).reduce((pricesMap, priceKey) => {
+    const coinPrice = prices[priceKey]
+
+    if (!coinPrice) return pricesMap
+
+    const coinCode = priceKey.split('-')[0]
+
+    return {
+      ...pricesMap,
+      [coinCode]: coinPrice
+    }
+  }, {})
 }
 
 const initialState: PricesStateType = {

--- a/packages/blockchain-wallet-v4-frontend/src/data/prices/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/prices/types.ts
@@ -1,9 +1,25 @@
 import { CoinType, RemoteDataType, WalletFiatType } from '@core/types'
 
+type CoinPrice = {
+  marketCap: number
+  price: number
+  timestamp: number
+  volume24h: number
+}
 // TODO: type this!
 export type PricesStateType = {
-  current: RemoteDataType<any, any>
-  previousDay: RemoteDataType<any, any>
+  current: RemoteDataType<
+    any,
+    {
+      [key: string]: CoinPrice
+    }
+  >
+  previousDay: RemoteDataType<
+    any,
+    {
+      [key: string]: CoinPrice
+    }
+  >
 }
 
 export type CoinPricesRequestType = {

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/PriceMovement/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CryptoSelection/CryptoSelector/PriceMovement/selectors.ts
@@ -15,8 +15,8 @@ export const getData = createDeepEqualSelector(
       coinPrices: ExtractSuccess<typeof coinPricesR>,
       previousCoinPrices: ExtractSuccess<typeof coinPricesR>
     ) => {
-      const currentPrice = coinPrices[coin]
-      const yesterdayPrice = previousCoinPrices[coin]
+      const currentPrice = coinPrices[coin]?.price || 0
+      const yesterdayPrice = previousCoinPrices[coin]?.price || 0
       const priceChangeNum = Number(((currentPrice - yesterdayPrice) / yesterdayPrice) * 100)
       return Number.isNaN(priceChangeNum) ? '0' : priceChangeNum.toFixed(2)
     }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/custodial.column.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/custodial.column.tsx
@@ -1,0 +1,10 @@
+export const getCustodialColumn = () => ({
+  accessor: 'custodial',
+  id: 'custodial',
+  sortType: (a, b, id) => {
+    const isCustodialA = a.original[id]
+    const isCustodialB = b.original[id]
+
+    return isCustodialA === isCustodialB ? 0 : isCustodialA ? 1 : -1
+  }
+})

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/index.tsx
@@ -1,6 +1,8 @@
 import { TableColumnsType } from '..'
 import { getActionsColumn } from './actions.column'
 import { getBalanceColumn } from './balance.column'
+import { getCustodialColumn } from './custodial.column'
+import { getMarketCapColumn } from './marketCap.column'
 import { getNameColumn } from './name.column'
 import { getPriceColumn } from './price.column'
 import { getPriceChangeColumn } from './priceChange.column'
@@ -13,5 +15,7 @@ export const getTableColumns =
       getPriceColumn(walletCurrency),
       getPriceChangeColumn(),
       getBalanceColumn(),
-      getActionsColumn(modalActions, buySellActions, swapActions, formActions)
+      getActionsColumn(modalActions, buySellActions, swapActions, formActions),
+      getCustodialColumn(),
+      getMarketCapColumn()
     ]

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/marketCap.column.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/marketCap.column.ts
@@ -1,0 +1,4 @@
+export const getMarketCapColumn = () => ({
+  accessor: 'marketCap',
+  id: 'marketCap'
+})

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/priceChange.column.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/Table/priceChange.column.tsx
@@ -13,10 +13,7 @@ export const getPriceChangeColumn = () => ({
     </CellHeaderText>
   ),
   accessor: 'priceChange',
-
   disableGlobalFilter: true,
-  // sortType: 'basic',
-  // sortMethod: (a, b) => Number(a)-Number(b),
   sortType: (a, b, id) => {
     if (Number(a.original[id]) > Number(b.original[id])) return 1
     if (Number(b.original[id]) > Number(a.original[id])) return -1

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/selectors.ts
@@ -16,13 +16,17 @@ export const getData = createDeepEqualSelector(
       coinPrices: ExtractSuccess<typeof coinPricesR>,
       coinPricesPrevious: ExtractSuccess<typeof coinPricesPreviousR>
     ) => {
+      const custodialCoins = selectors.core.data.coins.getCustodialCoins()
       const cryptos = selectors.core.data.coins.getAllCoins()
 
       const m = cryptos.map((coin: string) => {
         const { coinfig } = window.coins[coin]
 
-        const currentPrice = coinPrices[coinfig.symbol]
-        const yesterdayPrice = coinPricesPrevious[coinfig.symbol]
+        const coinPrice = coinPrices[coinfig.symbol]
+        const isCustodialCoin = custodialCoins.includes(coin)
+        // console.log("isCustodialCoin", isCustodialCoin, coin)
+        const currentPrice = coinPrice?.price || 0
+        const yesterdayPrice = coinPricesPrevious[coinfig.symbol]?.price || 0
         const coinBalance = getBalanceSelector(coinfig.symbol)(state).getOrElse(0).valueOf()
         const priceChangeNum = Number(((currentPrice - yesterdayPrice) / yesterdayPrice) * 100)
         const priceChangeStr = Number.isNaN(priceChangeNum) ? '0' : priceChangeNum.toPrecision(2)
@@ -34,6 +38,8 @@ export const getData = createDeepEqualSelector(
               : coinBalance,
           coin: coinfig.symbol,
           coinModel: coin,
+          custodial: isCustodialCoin,
+          marketCap: coinPrice?.marketCap || 0,
           name: `${coinfig.name} (${coinfig.displaySymbol})`,
           price: currentPrice,
           priceChange: priceChangeStr,

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/template.success.tsx
@@ -28,7 +28,12 @@ const options = {
 }
 
 const initialState = {
-  sortBy: [{ desc: true, id: 'price' }]
+  hiddenColumns: ['custodial', 'marketCap'],
+  sortBy: [
+    { desc: true, id: 'custodial' },
+    { desc: true, id: 'marketCap' },
+    { desc: true, id: 'name' }
+  ]
 }
 
 const PricesTable = (props: Props) => {
@@ -57,7 +62,7 @@ const PricesTable = (props: Props) => {
   // react-virtualized-auto-sizer grows outside of page width bounds, grab parent table width
   // and set that as width on AutoList's List child element
   const [tableRef, { width: parentTableWidth }] = useElementSize()
-
+  // console.log('data', JSON.stringify(data, null, 2))
   const {
     getTableBodyProps,
     getTableProps,


### PR DESCRIPTION
## Description
This changes the default sorting on the prices table to first sort by custodial coins and then by marketCap and name.

This also changes the "prices" Redux sagas to include all the information about the coins and not just the price

## Testing Steps
- Open the Prices page and byt default the custodial should be at the top

