### PR TITLE
fix(CoinView): map loading state correctly in wallets card

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/CoinPage/components/CoinPage/hooks/useWalletsCard/useWalletsCard.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/CoinPage/components/CoinPage/hooks/useWalletsCard/useWalletsCard.tsx
@@ -33,12 +33,12 @@ export const useWalletsCard = (coin: CoinType): [ReactNode] => {
   } = useWalletsForCoin({ coin })
 
   const isNotAsked = useMemo(
-    () => isCoinRatesNotAsked && isCoinBalanceNotAsked && isAddressDataNotAsked,
+    () => isCoinRatesNotAsked || isCoinBalanceNotAsked || isAddressDataNotAsked,
     [isCoinRatesNotAsked, isCoinBalanceNotAsked, isAddressDataNotAsked]
   )
 
   const isLoading = useMemo(
-    () => isLoadingCoinRates && isLoadingCoinBalance && isLoadingAddressData,
+    () => isLoadingCoinRates || isLoadingCoinBalance || isLoadingAddressData,
     [isLoadingCoinRates, isLoadingCoinBalance, isLoadingAddressData]
   )
 


### PR DESCRIPTION
## Description
The wallets card was not correctly setting the loading state, this changes the loading state to look at all dependencies