### PR TITLE
fix(BuySell): prevent order fails when deleting pending order

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
@@ -1694,7 +1694,14 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
   const cleanupCancellableOrders = function* () {
     const order = S.getCancelableOrder(yield select())
     if (order) {
-      yield call(api.cancelBSOrder, order)
+      try {
+        yield call(api.cancelBSOrder, order)
+      } catch (error) {
+        if (error.status !== 409) {
+          throw error
+        }
+      }
+
       yield put(A.fetchOrders())
       yield take(A.fetchOrdersSuccess.type)
     }


### PR DESCRIPTION
This prevents the buy sell flow from failing when the delete
order call fails with a 409 status. 409 status is a conflict
error from the api
