### PR TITLE
fix(PaymentMethods): update styles to match rest of option

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/ArriveInThreeDaysEasyBankTransferCard/ArriveInThreeDaysEasyBankTransferCard.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/ArriveInThreeDaysEasyBankTransferCard/ArriveInThreeDaysEasyBankTransferCard.tsx
@@ -1,54 +1,55 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Icon } from '@blockchain-com/constellation'
-import { IconBank, IconChevronRight } from '@blockchain-com/icons'
+import { Icon as ConstellationIcon } from '@blockchain-com/constellation'
+import { IconBank } from '@blockchain-com/icons'
 
-import { Text } from 'blockchain-info-components'
-import { DisplayContainer } from 'components/BuySell'
+import { Icon } from 'blockchain-info-components'
+import { Description, DisplayContainer, DisplaySubTitle, DisplayTitle } from 'components/BuySell'
 import { Expanded, Flex } from 'components/Flex'
 import { Padding } from 'components/Padding'
 
+import { IconContainer } from '../Methods.styles'
 import { ArriveInThreeDaysEasyBankTransferCardComponent } from './ArriveInThreeDaysEasyBankTransferCard.types'
 
 export const ArriveInThreeDaysEasyBankTransferCard: ArriveInThreeDaysEasyBankTransferCardComponent =
   ({ onClick }) => {
     const icon = (
-      <Icon label='' color='blue600'>
-        <IconBank />
-      </Icon>
+      <IconContainer>
+        <ConstellationIcon label='bank-icon' color='blue600'>
+          <IconBank />
+        </ConstellationIcon>
+      </IconContainer>
     )
 
     const body = (
       <Flex flexDirection='column' gap={4}>
         <Flex flexDirection='column'>
-          <Text size='16px' lineHeight='24px' weight={600}>
+          <DisplayTitle>
             <FormattedMessage
               id='modals.simplebuy.instant_easy_bank_transfer.title'
               defaultMessage='Easy Bank Transfer '
             />
-          </Text>
-          <Text size='14px' lineHeight='20px' weight={500}>
+          </DisplayTitle>
+          <DisplaySubTitle>
             <FormattedMessage
               id='modals.simplebuy.instant_easy_bank_transfer.sub_title'
               defaultMessage='Should arrive in 3 business days'
             />
-          </Text>
+          </DisplaySubTitle>
         </Flex>
 
-        <Text size='12px' lineHeight='16px' weight={500} color='grey600'>
+        <Description>
           <FormattedMessage
             id='modals.simplebuy.instant_easy_bank_transfer.content'
             defaultMessage='Quick and secure without entering account details.'
           />
-        </Text>
+        </Description>
       </Flex>
     )
 
     const chevronIcon = (
       <Padding top={4}>
-        <Icon label='chevron-right' color='grey700' size='sm'>
-          <IconChevronRight />
-        </Icon>
+        <Icon name='chevron-right' size='24px' color='grey400' />
       </Padding>
     )
 
@@ -60,7 +61,7 @@ export const ArriveInThreeDaysEasyBankTransferCard: ArriveInThreeDaysEasyBankTra
 
             <Expanded>{body}</Expanded>
 
-            {chevronIcon}
+            <Flex alignItems='center'>{chevronIcon}</Flex>
           </Flex>
         </Expanded>
       </DisplayContainer>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/InstantlyEasyBankTransferCard/InstantlyEasyBankTransferCard.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/InstantlyEasyBankTransferCard/InstantlyEasyBankTransferCard.tsx
@@ -1,55 +1,56 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Icon } from '@blockchain-com/constellation'
-import { IconBank, IconChevronRight } from '@blockchain-com/icons'
+import { Icon as ConstellationIcon } from '@blockchain-com/constellation'
+import { IconBank } from '@blockchain-com/icons'
 
-import { Text } from 'blockchain-info-components'
-import { DisplayContainer } from 'components/BuySell'
+import { Icon } from 'blockchain-info-components'
+import { Description, DisplayContainer, DisplaySubTitle, DisplayTitle } from 'components/BuySell'
 import { Expanded, Flex } from 'components/Flex'
 import { Padding } from 'components/Padding'
 
