### PR TITLE
fix(signup): only show dupe exchange acct error if user clicks on exc…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators } from 'redux'
 
@@ -13,6 +13,7 @@ import Error from './template.error'
 import ExchangeUserConflict from './template.error.exchange'
 
 const ProductPickerContainer: React.FC<Props> = (props) => {
+  const [showExchangeUserConflict, setExchangeUserConflict] = useState(false)
   const walletRedirect = () => {
     props.signupActions.setRegisterEmail(undefined)
     props.routerActions.push('/home')
@@ -22,8 +23,12 @@ const ProductPickerContainer: React.FC<Props> = (props) => {
   }
 
   const exchangeRedirect = () => {
-    props.signupActions.setRegisterEmail(undefined)
-    props.profileActions.authAndRouteToExchangeAction(ExchangeAuthOriginType.Signup)
+    if (props.exchangeUserConflict) {
+      setExchangeUserConflict(true)
+    } else {
+      props.signupActions.setRegisterEmail(undefined)
+      props.profileActions.authAndRouteToExchangeAction(ExchangeAuthOriginType.Signup)
+    }
   }
   const isMetadataRecovery = Remote.Success.is(props.isMetadataRecoveryR)
 
@@ -39,7 +44,7 @@ const ProductPickerContainer: React.FC<Props> = (props) => {
       return null
     },
     Success: () =>
-      props.exchangeUserConflict ? (
+      showExchangeUserConflict ? (
         <ExchangeUserConflict {...props} walletRedirect={walletRedirect} />
       ) : (
         <ProductPicker

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/template.error.exchange.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/template.error.exchange.tsx
@@ -12,15 +12,6 @@ const ContentWrapper = styled.div`
   align-items: center;
   flex-direction: column;
 `
-const IconWrapper = styled.div`
-  display: flex;
-  background: ${(props) => props.theme.blue600};
-  height: 40px;
-  width: 40px;
-  justify-content: center;
-  align-items: center;
-  border-radius: 50%;
-`
 
 const ExchangeUserConflict = ({ email, walletRedirect }: Props) => {
   return (


### PR DESCRIPTION
…hange in product picker

## Description (optional)
Show product picker as normal if user signs up for account with an email already associated with exchange account. Only show error below if user clicks on Exchange option.

<img width="623" alt="Screenshot 2022-05-24 at 17 00 09" src="https://user-images.githubusercontent.com/14954836/173960245-51455601-a1aa-495d-8416-acb37bd06b9e.png">

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

