### PR TITLE
fix(NabuError): handle when status icon is not present

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/GenericNabuError/GenericNabuError.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/GenericNabuError/GenericNabuError.tsx
@@ -32,15 +32,11 @@ const GenericNabuError: GenericNabuErrorComponent = ({ error, onDismiss }) => {
     [onClickDeepLink, onDismiss]
   )
 
-  const iconUrl = icon?.url
-
-  const iconStatusUrl = icon?.status ? icon.status.url : iconUrl
-
   return (
     <GenericErrorLayout>
       <ErrorIconWithSeverity
-        iconStatusUrl={iconStatusUrl || ''}
-        iconUrl={iconUrl || ''}
+        iconStatusUrl={icon?.status?.url || ''}
+        iconUrl={icon?.url || ''}
         statusFallback={
           <IconBadge color='orange600' size={1.5}>
             <IconAlert />

--- a/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/NabuError.types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/services/errors/NabuError/NabuError.types.ts
@@ -4,10 +4,10 @@ type NabuErrorAction = {
 }
 
 type NabuErrorIconProps = {
-  accessibility: {
+  accessibility?: {
     description: string
   }
-  status: {
+  status?: {
     url: string
   }
   url: string


### PR DESCRIPTION
## Description

read correct status icon URL
Before
<img width="703" alt="Screen Shot 2022-07-28 at 6 00 50 PM" src="https://user-images.githubusercontent.com/99212903/181636688-17af95e4-6258-4215-bd2a-c8bb22b1c986.png">

After

<img width="674" alt="Screen Shot 2022-07-28 at 5 53 58 PM" src="https://user-images.githubusercontent.com/99212903/181636741-36365398-5afb-4755-b4da-d2dbe3e7e7f6.png">