+import { IconContainer } from '../Methods.styles'
 import { InstantlyEasyBankTransferCardComponent } from './InstantlyEasyBankTransferCard.types'
 
 export const InstantlyEasyBankTransferCard: InstantlyEasyBankTransferCardComponent = ({
   onClick
 }) => {
   const icon = (
-    <Icon label='' color='blue600'>
-      <IconBank />
-    </Icon>
+    <IconContainer>
+      <ConstellationIcon label='bank-icon' color='blue600'>
+        <IconBank />
+      </ConstellationIcon>
+    </IconContainer>
   )
 
   const body = (
     <Flex flexDirection='column' gap={4}>
       <Flex flexDirection='column'>
-        <Text size='16px' lineHeight='24px' weight={600}>
+        <DisplayTitle>
           <FormattedMessage
             id='modals.simplebuy.instant_easy_bank_transfer.title'
             defaultMessage='Easy Bank Transfer '
           />
-        </Text>
-        <Text size='14px' lineHeight='20px' weight={500}>
+        </DisplayTitle>
+        <DisplaySubTitle>
           <FormattedMessage
             id='modals.simplebuy.instant_easy_bank_transfer.sub_title'
             defaultMessage='Should arrive instantly'
           />
-        </Text>
+        </DisplaySubTitle>
       </Flex>
 
-      <Text size='12px' lineHeight='16px' weight={500} color='grey600'>
+      <Description>
         <FormattedMessage
           id='modals.simplebuy.instant_easy_bank_transfer.content'
           defaultMessage='Quick and secure without entering account details.'
         />
-      </Text>
+      </Description>
     </Flex>
   )
 
   const chevronIcon = (
     <Padding top={4}>
-      <Icon label='chevron-right' color='grey700' size='sm'>
-        <IconChevronRight />
-      </Icon>
+      <Icon name='chevron-right' size='24px' color='grey400' />
     </Padding>
   )
 
@@ -61,7 +62,7 @@ export const InstantlyEasyBankTransferCard: InstantlyEasyBankTransferCardCompone
 
           <Expanded>{body}</Expanded>
 
-          {chevronIcon}
+          <Flex alignItems='center'>{chevronIcon}</Flex>
         </Flex>
       </Expanded>
     </DisplayContainer>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/Methods.styles.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/Methods.styles.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components'
+
+import { Text } from 'blockchain-info-components'
+import { FlyoutWrapper } from 'components/Flyout'
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  height: 100%;
+`
+
+export const TopText = styled(Text)`
+  display: flex;
+  align-items: center;
+  margin-bottom: 7px;
+`
+
+export const PaymentsWrapper = styled.div`
+  border-top: 1px solid ${(props) => props.theme.grey000};
+`
+
+export const NoMethods = styled(FlyoutWrapper)`
+  text-align: center;
+`
+
+export const IconContainer = styled.div`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-color: ${(props) => props.theme.blue000};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/OneDayBankTransferCard/OneDayBankTransferCard.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/OneDayBankTransferCard/OneDayBankTransferCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Icon } from '@blockchain-com/constellation'
-import { IconArrowDown, IconChevronRight } from '@blockchain-com/icons'
+import { Icon as ConstellationIcon } from '@blockchain-com/constellation'
+import { IconArrowDown } from '@blockchain-com/icons'
 
-import { Text } from 'blockchain-info-components'
-import { DisplayContainer } from 'components/BuySell'
+import { Icon } from 'blockchain-info-components'
+import { Description, DisplayContainer, DisplaySubTitle, DisplayTitle } from 'components/BuySell'
 import { Expanded, Flex } from 'components/Flex'
 import { Padding } from 'components/Padding'
 
