### PR TITLE
fix(WireTranfer): remove the order dependency on wire ttranfer flyout

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/BankWireDetails/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/BankWireDetails/index.tsx
@@ -2,9 +2,16 @@ import React, { PureComponent } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 
-import { BSPairType, CoinType, ExtractSuccess, FiatType, RemoteDataType } from '@core/types'
+import {
+  BSOrderType,
+  BSPairType,
+  CoinType,
+  ExtractSuccess,
+  FiatType,
+  RemoteDataType
+} from '@core/types'
 import DataError from 'components/DataError'
-import { actions } from 'data'
+import { actions, selectors } from 'data'
 import { RootState } from 'data/rootReducer'
 
 import Loading from '../template.loading'
@@ -23,13 +30,14 @@ class BankWireDetails extends PureComponent<Props> {
       Failure: (e) => <DataError message={{ message: e }} />,
       Loading: () => <Loading />,
       NotAsked: () => <Loading />,
-      Success: (val) => <Success {...val} {...this.props} />
+      Success: (val) => <Success {...val} {...this.props} order={this.props.order} />
     })
   }
 }
 
 const mapStateToProps = (state: RootState): LinkStatePropsType => ({
-  data: getData(state)
+  data: getData(state),
+  order: selectors.components.buySell.getBSOrder(state).data
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -50,6 +58,7 @@ export type SuccessStateType = ExtractSuccess<ReturnType<typeof getData>>
 
 type LinkStatePropsType = {
   data: RemoteDataType<string, SuccessStateType>
+  order?: BSOrderType
 }
 export type Props = OwnProps & ConnectedProps<typeof connector>
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/BankWireDetails/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/BankWireDetails/selectors.ts
@@ -6,11 +6,6 @@ import { RootState } from 'data/rootReducer'
 export const getData = (state: RootState) => {
   const accountR = selectors.components.buySell.getBSAccount(state)
   const userDataR = selectors.modules.profile.getUserData(state)
-  const orderR = selectors.components.buySell.getBSOrder(state)
 
-  return lift((account, userData, order) => ({ account, order, userData }))(
-    accountR,
-    userDataR,
-    orderR
-  )
+  return lift((account, userData) => ({ account, userData }))(accountR, userDataR)
 }


### PR DESCRIPTION
## Description
The Wire Transfer Page is dependent on the order remote, but when the user clicks in the Wire Transfer option, at that moment there is no order so the Wire Tranfer flyout would be loading forever.
This removes the dependency on the remote to render the page, that way the page can load the account and userData and then load the order separately

https://user-images.githubusercontent.com/99212903/180319241-4e9600a9-0c75-405d-ac04-44b5431f871d.mov


