### PR TITLE
feat(kyc extra): pass over context to save KYC extra fields call

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/model.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/model.ts
@@ -74,8 +74,3 @@ export const CAMPAIGNS = {
     coinName: 'Stellar'
   }
 }
-
-export enum EXTRA_KYC_CONTEXTS {
-  FIAT_DEPOSIT = 'FIAT_DEPOSIT',
-  TIER_TWO_VERIFICATION = 'TIER_TWO_VERIFICATION'
-}

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
@@ -2,7 +2,7 @@ import { isEmpty, prop, toUpper } from 'ramda'
 import { call, delay, put, select, take } from 'redux-saga/effects'
 
 import { Types } from '@core'
-import { ExtraQuestionsType, RemoteDataType, SDDVerifiedType } from '@core/types'
+import { ExtraKYCContext, ExtraQuestionsType, RemoteDataType, SDDVerifiedType } from '@core/types'
 import { actions, actionTypes, model, selectors } from 'data'
 import { ModalName } from 'data/modals/types'
 import { KycStateType } from 'data/types'
@@ -12,7 +12,6 @@ import profileSagas from '../../modules/profile/sagas'
 import {
   BAD_CODE_ERROR,
   EMAIL_STEPS,
-  EXTRA_KYC_CONTEXTS,
   FLOW_TYPES,
   ID_VERIFICATION_SUBMITTED_FORM,
   INFO_AND_RESIDENTIAL_FORM,
@@ -172,9 +171,7 @@ export default ({ api, coreSagas, networks }) => {
     let addExtraStep = false
     // check extra KYC fields
     const context =
-      origin === 'BuySell'
-        ? EXTRA_KYC_CONTEXTS.FIAT_DEPOSIT
-        : EXTRA_KYC_CONTEXTS.TIER_TWO_VERIFICATION
+      origin === 'BuySell' ? ExtraKYCContext.FIAT_DEPOSIT : ExtraKYCContext.TIER_TWO_VERIFICATION
 
     yield put(actions.components.identityVerification.fetchExtraKYC(context))
     yield take([A.fetchExtraKYCSuccess.type, A.fetchExtraKYCFailure.type])

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/ExtraFields.stories.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/ExtraFields.stories.tsx
@@ -7,6 +7,8 @@ import { combineReducers, createStore } from 'redux'
 import ExtraFields from './template.success'
 
 const EXTRA_STEPS_RESPONSE = {
+  blocking: true,
+  context: 'TIER_TWO_UPGRADE',
   nodes: [
     {
       hint: 'CUIL Number',

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/index.tsx
@@ -2,9 +2,9 @@ import React, { useEffect } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 
+import { ExtraKYCContext } from '@core/types'
 import { Text } from 'blockchain-info-components'
 import { actions, model, selectors } from 'data'
-import { EXTRA_KYC_CONTEXTS } from 'data/components/identityVerification/model'
 import { RootState } from 'data/rootReducer'
 import { Analytics, ExtraKeyFieldsFormValuesType } from 'data/types'
 
@@ -16,7 +16,7 @@ const { KYC_EXTRA_QUESTIONS_FORM } = model.components.identityVerification
 
 const KYCExtraQuestionnaire = (props: Props) => {
   useEffect(() => {
-    props.identityVerificationActions.fetchExtraKYC(EXTRA_KYC_CONTEXTS.TIER_TWO_VERIFICATION)
+    props.identityVerificationActions.fetchExtraKYC(ExtraKYCContext.TIER_TWO_VERIFICATION)
     props.analyticsActions.trackEvent({
       key: Analytics.ONBOARDING_ACCOUNT_INFO_SCREEN_VIEWED,
       properties: {}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/template.success.tsx
@@ -156,7 +156,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
   const updateItem = (nodeId: string, childId: string) => {
     props.formActions.change(KYC_EXTRA_QUESTIONS_FORM, nodeId, childId)
 
-    const { nodes } = props.extraSteps
+    const { blocking, context, nodes } = props.extraSteps
     let isChanged = false
 
     nodes.map(
@@ -177,14 +177,14 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
         })
     )
     if (isChanged) {
-      props.identityVerificationActions.updateExtraKYCQuestions({ nodes })
+      props.identityVerificationActions.updateExtraKYCQuestions({ blocking, context, nodes })
     }
   }
 
   const onChangeInput = (e, value) => {
     const itemId = e.currentTarget.name
 
-    const { nodes } = props.extraSteps
+    const { blocking, context, nodes } = props.extraSteps
     const isChanged = false
 
     nodes.map(
@@ -203,7 +203,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
     )
 
     if (isChanged) {
-      props.identityVerificationActions.updateExtraKYCQuestions({ nodes })
+      props.identityVerificationActions.updateExtraKYCQuestions({ blocking, context, nodes })
     }
   }
 

--- a/packages/blockchain-wallet-v4/src/network/api/kyc/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/kyc/index.ts
@@ -123,7 +123,7 @@ export default ({ authorizedGet, authorizedPost, authorizedPut, get, nabuUrl, po
   const updateKYCExtraQuestions = (extraQuestions: ExtraQuestionsType): SDDVerifiedType =>
     authorizedPut({
       contentType: 'application/json',
-      data: { nodes: extraQuestions.nodes },
+      data: { context: extraQuestions.context, nodes: extraQuestions.nodes },
       endPoint: '/kyc/extra-questions',
       ignoreQueryParams: true,
       url: nabuUrl

--- a/packages/blockchain-wallet-v4/src/network/api/kyc/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/kyc/types.ts
@@ -12,6 +12,11 @@ export enum CountryScope {
 
 export type CountryScopeType = keyof typeof CountryScope
 
+export enum ExtraKYCContext {
+  FIAT_DEPOSIT = 'FIAT_DEPOSIT',
+  TIER_TWO_VERIFICATION = 'TIER_TWO_VERIFICATION'
+}
+
 export enum NodeItemTypes {
   MULTIPLE_SELECTION = 'MULTIPLE_SELECTION',
   OPEN_ENDED = 'OPEN_ENDED',
@@ -63,5 +68,7 @@ export type NodeTextType = {
 }
 
 export type ExtraQuestionsType = {
+  blocking: boolean
+  context: keyof typeof ExtraKYCContext
   nodes: Array<NodeType>
 }


### PR DESCRIPTION
## Description (optional)
Pass context prop to PUT call
<img width="386" alt="image" src="https://user-images.githubusercontent.com/67264242/174796655-33e09071-da0d-4712-8a75-b24a7514ffd4.png">


## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

