### PR TITLE
feat(NabuError): log all nabu errors to segment

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/analytics/types/errors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/analytics/types/errors.ts
@@ -23,6 +23,7 @@ type ErrorSource = 'CLIENT' | 'NABU' | 'UNKNOWN'
 
 export type ClientErrorProperties = {
   action?: string
+  category?: string[]
   error: ErrorType
   network_endpoint?: string
   network_error_code?: number

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/NabuError.test.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/NabuError.test.ts
@@ -63,4 +63,14 @@ describe('NabuError()', () => {
     expect(actions[0].title).toEqual('Go to enter amount')
     expect(actions[1].title).toEqual('Blockchain')
   })
+
+  it('Should include the error categories when available', () => {
+    const error = new NabuError({
+      categories: ['TestCategory'],
+      message: 'Message',
+      title: 'Title'
+    })
+
+    expect(error.categories).toEqual(['TestCategory'])
+  })
 })

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/NabuError.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/NabuError.ts
@@ -7,13 +7,16 @@ class NabuError extends Error {
 
   message: string
 
+  categories?: string[]
+
   actions?: NabuErrorAction[]
 
-  constructor({ actions, icon, message, title }: NabuErrorProps) {
+  constructor({ actions, categories, icon, message, title }: NabuErrorProps) {
     super(title)
 
     this.title = title
     this.message = message
+    this.categories = categories
     this.icon = icon
     this.actions = actions
   }

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/NabuError.types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/NabuError.types.ts
@@ -15,6 +15,7 @@ type NabuErrorIconProps = {
 
 type NabuErrorProps = {
   actions?: NabuErrorAction[]
+  categories?: string[]
   icon?: NabuErrorIconProps
   message: string
   title: string

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/createNabuErrorAnalyticsInterceptor/createNabuErrorAnalyticsInterceptor.test.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/createNabuErrorAnalyticsInterceptor/createNabuErrorAnalyticsInterceptor.test.ts
@@ -1,0 +1,46 @@
+import { createNabuErrorAnalyticsInterceptor, NabuError } from 'services/errors'
+
+describe('createNabuErrorAnalyticsInterceptor()', () => {
+  it('Should not handle error that is not nabu', async () => {
+    const dispatchSpy = jest.fn()
+    const error = new Error()
+
+    const interceptor = createNabuErrorAnalyticsInterceptor(dispatchSpy)
+
+    const promise = interceptor(error)
+
+    await expect(promise).rejects.toEqual(error)
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('Should push the nabu error to the analytics service', async () => {
+    const dispatchSpy = jest.fn()
+    const error = new NabuError({
+      categories: ['TestCategory'],
+      message: 'Message',
+      title: 'Error title'
+    })
+
+    const interceptor = createNabuErrorAnalyticsInterceptor(dispatchSpy)
+
+    const promise = interceptor(error)
+
+    await expect(promise).rejects.toEqual(error)
+
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      payload: {
+        key: 'Client Error',
+        properties: {
+          category: ['TestCategory'],
+          error: 'NABU_ERROR',
+          network_error_description: error.message,
+          network_error_type: 'NABU_ERROR',
+          source: 'NABU',
+          title: error.title
+        }
+      },
+      type: 'trackEvent'
+    })
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/createNabuErrorAnalyticsInterceptor/createNabuErrorAnalyticsInterceptor.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/createNabuErrorAnalyticsInterceptor/createNabuErrorAnalyticsInterceptor.ts
@@ -1,0 +1,29 @@
+import { actions } from 'data'
+import { ClientErrorProperties } from 'data/analytics/types/errors'
+import { Analytics } from 'data/types'
+
+import { isNabuError } from '../isNabuError'
+import { CreateNabuErrorAnalyticsInterceptorUtility } from './createNabuErrorAnalyticsInterceptor.types'
+
+export const createNabuErrorAnalyticsInterceptor: CreateNabuErrorAnalyticsInterceptorUtility =
+  (dispatch) => (error) => {
+    if (isNabuError(error)) {
+      const clientError: ClientErrorProperties = {
+        category: error.categories,
+        error: 'NABU_ERROR',
+        network_error_description: error.message,
+        network_error_type: 'NABU_ERROR',
+        source: 'NABU',
+        title: error.title
+      }
+
+      dispatch(
+        actions.analytics.trackEvent({
+          key: Analytics.CLIENT_ERROR,
+          properties: clientError
+        })
+      )
+    }
+
+    return Promise.reject(error)
+  }

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/createNabuErrorAnalyticsInterceptor/createNabuErrorAnalyticsInterceptor.types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/createNabuErrorAnalyticsInterceptor/createNabuErrorAnalyticsInterceptor.types.ts
@@ -1,0 +1,5 @@
+import { Dispatch } from 'redux'
+
+export type CreateNabuErrorAnalyticsInterceptorUtility = (
+  dispatch: Dispatch
+) => (error: Error) => Promise<Error>

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/createNabuErrorAnalyticsInterceptor/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/createNabuErrorAnalyticsInterceptor/index.ts
@@ -1,0 +1,1 @@
+export * from './createNabuErrorAnalyticsInterceptor'

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './createNabuErrorAnalyticsInterceptor'
 export * from './createNabuErrorFulfilledInterceptor'
 export * from './createNabuErrorRejectedInterceptor'
 export * from './isNabuError'

--- a/packages/blockchain-wallet-v4-frontend/src/store/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/store/index.js
@@ -15,7 +15,7 @@ import { ApiSocket, createWalletApi, HorizonStreamingService, Socket } from '@co
 import { serializer } from '@core/types'
 import { actions, rootReducer, rootSaga, selectors } from 'data'
 import { isBrowserSupported } from 'services/browser'
-import { createNabuErrorFulfilledInterceptor, createNabuErrorRejectedInterceptor } from "services/errors/NabuError"
+import { createNabuErrorFulfilledInterceptor, createNabuErrorRejectedInterceptor, createNabuErrorAnalyticsInterceptor } from "services/errors/NabuError"
 import axios from "axios"
 
 import {
@@ -103,7 +103,7 @@ const configuredStore = async function () {
   axios.interceptors.response.use(
     createNabuErrorFulfilledInterceptor(),
     createNabuErrorRejectedInterceptor()
-  );
+  )
   
   const api = createWalletApi({
     apiKey: '1770d5d9-bcea-4d28-ad21-6cbd5be018a8',
@@ -161,6 +161,11 @@ const configuredStore = async function () {
   })
 
   store.dispatch(actions.goals.defineGoals())
+
+  axios.interceptors.response.use(
+    (response) => response,
+    createNabuErrorAnalyticsInterceptor(store.dispatch)
+  )
 
   return {
     history,


### PR DESCRIPTION
## Description
Add an interception to axios to intercept and log all nabu errors to segment

## Testing Steps
- Run app locally and open the [segment debugger](https://app.segment.com/blockchain/sources/web_staging/debugger) for staging
- Now for every nabu error you should see the error in segment a few seconds later


<img width="2351" alt="Screen Shot 2022-07-21 at 11 38 33 AM" src="https://user-images.githubusercontent.com/99212903/180244062-2ee3846f-1d1f-45d4-9b6e-2d14f595d6e0.png">
<img width="2560" alt="Screen Shot 2022-07-21 at 11 38 52 AM" src="https://user-images.githubusercontent.com/99212903/180244237-f0b541db-ca93-4e49-9e55-e44a4951466b.png">

