### PR TITLE
feat(ExternalSvg): add component to display svg from url

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/ExternalSVG.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/ExternalSVG.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+import { Image } from 'blockchain-info-components'
+
+import { ExternalSVG, ExternalSVGComponent } from '.'
+
+export default {
+  component: ExternalSVG,
+  title: 'Components/ExternalSVG'
+} as ComponentMeta<ExternalSVGComponent>
+
+const Template: ComponentStory<ExternalSVGComponent> = (args) => <ExternalSVG {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  height: 3,
+  src: 'https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/410.svg',
+  width: 3
+}
+
+export const FailedToLoadWithCallback = Template.bind({})
+FailedToLoadWithCallback.args = {
+  fallback: <Image name='empty-search' width='100%' height='100%' />,
+  height: 3,
+  src: 'https://dev.w3.org/should_fail',
+  width: 3
+}

--- a/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/ExternalSVG.test.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/ExternalSVG.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { ExternalSVG } from '.'
+
+describe('ExternalSVG', () => {
+  it('Should display the svg image', () => {
+    const wrapper = shallow(<ExternalSVG src='/assets/icon.svg' width={3} height={2} />)
+
+    expect(wrapper.type()).toEqual('svg')
+    expect(wrapper.getElement().props.width).toEqual('3rem')
+    expect(wrapper.getElement().props.height).toEqual('2rem')
+
+    const image = wrapper.find('image')
+
+    const imageProps = image.getElement().props
+
+    expect(imageProps.href).toEqual('/assets/icon.svg')
+    expect(imageProps.width).toEqual('3rem')
+    expect(imageProps.height).toEqual('2rem')
+  })
+
+  it('Should render fallback when image failed to load', () => {
+    const wrapper = shallow(
+      <ExternalSVG
+        src='/assets/icon.svg'
+        width={3}
+        height={2}
+        fallback={<div data-testid='image-fallback' />}
+      />
+    )
+
+    const image = wrapper.find('image')
+
+    const imageProps = image.getElement().props
+
+    expect(wrapper.find('[data-testid="image-fallback"]').exists()).toBe(false)
+
+    imageProps.onError()
+
+    expect(wrapper.find('[data-testid="image-fallback"]').exists()).toBe(true)
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/ExternalSVG.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/ExternalSVG.tsx
@@ -1,0 +1,30 @@
+import React, { CSSProperties, useCallback, useState } from 'react'
+
+import { ExternalSVGComponent } from './ExternalSVG.types'
+
+const ExternalSVG: ExternalSVGComponent = ({ fallback, height, src, width, ...props }) => {
+  const [hasFailure, setHasFailure] = useState<boolean>(false)
+
+  const handleOnFailure = useCallback(() => setHasFailure(true), [setHasFailure])
+
+  const sizeProps: Pick<CSSProperties, 'width' | 'height'> = {
+    height: `${height}rem`,
+    width: `${width}rem`
+  }
+
+  if (hasFailure && fallback) {
+    return (
+      <div style={{ ...sizeProps, display: 'inline-block' }} {...props}>
+        {fallback}
+      </div>
+    )
+  }
+
+  return (
+    <svg {...sizeProps} {...props}>
+      <image href={src} onError={handleOnFailure} {...sizeProps} />
+    </svg>
+  )
+}
+
+export default ExternalSVG

--- a/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/ExternalSVG.types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/ExternalSVG.types.ts
@@ -1,0 +1,12 @@
+import { FC, ReactNode } from 'react'
+
+type ExternalSVGProps = {
+  fallback?: ReactNode
+  height: number
+  src: string
+  width: number
+}
+
+type ExternalSVGComponent = FC<ExternalSVGProps>
+
+export type { ExternalSVGComponent, ExternalSVGProps }

--- a/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/ExternalSVG/index.ts
@@ -1,0 +1,2 @@
+export { default as ExternalSVG } from './ExternalSVG'
+export type { ExternalSVGComponent, ExternalSVGProps } from './ExternalSVG.types'


### PR DESCRIPTION
## Description
This adds the ExternalSVG component to be able to render an svg from a url.
This uses the image tag inside a svg to be able to fetch and render the svg, also handle failure and provides a fallback attribute

### example
```
<ExternalSVG
  src="/svg-path.svg"
  width={1} // in rem
  height={1} // in rem
  fallback={(
    <FallbackImageOrComponent />
  )}
/>
```
<img width="1470" alt="Screen Shot 2022-05-31 at 2 44 46 PM" src="https://user-images.githubusercontent.com/99212903/171255896-75c91821-4fac-4535-b0fd-97294230ced2.png">
<img width="1344" alt="Screen Shot 2022-05-31 at 2 44 54 PM" src="https://user-images.githubusercontent.com/99212903/171255910-f0683fb2-9eb8-4401-98e2-bf355de2df91.png">

