### PR TITLE
Feat/app refresh hotkey

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/package.json
+++ b/packages/blockchain-wallet-v4-frontend/package.json
@@ -132,6 +132,7 @@
     "react-csv": "2.0.3",
     "react-dom": "16.14.0",
     "react-dropzone": "7.0.1",
+    "react-hotkeys-hook": "3.4.7",
     "react-idle-timer": "5.2.0",
     "react-intl": "5.24.4",
     "react-intl-tel-input": "5.0.7",

--- a/packages/blockchain-wallet-v4-frontend/src/components/Navbar/Navbar.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Navbar/Navbar.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import { FormattedMessage } from 'react-intl'
 import { NavLink } from 'react-router-dom'
 import { colors, Icon, Text } from '@blockchain-com/constellation'
@@ -88,7 +89,8 @@ const ListStyles = styled.ul`
       transition-duration: 0.5s;
     }
 
-    &.refresh:active {
+    &.refresh:active,
+    &.refresh:focus {
       transform: rotate(360deg);
     }
   }
@@ -182,6 +184,10 @@ const Navbar = ({
   const [isMobileNavOpen, setMobileNav] = useState(false)
   const isMobile = useMedia('mobile')
   const isTablet = useMedia('tablet')
+  useHotkeys('cmd+r', (e) => {
+    e.preventDefault()
+    refreshClickHandler()
+  })
 
   const closeMobileNavOpenSendCallback = useCallback(() => {
     setMobileNav(false)
@@ -242,13 +248,15 @@ const Navbar = ({
       name: 'mobile-app'
     },
     {
-      component: () => (
-        <NavButton onClick={refreshClickHandler} data-e2e='refreshLink'>
-          <Icon color='grey400' label='refresh' size='sm'>
-            <IconRefresh />
-          </Icon>
-        </NavButton>
-      ),
+      component: () => {
+        return (
+          <NavButton onClick={refreshClickHandler} data-e2e='refreshLink'>
+            <Icon color='grey400' label='refresh' size='sm'>
+              <IconRefresh />
+            </Icon>
+          </NavButton>
+        )
+      },
       name: 'Refresh'
     },
     {

--- a/packages/blockchain-wallet-v4-frontend/src/components/Navbar/Navbar.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Navbar/Navbar.tsx
@@ -248,15 +248,13 @@ const Navbar = ({
       name: 'mobile-app'
     },
     {
-      component: () => {
-        return (
-          <NavButton onClick={refreshClickHandler} data-e2e='refreshLink'>
-            <Icon color='grey400' label='refresh' size='sm'>
-              <IconRefresh />
-            </Icon>
-          </NavButton>
-        )
-      },
+      component: () => (
+        <NavButton onClick={refreshClickHandler} data-e2e='refreshLink'>
+          <Icon color='grey400' label='refresh' size='sm'>
+            <IconRefresh />
+          </Icon>
+        </NavButton>
+      ),
       name: 'Refresh'
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14718,6 +14718,11 @@ hosted-git-info@^4.0.1:
   dependencies:
     lru-cache "^6.0.0"
 
+hotkeys-js@3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.9.4.tgz#ce1aa4c3a132b6a63a9dd5644fc92b8a9b9cbfb9"
+  integrity sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q==
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
@@ -20800,6 +20805,13 @@ react-helmet-async@^1.0.2, react-helmet-async@^1.0.7:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
+
+react-hotkeys-hook@3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-3.4.7.tgz#e16a0a85f59feed9f48d12cfaf166d7df4c96b7a"
+  integrity sha512-+bbPmhPAl6ns9VkXkNNyxlmCAIyDAcWbB76O4I0ntr3uWCRuIQf/aRLartUahe9chVMPj+OEzzfk3CQSjclUEQ==
+  dependencies:
+    hotkeys-js "3.9.4"
 
 react-idle-timer@5.2.0:
   version "5.2.0"


### PR DESCRIPTION
## Description (optional)
Uses react hotkey hook package to hijack the refresh keyboard shortcut so you can refresh the app without refreshing the entire page (and getting logged out).
![page-refresh](https://user-images.githubusercontent.com/57680122/181119636-392d11a3-3997-479b-9efe-8caa0c2a3d46.gif)

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