@@ -14,43 +14,41 @@ import { OneDayBankTransferCardComponent } from './OneDayBankTransferCard.types'
 export const OneDayBankTransferCard: OneDayBankTransferCardComponent = ({ onClick }) => {
   const icon = (
     <IconContainer>
-      <Icon label='' color='blue600'>
+      <ConstellationIcon label='bank-icon' color='blue600'>
         <IconArrowDown />
-      </Icon>
+      </ConstellationIcon>
     </IconContainer>
   )
 
   const body = (
     <Flex flexDirection='column' gap={4}>
       <Flex flexDirection='column'>
-        <Text size='16px' lineHeight='24px' weight={600}>
+        <DisplayTitle>
           <FormattedMessage
             id='modals.simplebuy.one_day_bank_transfer.title'
             defaultMessage='Bank Transfer'
           />
-        </Text>
-        <Text size='14px' lineHeight='20px' weight={500}>
+        </DisplayTitle>
+        <DisplaySubTitle>
           <FormattedMessage
             id='modals.simplebuy.one_day_bank_transfer.sub_title'
             defaultMessage='Should arrive in 1 business day '
           />
-        </Text>
+        </DisplaySubTitle>
       </Flex>
 
-      <Text size='12px' lineHeight='16px' weight={500} color='grey600'>
+      <Description>
         <FormattedMessage
           id='modals.simplebuy.one_day_bank_transfer.content'
           defaultMessage='Bank fees may apply.'
         />
-      </Text>
+      </Description>
     </Flex>
   )
 
   const chevronIcon = (
     <Padding top={4}>
-      <Icon label='chevron-right' color='grey700' size='sm'>
-        <IconChevronRight />
-      </Icon>
+      <Icon name='chevron-right' size='24px' color='grey400' />
     </Padding>
   )
 
@@ -62,7 +60,7 @@ export const OneDayBankTransferCard: OneDayBankTransferCardComponent = ({ onClic
 
           <Expanded>{body}</Expanded>
 
-          {chevronIcon}
+          <Flex alignItems='center'>{chevronIcon}</Flex>
         </Flex>
       </Expanded>
     </DisplayContainer>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/PaymentCard/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/PaymentCard/index.tsx
@@ -33,6 +33,8 @@ const CardContainer = styled.div`
 `
 const ChevronWrapper = styled.div`
   height: 125px;
+  display: flex;
+  align-items: center;
   ${media.mobile`
     height: 132px;
   `};

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/SameDayBankTransferCard/SameDayBankTransferCard.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/SameDayBankTransferCard/SameDayBankTransferCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Icon } from '@blockchain-com/constellation'
-import { IconArrowDown, IconChevronRight } from '@blockchain-com/icons'
+import { Icon as ConstellationIcon } from '@blockchain-com/constellation'
+import { IconArrowDown } from '@blockchain-com/icons'
 
-import { Text } from 'blockchain-info-components'
-import { DisplayContainer } from 'components/BuySell'
+import { Icon } from 'blockchain-info-components'
+import { Description, DisplayContainer, DisplaySubTitle, DisplayTitle } from 'components/BuySell'
 import { Expanded, Flex } from 'components/Flex'
 import { Padding } from 'components/Padding'
 
@@ -14,43 +14,41 @@ import { SameDayBankTransferCardComponent } from './SameDayBankTransferCard.type
 export const SameDayBankTransferCard: SameDayBankTransferCardComponent = ({ onClick }) => {
   const icon = (
     <IconContainer>
-      <Icon label='' color='blue600'>
+      <ConstellationIcon label='bank-icon' color='blue600'>
         <IconArrowDown />
-      </Icon>
+      </ConstellationIcon>
     </IconContainer>
   )
 
   const body = (
     <Flex flexDirection='column' gap={4}>
       <Flex flexDirection='column'>
-        <Text size='16px' lineHeight='24px' weight={600}>
+        <DisplayTitle>
           <FormattedMessage
             id='modals.simplebuy.same_day_bank_transfer.title'
             defaultMessage='Bank Transfer'
           />
-        </Text>
-        <Text size='14px' lineHeight='20px' weight={500}>
+        </DisplayTitle>
+        <DisplaySubTitle>
           <FormattedMessage
             id='modals.simplebuy.same_day_bank_transfer.sub_title'
             defaultMessage='Should arrive same day'
           />
-        </Text>
+        </DisplaySubTitle>
       </Flex>
 
-      <Text size='12px' lineHeight='16px' weight={500} color='grey600'>
+      <Description>
         <FormattedMessage
           id='modals.simplebuy.same_day_bank_transfer.content'
           defaultMessage='Transfers are made through the UK Faster Payments System and usually arrive in seconds.'
         />
-      </Text>
+      </Description>
     </Flex>
   )
 
   const chevronIcon = (
     <Padding top={4}>
-      <Icon label='chevron-right' color='grey700' size='sm'>
-        <IconChevronRight />
-      </Icon>
+      <Icon name='chevron-right' size='24px' color='grey400' />
     </Padding>
   )
 
@@ -62,7 +60,7 @@ export const SameDayBankTransferCard: SameDayBankTransferCardComponent = ({ onCl
 
           <Expanded>{body}</Expanded>
 
-          {chevronIcon}
+          <Flex alignItems='center'>{chevronIcon}</Flex>
         </Flex>
       </Expanded>
     </DisplayContainer>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/WireTransferCard/WireTransferCard.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/WireTransferCard/WireTransferCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Icon } from '@blockchain-com/constellation'
-import { IconArrowDown, IconChevronRight } from '@blockchain-com/icons'
+import { Icon as ConstellationIcon } from '@blockchain-com/constellation'
+import { IconArrowDown } from '@blockchain-com/icons'
 
-import { Text } from 'blockchain-info-components'
-import { DisplayContainer } from 'components/BuySell'
+import { Icon } from 'blockchain-info-components'
+import { Description, DisplayContainer, DisplaySubTitle, DisplayTitle } from 'components/BuySell'
 import { Expanded, Flex } from 'components/Flex'
 import { Padding } from 'components/Padding'
 
@@ -14,43 +14,41 @@ import { WireTransferCardComponent } from './WireTransferCard.types'
 export const WireTransferCard: WireTransferCardComponent = ({ onClick }) => {
   const icon = (
     <IconContainer>
-      <Icon label='' color='blue600'>
+      <ConstellationIcon label='bank-icon' color='blue600'>
         <IconArrowDown />
-      </Icon>
+      </ConstellationIcon>
     </IconContainer>
   )
 
   const body = (
     <Flex flexDirection='column' gap={4}>
       <Flex flexDirection='column'>
-        <Text size='16px' lineHeight='24px' weight={600}>
+        <DisplayTitle>
           <FormattedMessage
             id='modals.simplebuy.wire_transfer.title'
             defaultMessage='Wire Transfer'
           />
-        </Text>
-        <Text size='14px' lineHeight='20px' weight={500}>
+        </DisplayTitle>
+        <DisplaySubTitle>
           <FormattedMessage
             id='modals.simplebuy.wire_transfer.sub_title'
             defaultMessage='Should arrive in 3-5 business days '
           />
-        </Text>
+        </DisplaySubTitle>
       </Flex>
 
-      <Text size='12px' lineHeight='16px' weight={500} color='grey600'>
+      <Description>
         <FormattedMessage
           id='modals.simplebuy.wire_transfer.content'
           defaultMessage='For transferring large amounts. Bank fees may apply.'
         />
-      </Text>
+      </Description>
     </Flex>
   )
 
   const chevronIcon = (
     <Padding top={4}>
-      <Icon label='chevron-right' color='grey700' size='sm'>
-        <IconChevronRight />
-      </Icon>
+      <Icon name='chevron-right' size='24px' color='grey400' />
     </Padding>
   )
 
@@ -62,7 +60,7 @@ export const WireTransferCard: WireTransferCardComponent = ({ onClick }) => {
 
           <Expanded>{body}</Expanded>
 
-          {chevronIcon}
+          <Flex alignItems='center'>{chevronIcon}</Flex>
         </Flex>
       </Expanded>
     </DisplayContainer>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/Methods/index.tsx
@@ -5,7 +5,6 @@ import {
   DEFAULT_CARD_SVG_LOGO
 } from 'blockchain-wallet-v4-frontend/src/modals/BuySell/PaymentMethods/model'
 import { Form, reduxForm } from 'redux-form'
-import styled from 'styled-components'
 
 import {
   BSPaymentMethodType,
@@ -27,37 +26,11 @@ import BankWire from './BankWire'
 import GooglePay from './GooglePay'
 import { InstantlyEasyBankTransferCard } from './InstantlyEasyBankTransferCard'
 import LinkBank from './LinkBank'
+import { IconContainer, NoMethods, PaymentsWrapper, TopText, Wrapper } from './Methods.styles'
 import { OneDayBankTransferCard } from './OneDayBankTransferCard'
 import PaymentCard from './PaymentCard'
 import { SameDayBankTransferCard } from './SameDayBankTransferCard'
 import { WireTransferCard } from './WireTransferCard'
-
-const Wrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-  flex-direction: column;
-  height: 100%;
-`
-const TopText = styled(Text)`
-  display: flex;
-  align-items: center;
-  margin-bottom: 7px;
-`
-const PaymentsWrapper = styled.div`
-  border-top: 1px solid ${(props) => props.theme.grey000};
-`
-const NoMethods = styled(FlyoutWrapper)`
-  text-align: center;
-`
-const IconContainer = styled.div`
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background-color: ${(props) => props.theme.blue000};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`
 
 export type Props = OwnProps & SuccessStateType
 
@@ -448,22 +421,6 @@ const Methods = (props: Props) => {
           ) : null}
 
           {bankTransferCard}
-
-          {bankTransfer ? (
-            <LinkBank
-              {...bankTransfer}
-              // @ts-ignore
-              icon={getIcon({ type: BSPaymentTypes.BANK_TRANSFER })}
-              onClick={() =>
-                handlePaymentMethodSelect({
-                  method: {
-                    ...bankTransfer.value,
-                    type: BSPaymentTypes.LINK_BANK
-                  }
-                })
-              }
-            />
-          ) : null}
 
           {bankMethodCard}
         </PaymentsWrapper>


### PR DESCRIPTION
## Description
Remove duplicated Wire Transfer item in the payment methods and update style to match other items

Before:
<img width="682" alt="Screen Shot 2022-07-08 at 3 07 38 PM" src="https://user-images.githubusercontent.com/99212903/178047123-c1b81f68-6fe5-4488-88bc-0af0a8b518eb.png">


After:
<img width="636" alt="Screen Shot 2022-07-08 at 3 06 47 PM" src="https://user-images.githubusercontent.com/99212903/178047155-24f5339b-19ac-4859-8f25-5d5d2529f81b.png">

