### PR TITLE
Hotfix/extra kyc form single selection selected update

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/template.success.tsx
@@ -168,8 +168,12 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
             child.checked = !child.checked
             isChanged = true
           }
-          // for dropdown options remove all other checked values
-          if (child.id !== childId && node.isDropdown && child.checked) {
+          // remove all other checked values
+          if (
+            child.id !== childId &&
+            child.checked &&
+            node.type !== NodeItemTypes.MULTIPLE_SELECTION
+          ) {
             child.checked = false
             isChanged = true
           }


### PR DESCRIPTION
In Extra KYC form in the onboarding flow, when a SINGLE_SELECTION node changes the value more than once, it wasn't updating the previous selected value to false. Now is being updated properly
