### PR TITLE
fix(Flyout): only display error if is string

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Errors/Oops.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/Errors/Oops.tsx
@@ -59,7 +59,7 @@ const Failure = (props: FailurePropsType) => {
             defaultMessage='Oops. Something went wrong on our side. Please try again.'
           />
         </Title>
-        {props.errorMessage && (
+        {typeof props.errorMessage === 'string' && (
           <ErrorTextContainer>
             <ErrorText>
               <Icon label='alert' color='red600'>


### PR DESCRIPTION
Checks if the errorMessage is actually a string, this
is needed because errors can be objects and React is
throwing errors when trying to render an object in the view
