### PR TITLE
fix(Card/Bank): trim bank/card name when reach full width

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Flyout/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Flyout/model.tsx
@@ -613,7 +613,15 @@ const renderBankSubText = (
 
 const renderBank = (value: BSPaymentMethodType | BankTransferAccountType | BeneficiaryType) => (
   <>
-    <DisplayValue>{renderBankText(value)}</DisplayValue>
+    <DisplayValue
+      style={{
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap'
+      }}
+    >
+      {renderBankText(value)}
+    </DisplayValue>
     <DisplayTitle>{renderBankSubText(value)}</DisplayTitle>
   </>
 )

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/Payment/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/Payment/index.tsx
@@ -98,7 +98,9 @@ const Payment: React.FC<Props> = (props: Props) => {
       >
         <DisplayPaymentIcon showBackground={!props.method}>{renderIcon()}</DisplayPaymentIcon>
 
-        <PaymentText isMethod={!!props.method}>{renderText()}</PaymentText>
+        <PaymentText style={{ minWidth: 0 }} isMethod={!!props.method}>
+          {renderText()}
+        </PaymentText>
 
         {!props.isSddFlow && (
           <PaymentArrowContainer>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/LinkedPaymentAccounts/Accounts/Bank/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/LinkedPaymentAccounts/Accounts/Bank/index.tsx
@@ -45,11 +45,20 @@ const Bank = ({ icon, onClick, text, value }: Props) => {
   return (
     <DisplayContainer data-e2e={`sb${type.toLowerCase()}Banks`} role='button' onClick={onClick}>
       <DisplayIcon>{icon}</DisplayIcon>
-      <MultiRowContainer>
+      <MultiRowContainer style={{ minWidth: 0 }}>
         <Flex justifyContent='space-between'>
-          <StyledValue asTitle>{text}</StyledValue>
+          <StyledValue
+            asTitle
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap'
+            }}
+          >
+            {text}
+          </StyledValue>
 
-          {!!details && <StyledValue asTitle>***{details.accountNumber}</StyledValue>}
+          {!!details && <StyledTitle asValue>***{details.accountNumber}</StyledTitle>}
         </Flex>
 
         <Flex justifyContent='space-between'>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/LinkedPaymentAccounts/Accounts/Card/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/LinkedPaymentAccounts/Accounts/Card/index.tsx
@@ -42,10 +42,19 @@ const Card: React.FC<Props> = ({ icon, onClick, text, value }) => {
   return (
     <DisplayContainer data-e2e={`sb${type.toLowerCase()}Cards`} role='button' onClick={onClick}>
       <DisplayIcon>{icon}</DisplayIcon>
-      <MultiRowContainer>
+      <MultiRowContainer style={{ minWidth: 0 }}>
         <Flex justifyContent='space-between'>
-          <StyledValue asTitle>{text.toLowerCase()}</StyledValue>
-          {!!card && <StyledTitle asValue>***{card.number}</StyledTitle>}
+          <StyledValue
+            asTitle
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap'
+            }}
+          >
+            {text.toLowerCase()}
+          </StyledValue>
+          {!!card && <StyledTitle asValue>****{card.number}</StyledTitle>}
         </Flex>
 
         <Flex justifyContent='space-between'>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/template.success.tsx
@@ -81,10 +81,19 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
                     <Image name={getBankLogoImageName(account.details?.bankName)} />
                   </Flex>
 
-                  <Expanded>
+                  <Expanded style={{ minWidth: 0 }}>
                     <Flex flexDirection='column'>
                       <Flex justifyContent='space-between'>
-                        <Text size='16px' color='grey800' weight={600}>
+                        <Text
+                          size='16px'
+                          color='grey800'
+                          weight={600}
+                          style={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap'
+                          }}
+                        >
                           {account.details?.bankName}
                         </Text>
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedCards/template.success.tsx
@@ -98,7 +98,7 @@ const Success: React.FC<
                       </Text>
 
                       <Text size='14px' color='grey600' weight={500}>
-                        ***{card.card.number}
+                        ****{card.card.number}
                       </Text>
                     </Flex>
 


### PR DESCRIPTION
## Description
Fix some UI styles in the card/bank items
<img width="537" alt="Screen Shot 2022-07-22 at 3 32 59 PM" src="https://user-images.githubusercontent.com/99212903/180502863-68918590-def9-415c-8611-fb6156c5ba71.png">
<img width="605" alt="Screen Shot 2022-07-22 at 3 29 08 PM" src="https://user-images.githubusercontent.com/99212903/180502873-d1375298-a88f-479e-b2f7-e0aa2bb0a7db.png">
<img width="1215" alt="Screen Shot 2022-07-22 at 3 25 56 PM" src="https://user-images.githubusercontent.com/99212903/180502886-479300af-086f-4638-a2b9-ac70220c00db.png">

