### PR TITLE
fix(Settings): make product name lowercase in eligible product api call

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/settings/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/settings/types.ts
@@ -1,11 +1,11 @@
 import { FiatType, RemoteDataType } from '@core/types'
 
-export type NabuProductType = 'SWAP' | 'SIMPLEBUY' | 'SAVINGS' | 'BROKERAGE'
+export type NabuProductType = 'swap' | 'simplebuy' | 'savings' | 'brokerage'
 export enum NabuProducts {
-  BROKERAGE = 'BROKERAGE',
-  SAVINGS = 'SAVINGS',
-  SIMPLEBUY = 'SIMPLEBUY',
-  SWAP = 'SWAP'
+  BROKERAGE = 'brokerage',
+  SAVINGS = 'savings',
+  SIMPLEBUY = 'simplebuy',
+  SWAP = 'swap'
 }
 
 export type ProductEligibilityResponse = {


### PR DESCRIPTION
## Description (optional)
the API call to `https://api.staging.blockchain.info/nabu-gateway/eligible/product/brokerage` is sending the product name in upper case. This PR changes the product name to lowercase, so the API call is in lowercase

Towards [FWN-1622](https://blockchain.atlassian.net/browse/FWN-1622?jql=project%20in%20(%22Wallet%20-%20iOS%22%2C%20%22Wallet%20-%20Android%22%2C%20%22Wallet%20-%20Web%22)%20AND%20type%20in%20(Issue%2C%20Bug)%20AND%20status%20in%20(%22Awaiting%20Dev%22%2C%20Backlog%2C%20%22To%20Do%22%2C%20TODO%2C%20%22In%20Progress%22)%20AND%20(%22Squad%5BDropdown%5D%22%20in%20(%22Crypto%20Investing%22%2C%20Crypto-Investing)%20OR%20%22Squad%5BLabels%5D%22%20in%20(Crypto-Investing))%20AND%20resolution%20%3D%20Unresolved%20AND%20assignee%20%3D%20ug%3A9a1f03c6-f460-4bea-9ce6-8882f7d97228%20ORDER%20BY%20created%20DESC)