### PR TITLE
fix(storybook): add generated files to alias

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -31,7 +31,8 @@ module.exports = {
       middleware: path.resolve(__dirname, '..', 'packages/blockchain-wallet-v4-frontend/src/middleware/'),
       providers: path.resolve(__dirname, '..', 'packages/blockchain-wallet-v4-frontend/src/providers/'),
       services: path.resolve(__dirname, '..', 'packages/blockchain-wallet-v4-frontend/src/services/'),
-      utils: path.resolve(__dirname, '..', 'packages/blockchain-wallet-v4-frontend/src/utils/')
+      utils: path.resolve(__dirname, '..', 'packages/blockchain-wallet-v4-frontend/src/utils/'),
+      generated: path.resolve(__dirname, '..', 'packages/blockchain-wallet-v4-frontend/src/generated/')
     }
 
     // Return the altered config


### PR DESCRIPTION
## Description
Storybook is not running because it cannot resolve the generated/types file.
So, this adds the generated folder alias to storybook