### PR TITLE
Fix/recovery flow

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -338,7 +338,7 @@ export default ({ api, coreSagas, networks }) => {
         yield put(actions.modules.settings.updateCurrency(currency, true))
         yield put(actions.core.settings.setCurrency(currency))
 
-        if (isAccountReset || recovery) {
+        if (isAccountReset) {
           if (product === ProductAuthOptions.EXCHANGE) {
             yield put(
               actions.modules.profile.authAndRouteToExchangeAction(ExchangeAuthOriginType.Login)

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -338,7 +338,7 @@ export default ({ api, coreSagas, networks }) => {
         yield put(actions.modules.settings.updateCurrency(currency, true))
         yield put(actions.core.settings.setCurrency(currency))
 
-        if (isAccountReset) {
+        if (isAccountReset || recovery) {
           if (product === ProductAuthOptions.EXCHANGE) {
             yield put(
               actions.modules.profile.authAndRouteToExchangeAction(ExchangeAuthOriginType.Login)

--- a/packages/blockchain-wallet-v4-frontend/src/data/signup/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/signup/sagas.ts
@@ -73,7 +73,13 @@ export default ({ api, coreSagas, networks }) => {
       yield put(actions.auth.loginLoading())
       yield put(actions.signup.setRegisterEmail(email))
       const captchaToken = yield call(generateCaptchaToken, CaptchaActionName.SIGNUP)
-      yield call(coreSagas.wallet.createWalletSaga, { captchaToken, email, language, password })
+      yield call(coreSagas.wallet.createWalletSaga, {
+        captchaToken,
+        email,
+        forceVerifyEmail: isAccountReset,
+        language,
+        password
+      })
       // We don't want to show the account success message if user is resetting their account
       if (!isAccountReset) {
         yield put(actions.alerts.displaySuccess(C.REGISTER_SUCCESS))

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/index.tsx
@@ -39,6 +39,9 @@ export const Card = styled.div`
     width: 100%;
     padding: 1.5rem;
   `}
+  ${media.mobile`
+  padding: 0;
+`}
 `
 export const CardHeader = styled.div`
   align-items: center;

--- a/packages/blockchain-wallet-v4/src/network/api/wallet/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/wallet/index.ts
@@ -37,12 +37,13 @@ export default ({ get, post, rootUrl }) => {
       url: rootUrl
     }).then(() => data.checksum)
 
-  const createPayload = (email, captchaToken, data) =>
+  const createPayload = (email, captchaToken, forceVerifyEmail, data) =>
     post({
       data: mergeRight(
         {
           captcha: captchaToken,
           email,
+          force: forceVerifyEmail,
           format: 'plain',
           method: 'insert',
           siteKey: window.CAPTCHA_KEY

--- a/packages/blockchain-wallet-v4/src/network/walletApi.js
+++ b/packages/blockchain-wallet-v4/src/network/walletApi.js
@@ -74,12 +74,12 @@ const createWalletApi = (
 
   // **********
 
-  const createWalletTask = (email, captchaToken) => (wrapper) => {
-    const create = (data) => ApiPromise.createPayload(email, captchaToken, data)
+  const createWalletTask = (email, captchaToken, forceVerifyEmail) => (wrapper) => {
+    const create = (data) => ApiPromise.createPayload(email, captchaToken, forceVerifyEmail, data)
     return Wrapper.toEncJSON(wrapper).chain(promiseToTask(create))
   }
-  const createWallet = (email, captchaToken, wrapper) =>
-    compose(taskToPromise, createWalletTask(email, captchaToken))(wrapper)
+  const createWallet = (email, captchaToken, wrapper, forceVerifyEmail) =>
+    compose(taskToPromise, createWalletTask(email, captchaToken, forceVerifyEmail))(wrapper)
 
   // **********
 

--- a/packages/blockchain-wallet-v4/src/redux/wallet/sagas.ts
+++ b/packages/blockchain-wallet-v4/src/redux/wallet/sagas.ts
@@ -83,7 +83,13 @@ export default ({ api, networks }) => {
     yield refetchContextData()
   }
 
-  const createWalletSaga = function* ({ captchaToken, email, language, password }) {
+  const createWalletSaga = function* ({
+    captchaToken,
+    email,
+    forceVerifyEmail = false,
+    language,
+    password
+  }) {
     const mnemonic = yield call(generateMnemonic, api)
     const [guid, sharedKey] = yield call(api.generateUUIDs, 2)
     const wrapper = Wrapper.createNew(
@@ -96,7 +102,7 @@ export default ({ api, networks }) => {
       undefined,
       networks.btc
     )
-    yield call(api.createWallet, email, captchaToken, wrapper)
+    yield call(api.createWallet, email, captchaToken, wrapper, forceVerifyEmail)
     yield put(A.wallet.refreshWrapper(wrapper))
   }
 


### PR DESCRIPTION
## Description (optional)
Upon creating a wallet on the account recovery flow, we need to send a force=true parameter to ensure that the wallet’s welcome email sequence is removed. Also automatically verified the email for the new wallet. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

