### PR TITLE
fix(textarea): pass autocomplete prop to base textarea component

### DIFF
--- a/packages/blockchain-info-components/src/Form/TextAreaInput.js
+++ b/packages/blockchain-info-components/src/Form/TextAreaInput.js
@@ -3,7 +3,9 @@ import styled from 'styled-components'
 
 import { selectBorderColor, selectFocusBorderColor } from './helper'
 
-const BaseTextAreaInput = styled.textarea`
+const BaseTextAreaInput = styled.textarea.attrs((props) => ({
+  autoComplete: props.autoComplete
+}))`
   display: block;
   width: 100%;
   padding: 6px 12px;
@@ -35,7 +37,7 @@ const BaseTextAreaInput = styled.textarea`
   &:disabled {
     cursor: not-allowed;
     background-color: ${(props) => props.theme.grey100};
-    border: '1px solid transparent';
+    border: 1px solid transparent;
   }
 `
 

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/TextArea/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/TextArea/index.js
@@ -31,10 +31,11 @@ const TextArea = (field) => {
     <Container>
       <TextAreaInput
         {...field.input}
+        autoComplete={field.autoComplete}
+        data-e2e={field['data-e2e']}
         errorState={errorState}
         placeholder={field.placeholder}
         rows={field.rows}
-        data-e2e={field['data-e2e']}
       />
       {field.meta.touched && field.meta.error && (
         <Error size='12px' weight={400} color='error'>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryPhrase/FirstStep/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryPhrase/FirstStep/index.tsx
@@ -5,7 +5,7 @@ import { Field } from 'redux-form'
 import styled from 'styled-components'
 
 import { Button, HeartbeatLoader, Text } from 'blockchain-info-components'
-import TextArea from 'components/Form/TextArea'
+import TextBox from 'components/Form/TextBox'
 import { Analytics, RecoverSteps } from 'data/types'
 import { required } from 'services/forms'
 
@@ -75,11 +75,10 @@ const FirstStep = (props: Props) => {
             bgColor='grey000'
             autoComplete='off'
             autoFocus
-            component={TextArea}
+            component={TextBox}
             disableSpellcheck
             name='mnemonic'
             validate={[required, validMnemonic]}
-            height='96px'
             placeholder='Enter your secret private key recovery phrase'
           />
         </FormBody>


### PR DESCRIPTION
## Description
- Use input (TextBox) for mnemonic recovery form
- Ensure autocomplete='off' prop gets passed correctly to textarea component

<img width="1083" alt="Screen Shot 2022-06-15 at 10 43 46 AM" src="https://user-images.githubusercontent.com/6364918/173855890-ff7b4099-177e-43d5-8a63-d575aa3bdf74.png">


