### PR TITLE
fix(signup): state field value and exchange signup fix

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/signup/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/signup/sagas.ts
@@ -49,8 +49,7 @@ export default ({ api, coreSagas, networks }) => {
       yield call(authNabu)
       yield call(createUser)
       // store initial address in case of US state we add prefix
-      const userState = country === 'US' ? `US-${state}` : state
-      yield call(api.setUserInitialAddress, country, userState)
+      yield call(api.setUserInitialAddress, country, state)
       yield call(coreSagas.settings.fetchSettings)
 
       const guid = yield select(selectors.core.wallet.getGuid)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/SignupForm/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/SignupForm/index.tsx
@@ -107,7 +107,6 @@ const SignupForm = (props: Props) => {
 
   const { data: supportedCountries } = useCountryList({ scope: CountryScope.SIGNUP })
   const { data: supportedUSStates } = useUSStateList()
-
   if (!supportedCountries?.countries || !supportedUSStates?.states) {
     return <></>
   }
@@ -245,7 +244,6 @@ const SignupForm = (props: Props) => {
               component={SelectBox}
               errorBottom
               validate={[required]}
-              normalize={(val) => val && val.code}
               label='Select State'
             />
           </FieldWithoutTopRadius>


### PR DESCRIPTION
## Description (optional)
1. send correct state format to `/address/initial` when signing up via exchange mobile
2. Remove normalization of state value. Value would become undefined after state was chosen, triggering this error
<img width="641" alt="Screen Shot 2022-06-23 at 1 31 16 PM" src="https://user-images.githubusercontent.com/14954836/175399680-82a8e29b-b79b-4472-94d2-ed138496e3a2.png">

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

