### PR TITLE
fix(AppleAndGooglePay): this changes the banner order

### DIFF
--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -35,7 +35,7 @@
         "addCheckoutPaymentProvider": true,
         "addStripePaymentProvider": false,
         "applePayPaymentMethod": true,
-        "appleAndGooglePayPromoBanner": false,
+        "appleAndGooglePayPromoBanner": true,
         "bindIntegrationArEnabled": true,
         "coinViewV2": false,
         "completeYourProfile": true,

--- a/packages/blockchain-wallet-v4-frontend/src/hooks/useApplePay/utils/isApplePayAvailable/isApplePayAvailable.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/hooks/useApplePay/utils/isApplePayAvailable/isApplePayAvailable.ts
@@ -1,2 +1,11 @@
-export const isApplePayAvailable = (): boolean =>
-  (window.ApplePaySession && ApplePaySession?.canMakePayments()) || false
+export const isApplePayAvailable = (): boolean => {
+  if (!window.ApplePaySession) return false
+
+  try {
+    return ApplePaySession.canMakePayments()
+  } catch (err) {
+    console.error(err)
+
+    return false
+  }
+}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
@@ -250,6 +250,8 @@ export const getData = (state: RootState): { bannerToShow: BannerType } => {
     bannerToShow = 'completeYourProfile'
   } else if (showDocResubmitBanner && !isKycPendingOrVerified) {
     bannerToShow = 'resubmit'
+  } else if (showAppleAndGooglePayBanner) {
+    bannerToShow = 'appleAndGooglePay'
   } else if (showServicePriceUnavailableBanner) {
     bannerToShow = 'servicePriceUnavailable'
   } else if (showKYCFinishBanner) {
@@ -266,8 +268,6 @@ export const getData = (state: RootState): { bannerToShow: BannerType } => {
     bannerToShow = 'earnRewards'
   } else if (showRecurringBuyBanner) {
     bannerToShow = 'recurringBuys'
-  } else if (showAppleAndGooglePayBanner) {
-    bannerToShow = 'appleAndGooglePay'
   } else {
     bannerToShow = null
   }


### PR DESCRIPTION
Updates the order of the banners so apple and google pay
is first, and catch error when trying to check for apple pay
availability on safari
