### PR TITLE
feat(PaymentMethod): use nabu ux title as the buy flow button content

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/hooks/useBlockedPayments/useBlockedPayments.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/hooks/useBlockedPayments/useBlockedPayments.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { FormattedMessage } from 'react-intl'
 
 import { Button, Image } from 'blockchain-info-components'
 import { Flex } from 'components/Flex'
@@ -37,7 +36,7 @@ export const useBlockedPayments: BlockedPaymentsHook = (selectedMethod) => {
   }, [nabuError, isCardVisible])
 
   const paymentErrorButton = useMemo(() => {
-    if (!isPaymentMethodBlocked) return
+    if (!isPaymentMethodBlocked || !nabuError) return
 
     return (
       <Button
@@ -49,14 +48,11 @@ export const useBlockedPayments: BlockedPaymentsHook = (selectedMethod) => {
       >
         <Flex alignItems='center' gap={8}>
           <Image name='alert-orange' />
-          <FormattedMessage
-            id='EnterAmount.paymentMethodBlockedButton.label'
-            defaultMessage='Buying crypto not supported'
-          />
+          {nabuError.title}
         </Flex>
       </Button>
     )
-  }, [isPaymentMethodBlocked, setCardVisibility])
+  }, [isPaymentMethodBlocked, setCardVisibility, nabuError])
 
   useEffect(() => setCardVisibility(false), [selectedMethod, setCardVisibility])
 


### PR DESCRIPTION
## Description 
Use the nabu ux title when rendering the buy button
<img width="573" alt="Screen Shot 2022-08-15 at 11 18 02 AM" src="https://user-images.githubusercontent.com/99212903/184653663-92ee66f6-8293-4e40-8071-23ed15caed44.png">

