### PR TITLE
fix(stx-airdrop): remove old availability copy

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Airdrops/StxAirdrop/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Airdrops/StxAirdrop/model.tsx
@@ -232,27 +232,6 @@ export const StxFooterCta = ({ kycState, tags, userCampaignsInfoResponseList }: 
 
   if (stxCampaign) {
     switch (stxCampaign.userCampaignState) {
-      case 'REWARD_SENT':
-      case 'TASK_FINISHED':
-      case 'REWARD_RECEIVED':
-        return (
-          <Text size='12px' color='grey600' weight={500}>
-            <FormattedMessage
-              id='scenes.airdrop.stx.wallet.balance'
-              defaultMessage='Please note the balance is currently non-transferable. Learn more about this and future wallet support for STX'
-            />{' '}
-            <Link
-              href='https://support.blockchain.com/hc/en-us/articles/360038745191'
-              target='_blank'
-              size='12px'
-              weight={500}
-              style={{ textDecoration: 'underline' }}
-            >
-              <FormattedMessage id='copy.here' defaultMessage='here' />
-            </Link>
-            .
-          </Text>
-        )
       case 'FAILED':
         return (
           <Link href='https://support.blockchain.com' target='_blank' rel='noopener noreferrer'>
@@ -264,6 +243,9 @@ export const StxFooterCta = ({ kycState, tags, userCampaignsInfoResponseList }: 
       case undefined:
       case 'REGISTERED':
       case 'NONE':
+      case 'REWARD_SENT':
+      case 'TASK_FINISHED':
+      case 'REWARD_RECEIVED':
       default:
         return null
     }


### PR DESCRIPTION
## Description (optional)
Removes text at the bottom of this modal:
<img width="400" alt="Screen Shot 2022-08-08 at 2 02 52 PM" src="https://user-images.githubusercontent.com/14954836/183523059-af02c347-7a44-46fb-9842-a33f62ffc353.png">

Looks like this now
<img width="351" alt="Screen Shot 2022-08-08 at 4 08 19 PM" src="https://user-images.githubusercontent.com/14954836/183523080-da0e9a0f-79f0-4135-b1e4-5dc46369b137.png">

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

