### PR TITLE
SRW-91 - modify 1-click interest in buy flow

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
@@ -43,7 +43,7 @@ const IconWrapper = styled.div`
   justify-content: center;
 `
 const TitleWrapper = styled(Text)`
-  padding: 32px 0 24px 0;
+  padding: 2rem 0 1.5rem 0;
   width: 100%;
 `
 const BottomInfo = styled(Bottom)`
@@ -58,7 +58,7 @@ const BottomPromo = styled.div`
   justify-content: flex-end;
   flex-direction: column;
   height: 180px;
-  margin-bottom: 15px;
+  margin-bottom: 1rem;
 `
 
 const SecondaryInfoText = styled.div`
@@ -66,11 +66,11 @@ const SecondaryInfoText = styled.div`
 `
 
 const StyledDoneButton = styled(Button)`
-  margin-top: 16px;
+  margin-top: 1rem;
 `
 
 const StyledEarnButton = styled(Button)`
-  margin-top: 24px;
+  margin-top: 1.5rem;
 `
 
 const OrderSummary: React.FC<Props> = ({

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
@@ -100,6 +100,7 @@ const OrderSummary: React.FC<Props> = ({
 
   const { days } = intervalToDuration({ end: lockTime, start: 0 })
 
+  // Getting the interest rate for the coin that was bought
   const coinInterestRate = !!interestRate[outputCurrency] && interestRate[outputCurrency]
 
   const isInterestEligibleCoin = useMemo(
@@ -112,10 +113,6 @@ const OrderSummary: React.FC<Props> = ({
   )
 
   const handleEarnRewardsButton = useCallback(() => {
-    analyticsActions.trackEvent({
-      key: Analytics.WALLET_BUY_EARN_REWARDS_CLICKED,
-      properties: {}
-    })
     handleClose()
     setTimeout(() => {
       interestActions.showInterestModal({
@@ -123,6 +120,10 @@ const OrderSummary: React.FC<Props> = ({
         step: 'ACCOUNT_SUMMARY'
       })
     }, duration)
+    analyticsActions.trackEvent({
+      key: Analytics.WALLET_BUY_EARN_REWARDS_CLICKED,
+      properties: {}
+    })
   }, [outputCurrency, handleClose])
 
   useEffect(() => {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Brokerage/OrderSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { intervalToDuration } from 'date-fns'
 import { isEmpty } from 'ramda'
@@ -124,6 +124,15 @@ const OrderSummary: React.FC<Props> = ({
       })
     }, duration)
   }, [outputCurrency, handleClose])
+
+  useEffect(() => {
+    if (isInterestEligibleCoin) {
+      analyticsActions.trackEvent({
+        key: Analytics.WALLET_BUY_EARN_REWARDS_VIEWED,
+        properties: {}
+      })
+    }
+  }, [outputCurrency])
 
   return (
     <Container>

--- a/packages/blockchain-wallet-v4-frontend/src/data/analytics/types/walletRewardsClientEvents.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/analytics/types/walletRewardsClientEvents.ts
@@ -1,4 +1,8 @@
 export enum Events {
+  // BUY: Wallet. The user clicks the buy earn rewards button.
+  WALLET_BUY_EARN_REWARDS_CLICKED = 'Wallet Buy Earn Rewards Clicked',
+  // BUY: Wallet. What the user sees after the wallet clicks the Buy Earn Rewards Button
+  WALLET_BUY_EARN_REWARDS_VIEWED = 'Wallet Buy Earn Rewards Viewed',
   // ADD: User changes the wallet on the interest deposit page.
   WALLET_REWARDS_DEPOSIT_CHANGE_WALLET_CLICKED = 'Wallet Rewards Deposit Change Wallet Clicked',
   // ADD: User clicks on transfer on the deposit page.
@@ -132,6 +136,17 @@ type WalletRewardsWithdrawTransferClicked = {
   }
 }
 
+// BUY
+type WalletBuyEarnRewardsClicked = {
+  key: Events.WALLET_BUY_EARN_REWARDS_CLICKED
+  properties: {}
+}
+
+type WalletBuyEarnRewardsViewed = {
+  key: Events.WALLET_BUY_EARN_REWARDS_VIEWED
+  properties: {}
+}
+
 export type TrackEventAction =
   | WalletRewardsDetailClicked
   | WalletRewardsTransactionHistoryClicked
@@ -146,3 +161,5 @@ export type TrackEventAction =
   | WalletRewardsWithdrawChangeWalletClicked
   | WalletRewardsWithdrawMaxAmountClicked
   | WalletRewardsWithdrawTransferClicked
+  | WalletBuyEarnRewardsClicked
+  | WalletBuyEarnRewardsViewed

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/index.tsx
@@ -31,7 +31,6 @@ import {
 } from 'data/types'
 
 import Loading from '../template.loading'
-import InterestBanner from './InterestBanner'
 import { getData } from './selectors'
 import SuccessSdd from './template.sdd.success'
 
@@ -49,7 +48,8 @@ class OrderSummaryContainer extends PureComponent<Props> {
 
     this.props.buySellActions.fetchOrders()
 
-    this.props.interestActions.fetchShowInterestCardAfterTransaction({})
+    this.props.interestActions.fetchInterestEligible()
+    this.props.interestActions.fetchInterestRate()
   }
 
   handleOkButton = () => {
@@ -80,7 +80,7 @@ class OrderSummaryContainer extends PureComponent<Props> {
       Loading: () => <Loading />,
       NotAsked: () => <Loading />,
       Success: (val) => {
-        const { order } = val
+        const { interestEligible, interestRate, order } = val
         const { state } = order
         const currencySymbol = getSymbol(getCounterCurrency(order))
         const [recurringBuy] = val.recurringBuyList.filter((rb) => {
@@ -148,25 +148,25 @@ class OrderSummaryContainer extends PureComponent<Props> {
           <SuccessSdd {...val} {...this.props} />
         ) : (
           <OrderSummary
+            analyticsActions={this.props.analyticsActions}
             baseAmount={getBaseAmount(order)}
             baseCurrency={getBaseCurrency(order)}
             counterAmount={getCounterAmount(order)}
             currencySymbol={currencySymbol}
+            frequencyText={frequencyText}
             handleClose={this.props.handleClose}
             handleCompleteButton={handleCompleteButton}
             handleOkButton={this.handleOkButton}
+            interestActions={this.props.interestActions}
+            interestEligible={interestEligible}
+            interestRate={interestRate}
             lockTime={val.lockTime}
             orderState={state}
             orderType={getOrderType(order) as OrderType}
             outputCurrency={order.outputCurrency}
             paymentState={order.attributes?.everypay?.paymentState || null}
             paymentType={order.paymentType}
-            frequencyText={frequencyText}
-          >
-            {val.interestAfterTransaction.show ? (
-              <InterestBanner handleClose={this.props.handleClose} />
-            ) : null}
-          </OrderSummary>
+          />
         )
       }
     })
@@ -188,6 +188,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps): LinkStatePropsTy
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   buySellActions: bindActionCreators(actions.components.buySell, dispatch),
   interestActions: bindActionCreators(actions.components.interest, dispatch),
   recurringBuyActions: bindActionCreators(actions.components.recurringBuy, dispatch),

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/selectors.ts
@@ -5,10 +5,11 @@ import { selectors } from 'data'
 import { RootState } from 'data/rootReducer'
 
 export const getData = (state: RootState) => {
+  const interestEligibleR = selectors.components.interest.getInterestEligible(state)
+  const interestRateR = selectors.components.interest.getInterestRate(state)
   const cardsR = selectors.components.buySell.getBSCards(state)
   const userDataR = selectors.modules.profile.getUserData(state)
   const withdrawLockCheckR = selectors.components.send.getWithdrawLockCheckRule(state)
-  const interestAfterTransactionR = selectors.components.interest.getAfterTransaction(state)
   const recurringBuyListR = selectors.components.recurringBuy.getRegisteredList(state)
   const orderR = selectors.components.buySell.getBSOrder(state)
 
@@ -17,18 +18,28 @@ export const getData = (state: RootState) => {
       cards: ExtractSuccess<typeof cardsR>,
       userData: ExtractSuccess<typeof userDataR>,
       withdrawLockCheck: ExtractSuccess<typeof withdrawLockCheckR>,
-      interestAfterTransaction: ExtractSuccess<typeof interestAfterTransactionR>,
       recurringBuyList: ExtractSuccess<typeof recurringBuyListR>,
-      order: ExtractSuccess<typeof orderR>
+      order: ExtractSuccess<typeof orderR>,
+      interestRate: ExtractSuccess<typeof interestRateR>,
+      interestEligible: ExtractSuccess<typeof interestEligibleR>
     ) => {
       return {
         cards,
-        interestAfterTransaction,
+        interestEligible,
+        interestRate,
         lockTime: withdrawLockCheck?.lockTime || 0,
         order,
         recurringBuyList,
         userData
       }
     }
-  )(cardsR, userDataR, withdrawLockCheckR, interestAfterTransactionR, recurringBuyListR, orderR)
+  )(
+    cardsR,
+    userDataR,
+    withdrawLockCheckR,
+    recurringBuyListR,
+    orderR,
+    interestRateR,
+    interestEligibleR
+  )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/index.tsx
@@ -93,7 +93,7 @@ class BuySell extends PureComponent<Props, State> {
       this.props.deleteGoal(goalID)
     }
     setTimeout(() => {
-      this.props.close()
+      this.props.close(ModalName.SIMPLE_BUY_MODAL)
     }, duration)
   }
 
@@ -304,6 +304,7 @@ const mapStateToProps = (state: RootState) => ({
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   buySellActions: bindActionCreators(actions.components.buySell, dispatch),
   custodialActions: bindActionCreators(actions.custodial, dispatch),
   deleteGoal: (id: string) => dispatch(actions.goals.deleteGoal(id)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8698,6 +8698,11 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+boring-avatars@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/boring-avatars/-/boring-avatars-1.7.0.tgz#70ac7146bbf37d8e69a35544b24f1d75558f868a"
+  integrity sha512-ZNHd8J7C/V0IjQMGQowLJ5rScEFU23WxePigH6rqKcT2Esf0qhYvYxw8s9i3srmlfCnCV00ddBjaoGey1eNOfA==
+
 bowser@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"


### PR DESCRIPTION
## Description (optional)
- Remove the rewards legacy banner
- Add "Earn Rewards" flow to "Buy" flow if user/token is eligible.

### Eligible demo
![wV9JTv1LcO](https://user-images.githubusercontent.com/97299628/175095210-36aa2a79-f802-45ec-a7d1-dd2aa0da4128.gif)

### Not eligible demo
![SJGubaShy4](https://user-images.githubusercontent.com/97299628/175095264-100400ef-3311-47a3-aa7b-a68aa1b5d5e7.gif)

### Button click tracked event
![Blockchain_com_Wallet](https://user-images.githubusercontent.com/97299628/175095315-f83105d9-c5f9-4b3d-a7c7-58a0b31260c0.jpg)

