### PR TITLE
feat: disable "Add [coin]" button when coin not eligible on interest flow

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/AccountSummary/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/AccountSummary/selectors.ts
@@ -11,6 +11,7 @@ export const getCurrency = (state: RootState) => {
 export const getData = (state: RootState) => {
   const accountBalancesR = selectors.components.interest.getInterestAccountBalance(state)
   const interestLimitsR = selectors.components.interest.getInterestLimits(state)
+  const interestEligibleR = selectors.components.interest.getInterestEligible(state)
   const interestRateR = selectors.components.interest.getInterestRate(state)
   const flagEDDInterestFileUpload = selectors.core.walletOptions
     .getEDDInterestFileUpload(state)
@@ -20,12 +21,14 @@ export const getData = (state: RootState) => {
     (
       accountBalances: ExtractSuccess<typeof accountBalancesR>,
       interestLimits: ExtractSuccess<typeof interestLimitsR>,
-      interestRate: ExtractSuccess<typeof interestRateR>
+      interestRate: ExtractSuccess<typeof interestRateR>,
+      interestEligible: ExtractSuccess<typeof interestEligibleR>
     ) => ({
       accountBalances,
       flagEDDInterestFileUpload,
+      interestEligible,
       interestLimits,
       interestRate
     })
-  )(accountBalancesR, interestLimitsR, interestRateR)
+  )(accountBalancesR, interestLimitsR, interestRateR, interestEligibleR)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Interest/AccountSummary/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Interest/AccountSummary/template.success.tsx
@@ -40,6 +40,7 @@ const AccountSummary: React.FC<Props> = (props) => {
     handleClose,
     handleDepositClick,
     interestActions,
+    interestEligible,
     interestLimits,
     interestRate,
     interestUploadDocumentActions,
@@ -62,6 +63,16 @@ const AccountSummary: React.FC<Props> = (props) => {
   const accountBalanceStandard = convertBaseToStandard(coin, accountBalanceBase)
   const interestBalanceStandard = convertBaseToStandard(coin, interestBalanceBase)
   const pendingInterestStandard = convertBaseToStandard(coin, pendingInterestBase)
+
+  const getInterestEligibility = () => {
+    const interestEligibility = interestEligible[coin]
+    if (!interestEligibility) {
+      return false
+    }
+    return interestEligibility.eligible
+  }
+
+  const isDepositEnabled = getInterestEligibility()
 
   const handleBuyCoin = useCallback(() => {
     analyticsActions.trackEvent({
@@ -332,6 +343,7 @@ const AccountSummary: React.FC<Props> = (props) => {
               data-e2e='interestDeposit'
               height='48px'
               nature='primary'
+              disabled={!isDepositEnabled}
               onClick={handleDepositClick}
               width='192px'
             >


### PR DESCRIPTION
## Description (optional)

On the left we have a user with eligible coins and on the right we have a US user with no eligibility but with already used rewards account so it's possible to buy or to withdraw the coins

![IIA080tmDp](https://user-images.githubusercontent.com/97299628/176955691-162a5004-9f54-48a3-b40f-5cd62a982b68.gif)

