### PR TITLE
feat/CI-183/add-status-to-transaction-item

### DIFF
--- a/packages/blockchain-info-components/index.d.ts
+++ b/packages/blockchain-info-components/index.d.ts
@@ -9,10 +9,12 @@ import { DefaultTheme } from 'styled-components'
 import { IcoMoonType } from './src/Icons/Icomoon'
 import { ImageType } from './src/Images/Images'
 import { CoinType, WalletCurrencyType } from '@core/types'
+import { BannerType as BType } from './src/Banners'
 
 export type AllCoinsType = WalletCurrencyType | 'STX'
 export const Badge: FunctionComponent<any>
 export const Banner: FunctionComponent<any>
+export const BannerType: typeof BType
 export const Box: FunctionComponent<any>
 export const BlockchainLoader: FunctionComponent<{
   width?: string

--- a/packages/blockchain-info-components/src/Banners/Banner.js
+++ b/packages/blockchain-info-components/src/Banners/Banner.js
@@ -32,23 +32,32 @@ const BannerContent = styled(Text)`
   }
 `
 
+export const BannerType = {
+  ALERT: 'alert',
+  CAUTION: 'caution',
+  INFORMATIONAL: 'informational',
+  SUCCESS: 'success',
+  WARNING: 'warning',
+  WHITE: 'white'
+}
+
 const selectStyle = (type) => {
   switch (type) {
-    case 'success':
+    case BannerType.SUCCESS:
       return {
         color: 'success',
         icon: 'checkmark-in-circle',
         uppercase: false
       }
-    case 'warning':
+    case BannerType.WARNING:
       return { color: 'error', icon: 'alert-filled', uppercase: true }
-    case 'alert':
+    case BannerType.ALERT:
       return { color: 'blue600', icon: 'bell', uppercase: false }
-    case 'caution':
+    case BannerType.CAUTION:
       return { color: 'brand-yellow', icon: 'alert-filled', uppercase: false }
-    case 'white':
+    case BannerType.WHITE:
       return { color: 'white', icon: null, uppercase: true }
-    case 'informational':
+    case BannerType.INFORMATIONAL:
       return { color: 'grey700', icon: null, uppercase: false }
     default:
       return { color: 'blue600', icon: null, uppercase: false }
@@ -56,10 +65,21 @@ const selectStyle = (type) => {
 }
 
 const Banner = (props) => {
-  const { children, inline, label, size, style: customCss, type, width } = props
+  const {
+    children,
+    icon: customIcon = undefined,
+    inline,
+    label,
+    size,
+    style: customCss,
+    type,
+    width
+  } = props
   const style = selectStyle(type)
-  const { color, icon, uppercase } = style
+  const { color, uppercase } = style
 
+  // For removing default icon value it could be sent null as value
+  const icon = customIcon !== undefined ? customIcon : style.icon
   return (
     <Container
       className={props.className}
@@ -86,9 +106,16 @@ const Banner = (props) => {
 
 Banner.propTypes = {
   children: PropTypes.node.isRequired,
+  icon: PropTypes.string,
   // eslint-disable-next-line react/forbid-prop-types
   style: PropTypes.object,
-  type: PropTypes.oneOf(['success', 'warning', 'alert', 'caution', 'informational']),
+  type: PropTypes.oneOf([
+    BannerType.SUCCESS,
+    BannerType.WARNING,
+    BannerType.ALERT,
+    BannerType.CAUTION,
+    BannerType.INFORMATIONAL
+  ]),
   width: PropTypes.string
 }
 

--- a/packages/blockchain-info-components/src/Banners/Banner.spec.js
+++ b/packages/blockchain-info-components/src/Banners/Banner.spec.js
@@ -2,7 +2,8 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 
-import Banner from './Banner'
+import { Icon } from '../Icons'
+import Banner, { BannerType } from './Banner'
 
 describe('Banner component', () => {
   it('type standard renders correctly', () => {
@@ -12,29 +13,43 @@ describe('Banner component', () => {
   })
 
   it('type alert renders correctly', () => {
-    const component = shallow(<Banner type='alert'>ALERT</Banner>)
+    const component = shallow(<Banner type={BannerType.ALERT}>ALERT</Banner>)
     const tree = toJson(component)
     expect(tree).toMatchSnapshot()
   })
 
   it('type success renders correctly', () => {
-    const component = shallow(<Banner type='success'>SUCCESS</Banner>)
+    const component = shallow(<Banner type={BannerType.SUCCESS}>SUCCESS</Banner>)
+
+    expect(component.find(Icon)).toHaveLength(1)
     const tree = toJson(component)
     expect(tree).toMatchSnapshot()
   })
 
   it('type warning renders correctly', () => {
-    const component = shallow(<Banner type='warning'>WARNING</Banner>)
+    const component = shallow(<Banner type={BannerType.WARNING}>WARNING</Banner>)
     const tree = toJson(component)
     expect(tree).toMatchSnapshot()
   })
 
   it('type caution renders correctly', () => {
     const component = shallow(
-      <Banner type='caution' size='12px' weight={400} width='130%'>
+      <Banner type={BannerType.CAUTION} size='12px' weight={400} width='130%'>
         ALERT
       </Banner>
     )
+    const tree = toJson(component)
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('type success without icon renders correctly', () => {
+    const component = shallow(
+      <Banner type={BannerType.SUCCESS} icon={null}>
+        SUCCESS
+      </Banner>
+    )
+
+    expect(component.find(Icon)).toHaveLength(0)
     const tree = toJson(component)
     expect(tree).toMatchSnapshot()
   })

--- a/packages/blockchain-info-components/src/Banners/__snapshots__/Banner.spec.js.snap
+++ b/packages/blockchain-info-components/src/Banners/__snapshots__/Banner.spec.js.snap
@@ -82,6 +82,21 @@ exports[`Banner component type success renders correctly 1`] = `
 </styled.div>
 `;
 
+exports[`Banner component type success without icon renders correctly 1`] = `
+<styled.div
+  color="success"
+>
+  <Styled(Text)
+    color="success"
+    size="12px"
+    uppercase={false}
+    weight={500}
+  >
+    SUCCESS
+  </Styled(Text)>
+</styled.div>
+`;
+
 exports[`Banner component type warning renders correctly 1`] = `
 <styled.div
   color="error"

--- a/packages/blockchain-info-components/src/Banners/index.js
+++ b/packages/blockchain-info-components/src/Banners/index.js
@@ -1,1 +1,1 @@
-export { default as Banner } from './Banner'
+export { default as Banner, BannerType } from './Banner'

--- a/packages/blockchain-info-components/src/index.js
+++ b/packages/blockchain-info-components/src/index.js
@@ -1,5 +1,5 @@
 export { Badge } from './Badges'
-export { Banner } from './Banners'
+export { Banner, BannerType } from './Banners'
 export { default as Box } from './Box'
 export { Button, ButtonGroup, IconButton } from './Buttons'
 export { Color, Palette } from './Colors/index.ts'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/DebitCard/CardDashboard/TransactionsBox/TransactionsBox.template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/DebitCard/CardDashboard/TransactionsBox/TransactionsBox.template.tsx
@@ -5,10 +5,10 @@ import { IconMinusCircle, IconPlusCircle } from '@blockchain-com/icons'
 import { isEmpty } from 'ramda'
 import styled from 'styled-components'
 
-import { SkeletonRectangle, Text } from 'blockchain-info-components'
+import { Banner, BannerType, SkeletonRectangle, Text } from 'blockchain-info-components'
 import CoinBalanceDisplay from 'components/CoinWithBalance/CoinBalanceDisplay'
 import { selectors } from 'data'
-import { BalanceType, TransactionType } from 'data/components/debitCard/types'
+import { BalanceType, TransactionState, TransactionType } from 'data/components/debitCard/types'
 import { useRemote } from 'hooks'
 
 import {
@@ -33,6 +33,13 @@ const SkeletonLoader = styled.div`
 const TransactionsWrapper = styled.div`
   max-height: 350px;
   overflow: auto;
+`
+
+const StyledBanner = styled(Banner)`
+  max-width: fit-content;
+  display: inline-flex;
+  margin-left: 8px;
+  border: unset;
 `
 
 const LoadingDetail = () => (
@@ -116,20 +123,38 @@ const TransactionsBox = () => {
     return type === TransactionType.PAYMENT ? <IconMinusCircle /> : <IconPlusCircle />
   }
 
+  const getBannerType = (state: TransactionState) => {
+    switch (state) {
+      case TransactionState.COMPLETED:
+        return BannerType.SUCCESS
+      case TransactionState.CANCELLED:
+      case TransactionState.DECLINED:
+        return BannerType.WARNING
+      case TransactionState.PENDING:
+      default:
+        return BannerType.INFORMATIONAL
+    }
+  }
+
   const ListComponent = () => (
     <>
       {!data || isEmpty(data) ? (
         <EmptyList />
       ) : (
         <TransactionsWrapper>
-          {data.map(({ id, merchantName, originalAmount, type, userTransactionTime }) => (
+          {data.map(({ id, merchantName, originalAmount, state, type, userTransactionTime }) => (
             <BoxRowWithBorder key={id}>
               <Icon color='blue300' label='Spent' size='sm'>
                 {generateTransactionIcon(type)}
               </Icon>
               <BoxRowItemTitle>
                 {generateTransactionTitle(type, originalAmount, merchantName)}
-                <BoxRowItemSubTitle>{dateTimeFormatter(userTransactionTime)}</BoxRowItemSubTitle>
+                <BoxRowItemSubTitle>
+                  {dateTimeFormatter(userTransactionTime)}
+                  <StyledBanner type={getBannerType(state)} icon={null}>
+                    {state}
+                  </StyledBanner>
+                </BoxRowItemSubTitle>
               </BoxRowItemTitle>
               <CoinBalanceDisplay coin={originalAmount.symbol} balance={originalAmount.value} />
             </BoxRowWithBorder>


### PR DESCRIPTION
## Description 
* Add banner types and export it, add possibility of removing default icon or adding a custom one in banner component
* Add display transaction state logic

## Demo
![image](https://user-images.githubusercontent.com/97310750/176211907-20eff5bb-d4c2-4813-aa49-05e51546f1f3.png)


