### PR TITLE
fix(recovery): route to exchange or wallet directly after mnemonic re…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -297,7 +297,7 @@ export default ({ api, coreSagas, networks }) => {
       yield call(coreSagas.data.xlm.fetchData)
 
       yield call(authNabu)
-      if (product === ProductAuthOptions.EXCHANGE && !firstLogin) {
+      if (product === ProductAuthOptions.EXCHANGE && (recovery || !firstLogin)) {
         return yield put(
           actions.modules.profile.authAndRouteToExchangeAction(ExchangeAuthOriginType.Login)
         )

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators } from 'redux'
 
+import { Remote } from '@core'
 import { RemoteDataType } from '@core/types'
 import { SpinningLoader } from 'blockchain-info-components'
 import { actions, selectors } from 'data'
@@ -24,11 +25,16 @@ const ProductPickerContainer: React.FC<Props> = (props) => {
     props.signupActions.setRegisterEmail(undefined)
     props.profileActions.authAndRouteToExchangeAction(ExchangeAuthOriginType.Signup)
   }
+  const isMetadataRecovery = Remote.Success.is(props.isMetadataRecoveryR)
 
   return props.walletLoginData.cata({
     Failure: (error) => <Error error={error} />,
     Loading: () => <SpinningLoader />,
     NotAsked: () => {
+      if (isMetadataRecovery) {
+        props.routerActions.push('/home')
+        return null
+      }
       props.routerActions.push('/login?product=exchange')
       return null
     },
@@ -48,6 +54,7 @@ const mapStateToProps = (state) => ({
   appEnv: selectors.core.walletOptions.getAppEnv(state).getOrElse('prod'),
   email: selectors.signup.getRegisterEmail(state) as string,
   exchangeUserConflict: selectors.auth.getExchangeConflictStatus(state) as boolean,
+  isMetadataRecoveryR: selectors.signup.getMetadataRestore(state),
   walletLoginData: selectors.auth.getLogin(state) as RemoteDataType<any, any>
 })
 


### PR DESCRIPTION
…covery

## Description (optional)
1. If mnemonic recovery is started from exchange tab, take user directly to exchange after recovery
2. If recovery is stared from wallet tab and its mnemonic is a metadata recovery, take user straight to wallet. (skips email verification if wallet had verified email, skips product picker)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

