### PR TITLE
fix(login-error-overlap): move error to bottom

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/TextBox/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/TextBox/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { Icon, Text, TextInput } from 'blockchain-info-components'
+import { Text, TextInput } from 'blockchain-info-components'
 
 const Container = styled.div`
   position: relative;
@@ -11,7 +11,7 @@ const Container = styled.div`
   align-items: flex-start;
   width: 100%;
   height: ${(props) => props.height};
-  ${({ errorBottom }) => errorBottom && `padding-bottom: 4px;`}
+  ${({ errorBottom }) => errorBottom && `padding-bottom: 6px;`}
 `
 const Error = styled(Text)`
   position: absolute;
@@ -20,14 +20,8 @@ const Error = styled(Text)`
   left: ${(props) => (props.errorLeft ? '0' : 'initial')};
   bottom: ${(props) => (props.errorBottom ? '-20px' : 'initial')};
   right: 0;
-  ${({ errorBottom }) => errorBottom && `padding-top: 4px;`}
+  ${({ errorBottom }) => errorBottom && `padding-top: 6px;`}
   height: 15px;
-`
-const WarningIcon = styled(Icon)`
-  position: absolute;
-  margin: auto 0;
-  right: 16px;
-  top: 14px;
 `
 
 const getErrorState = ({ invalid, touched }) => {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/TextBox/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/TextBox/index.js
@@ -11,6 +11,7 @@ const Container = styled.div`
   align-items: flex-start;
   width: 100%;
   height: ${(props) => props.height};
+  ${({ errorBottom }) => errorBottom && `padding-bottom: 4px;`}
 `
 const Error = styled(Text)`
   position: absolute;
@@ -19,6 +20,7 @@ const Error = styled(Text)`
   left: ${(props) => (props.errorLeft ? '0' : 'initial')};
   bottom: ${(props) => (props.errorBottom ? '-20px' : 'initial')};
   right: 0;
+  ${({ errorBottom }) => errorBottom && `padding-top: 4px;`}
   height: 15px;
 `
 const WarningIcon = styled(Icon)`
@@ -54,7 +56,7 @@ const TextBox = (field) => {
   const errorState = getErrorState(meta)
 
   return (
-    <Container className={className} height={height}>
+    <Container className={className} height={height} errorBottom={errorBottom}>
       <TextInput
         {...input}
         active={active}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
@@ -27,6 +27,11 @@ const LoginWrapper = styled(Wrapper)`
     padding: 0 0 16px 0;
   `}
 `
+const CustomFormItem = styled(FormItem)`
+  & > div > div:last-child {
+    padding-top: 4px;
+  }
+`
 
 const EnterEmailOrGuid = (props: Props) => {
   const { busy, exchangeTabClicked, formValues, invalid, magicLinkData, submitting, walletError } =
@@ -38,7 +43,7 @@ const EnterEmailOrGuid = (props: Props) => {
       <ProductTabMenu active={ProductAuthOptions.WALLET} onExchangeTabClick={exchangeTabClicked} />
       <WrapperWithPadding>
         <FormGroup>
-          <FormItem style={{ marginTop: '40px' }}>
+          <CustomFormItem style={{ marginTop: '40px' }}>
             <LoginFormLabel htmlFor='guid'>
               <FormattedMessage id='scenes.login.email_guid' defaultMessage='Email or Wallet ID' />
             </LoginFormLabel>
@@ -48,12 +53,13 @@ const EnterEmailOrGuid = (props: Props) => {
               data-e2e='loginGuidOrEmail'
               disableSpellcheck
               errorBottom
+              errorLeft
               name='guidOrEmail'
               normalize={removeWhitespace}
               validate={[required, validWalletIdOrEmail]}
               placeholder='Enter Email or Wallet ID'
             />
-          </FormItem>
+          </CustomFormItem>
           {guidError && (
             <GuidError inline>
               <Text size='12px' color='error' weight={400} data-e2e='walletIdError'>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
@@ -43,14 +43,15 @@ const EnterEmailOrGuid = (props: Props) => {
               <FormattedMessage id='scenes.login.email_guid' defaultMessage='Email or Wallet ID' />
             </LoginFormLabel>
             <Field
+              autoFocus
               component={TextBox}
               data-e2e='loginGuidOrEmail'
               disableSpellcheck
+              errorBottom
               name='guidOrEmail'
               normalize={removeWhitespace}
               validate={[required, validWalletIdOrEmail]}
               placeholder='Enter Email or Wallet ID'
-              autoFocus
             />
           </FormItem>
           {guidError && (

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
@@ -27,11 +27,6 @@ const LoginWrapper = styled(Wrapper)`
     padding: 0 0 16px 0;
   `}
 `
-const CustomFormItem = styled(FormItem)`
-  & > div > div:last-child {
-    padding-top: 4px;
-  }
-`
 
 const EnterEmailOrGuid = (props: Props) => {
   const { busy, exchangeTabClicked, formValues, invalid, magicLinkData, submitting, walletError } =
@@ -43,7 +38,7 @@ const EnterEmailOrGuid = (props: Props) => {
       <ProductTabMenu active={ProductAuthOptions.WALLET} onExchangeTabClick={exchangeTabClicked} />
       <WrapperWithPadding>
         <FormGroup>
-          <CustomFormItem style={{ marginTop: '40px' }}>
+          <FormItem style={{ marginTop: '40px' }}>
             <LoginFormLabel htmlFor='guid'>
               <FormattedMessage id='scenes.login.email_guid' defaultMessage='Email or Wallet ID' />
             </LoginFormLabel>
@@ -59,7 +54,7 @@ const EnterEmailOrGuid = (props: Props) => {
               validate={[required, validWalletIdOrEmail]}
               placeholder='Enter Email or Wallet ID'
             />
-          </CustomFormItem>
+          </FormItem>
           {guidError && (
             <GuidError inline>
               <Text size='12px' color='error' weight={400} data-e2e='walletIdError'>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryPhrase/SecondStep/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/RecoveryPhrase/SecondStep/template.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { has } from 'ramda'
 import { Field } from 'redux-form'
 import styled from 'styled-components'
 


### PR DESCRIPTION
## Description (optional)
* move error message to bottom of input to avoid overlap
<img width="545" alt="Screen Shot 2022-06-16 at 1 55 15 PM" src="https://user-images.githubusercontent.com/53186076/174135213-f62bd804-2c8a-45e4-96b0-303dea1995ce.png">

