### PR TITLE
refactor(useCoinConfig): this refactor adds an async state to the hook

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/hooks/useCoinConfig/useCoinConfig.spec.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/hooks/useCoinConfig/useCoinConfig.spec.ts
@@ -1,0 +1,32 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useCoinConfig } from 'hooks'
+
+describe('useCoinConfig()', () => {
+  const originalWindowCoins = { ...window.coins }
+
+  const populateWindowCoins = () => {
+    window.coins = originalWindowCoins
+  }
+
+  beforeEach(() => {
+    // @ts-ignore
+    delete window.coins
+  })
+
+  afterEach(populateWindowCoins)
+
+  it('Should start at the loading state and then provide the data when window.coins is populated', async () => {
+    const { result, waitFor } = renderHook(() => useCoinConfig({ coin: 'BTC' }))
+
+    expect(result.current.isLoading).toEqual(true)
+    expect(result.current.data).toBeUndefined()
+
+    populateWindowCoins()
+
+    await waitFor(() => result.current.isLoading === false)
+
+    expect(result.current.isLoading).toEqual(false)
+    expect(result.current.data).toEqual(originalWindowCoins.BTC.coinfig)
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/hooks/useCoinConfig/useCoinConfig.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/hooks/useCoinConfig/useCoinConfig.ts
@@ -1,6 +1,45 @@
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { CoinConfigHook } from './useCoinConfig.types'
 
-export const useCoinConfig: CoinConfigHook = ({ coin }) =>
-  useMemo(() => window.coins[coin].coinfig, [coin])
+export const useCoinConfig: CoinConfigHook = ({ coin }) => {
+  const intervalRef = useRef<NodeJS.Timeout>()
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
+  const data = useMemo(() => {
+    if (isLoading) return undefined
+
+    return window.coins[coin].coinfig
+  }, [coin, isLoading])
+
+  const clearInterval = useCallback(() => {
+    const interval = intervalRef.current
+
+    if (interval) {
+      window.clearInterval(interval)
+
+      intervalRef.current = undefined
+    }
+  }, [intervalRef])
+
+  const checkForCoinsData = useCallback(() => {
+    if (window.coins) {
+      setIsLoading(false)
+
+      clearInterval()
+    }
+  }, [clearInterval])
+
+  useEffect(() => {
+    if (!intervalRef.current) {
+      intervalRef.current = setInterval(checkForCoinsData, 0)
+    }
+
+    return clearInterval
+  }, [clearInterval, checkForCoinsData])
+
+  return {
+    data,
+    isLoading
+  }
+}

--- a/packages/blockchain-wallet-v4-frontend/src/hooks/useCoinConfig/useCoinConfig.types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/hooks/useCoinConfig/useCoinConfig.types.ts
@@ -2,4 +2,7 @@ import { CoinfigType } from '@core/types'
 
 export type CoinConfigHookProps = { coin: string }
 
-export type CoinConfigHook = (props: CoinConfigHookProps) => CoinfigType
+export type CoinConfigHook = (props: CoinConfigHookProps) => {
+  data?: CoinfigType
+  isLoading: boolean
+}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/CoinPage/components/CoinPage/hooks/useHoldingsCard/useHoldingsCard.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/CoinPage/components/CoinPage/hooks/useHoldingsCard/useHoldingsCard.tsx
@@ -22,7 +22,7 @@ import { HoldingsCardHook } from './types'
 
 export const useHoldingsCard: HoldingsCardHook = ({ coin }) => {
   const currency = useCurrency()
-  const coinfig = useCoinConfig({ coin })
+  const { data: coinfig, isLoading: isLoadingCoinConfig } = useCoinConfig({ coin })
   const [openOpenBuyFlow] = useOpenBuyFlow()
   const [openOpenSellFlow] = useOpenSellFlow()
   const [openOpenReceiveCryptoModal] = useOpenReceiveCryptoModal()
@@ -33,12 +33,12 @@ export const useHoldingsCard: HoldingsCardHook = ({ coin }) => {
   const { data: rates, isLoading: isRatesLoading } = useCoinRates({ coin })
 
   const isLoading = useMemo(
-    () => isCoinBalanceLoading || isRatesLoading,
-    [isCoinBalanceLoading, isRatesLoading]
+    () => isCoinBalanceLoading || isRatesLoading || isLoadingCoinConfig,
+    [isCoinBalanceLoading, isRatesLoading, isLoadingCoinConfig]
   )
 
   const actions: ReactElement[] = useMemo(() => {
-    if (!coinBalance) return []
+    if (!coinBalance || !coinfig) return []
 
     const isBroke = coinBalance <= 0
     const isCustodialWalletBalance = coinfig.products.includes('CustodialWalletBalance')
@@ -99,7 +99,7 @@ export const useHoldingsCard: HoldingsCardHook = ({ coin }) => {
 
     const coinTotalAmount = Exchange.displayCoinToCoin({
       coin,
-      isFiat: coinfig.type.name === 'FIAT',
+      isFiat: coinfig?.type.name === 'FIAT',
       value: coinBalance
     })
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/CoinPage/components/CoinPage/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/CoinPage/components/CoinPage/index.tsx
@@ -26,10 +26,10 @@ const CoinPageContainer: FC<RouteComponentProps> = ({ computedMatch }) => {
   const [recurringBuyPanel] = useRecurringBuyPanel({ coin })
   const [tabsNode, { selectedTimeRange }] = useTabs({ coin })
   const [walletsCard] = useWalletsCard(coin)
-  const coinfig = useCoinConfig({ coin })
+  const { data: coinfig, isLoading: isLoadingCoinConfig } = useCoinConfig({ coin })
   const [activityFeed] = useActivityFeed({ coin })
 
-  const displayName = useMemo(() => coinfig.name, [coinfig.name])
+  const displayName = useMemo(() => coinfig?.name, [coinfig])
 
   const [chart] = useChart({
     timeRange: selectedTimeRange
@@ -39,13 +39,17 @@ const CoinPageContainer: FC<RouteComponentProps> = ({ computedMatch }) => {
     coin
   })
 
+  if (isLoadingCoinConfig) {
+    return <span>Loading</span>
+  }
+
   return (
     <Flex alignItems='center'>
       <CoinPage
         chartTabs={tabsNode}
         about={acoutSection}
         chart={chart}
-        header={<CoinHeader coinCode={coin} coinDescription='' coinName={displayName} />}
+        header={<CoinHeader coinCode={coin} coinDescription='' coinName={coinfig?.name ?? ''} />}
         chartBalancePanel={chartBalancePanel}
         recurringBuys={recurringBuyPanel}
         holdings={holdingsCard}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/CoinPage/components/TransactionListItem/TransactionListItem.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/CoinPage/components/TransactionListItem/TransactionListItem.tsx
@@ -13,16 +13,19 @@ import { TransactionListItemComponent } from './TransactionListItem.types'
 
 const TransactionListItem: TransactionListItemComponent = ({ coin, transaction }) => {
   const currency = useCurrency()
-  const coinfig = useCoinConfig({
+
+  const { data: coinfig } = useCoinConfig({
     coin
   })
+
+  if (!coinfig) return null
 
   return 'processingErrorType' in transaction ? null : 'hash' in transaction ? (
     <NonCustodialTxListItem
       key={transaction.hash}
       transaction={transaction}
       coin={coin}
-      coinTicker={coinfig.symbol}
+      coinTicker={coinfig?.symbol}
       currency={currency}
     />
   ) : 'priceFunnel' in transaction ? (


### PR DESCRIPTION
This refactor allow the consumer of this hook to wait for the coin's
configuration to be loaded before consuming the window.coins.
This is required because the window.coins are loaded asynchronously, and
this hook could emit an error when the coin is not loaded yet

