### PR TITLE
feat(Buy): add recurring buy option in checkout page

### DIFF
--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -38,6 +38,7 @@
         "appleAndGooglePayPromoBanner": true,
         "bindIntegrationArEnabled": true,
         "coinViewV2": true,
+        "recurringBuysInCheckoutPage": true,
         "completeYourProfile": true,
         "createExchangeUserOnSignupOrLogin": true,
         "developerMobilePairing": true,

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagaRegister.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagaRegister.ts
@@ -20,6 +20,10 @@ export default ({ api, coreSagas, networks }) => {
     yield takeLatest(actions.activateCard.type, buySellSagas.activateBSCard)
     yield takeLatest(actions.cancelOrder.type, buySellSagas.cancelBSOrder)
     yield takeLatest(actions.createOrder.type, buySellSagas.createBSOrder)
+    yield takeLatest(
+      actions.createRecurringOrderIfEllegble.type,
+      buySellSagas.createRecurringOrderIfEllegble
+    )
     yield takeLatest(actions.confirmFundsOrder.type, buySellSagas.confirmBSFundsOrder)
     yield takeLatest(actions.confirmOrderPoll.type, buySellSagas.confirmOrderPoll)
     yield takeLatest(actions.confirmOrder.type, buySellSagas.confirmOrder)

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/slice.ts
@@ -223,6 +223,7 @@ const buySellSlice = createSlice({
       state.order = Remote.Success(action.payload)
       state.pendingOrder = action.payload
     },
+    createRecurringOrderIfEllegble: (state, action: PayloadAction<BSOrderType>) => {},
     defaultMethodEvent: (state, action: PayloadAction<BSPaymentMethodType>) => {},
     deleteCard: (state, action: PayloadAction<BSCardType['id']>) => {},
     destroyCheckout: (state) => {

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/CheckoutConfirm.styles.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/CheckoutConfirm.styles.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+
+export const StyledCheckboxInput = styled.input`
+  width: 1rem;
+  height: 1rem;
+`
+
+export const RecurringBuyLabel = styled.label`
+  cursor: pointer;
+`

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/hooks/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useRecurringBuySection'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/hooks/useRecurringBuySection/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/hooks/useRecurringBuySection/index.ts
@@ -1,0 +1,1 @@
+export { useRecurringBuySection } from './useRecurringBuySection'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/hooks/useRecurringBuySection/useRecurringBuySection.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/hooks/useRecurringBuySection/useRecurringBuySection.ts
@@ -1,0 +1,47 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { change } from 'redux-form'
+
+import { selectors } from 'data'
+import { FORM_BS_CHECKOUT } from 'data/components/buySell/model'
+import { RecurringBuyPeriods } from 'data/types'
+
+import { RecurringBuySectionHook } from './useRecurringBuySection.types'
+
+export const useRecurringBuySection: RecurringBuySectionHook = ({ initialPeriod, paymentType }) => {
+  const selectedPeriodRef = useRef(initialPeriod)
+  const dispatch = useDispatch()
+
+  const availableRecurringBuyPayments = useSelector(
+    selectors.components.recurringBuy.availableMethods
+  )
+
+  const isRecurringBuysInCheckoutPageEnabled =
+    useSelector(selectors.core.walletOptions.getRecurringBuysInCheckoutPage).data === true
+
+  const isPaymentEllegbleForRecurringBuy = useMemo(() => {
+    if (!paymentType) return false
+
+    return availableRecurringBuyPayments.includes(paymentType)
+  }, [paymentType, availableRecurringBuyPayments])
+
+  const showRecurringBuySection = useMemo(
+    () =>
+      selectedPeriodRef.current === RecurringBuyPeriods.ONE_TIME &&
+      isRecurringBuysInCheckoutPageEnabled &&
+      isPaymentEllegbleForRecurringBuy,
+    [selectedPeriodRef, isRecurringBuysInCheckoutPageEnabled, isPaymentEllegbleForRecurringBuy]
+  )
+
+  const setPeriod = useCallback(
+    (period: RecurringBuyPeriods) => {
+      dispatch(change(FORM_BS_CHECKOUT, 'period', period))
+    },
+    [dispatch]
+  )
+
+  return {
+    setPeriod,
+    showRecurringBuySection
+  }
+}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/hooks/useRecurringBuySection/useRecurringBuySection.types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/hooks/useRecurringBuySection/useRecurringBuySection.types.ts
@@ -1,0 +1,12 @@
+import { BSPaymentTypes } from '@core/types'
+import { RecurringBuyPeriods } from 'data/types'
+
+export type RecurringBuySectionHookProps = {
+  initialPeriod: RecurringBuyPeriods | undefined
+  paymentType: BSPaymentTypes | undefined
+}
+
+export type RecurringBuySectionHook = (props: RecurringBuySectionHookProps) => {
+  setPeriod: (period: RecurringBuyPeriods) => void
+  showRecurringBuySection: boolean
+}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react'
+import React, { ChangeEventHandler, useCallback, useEffect, useMemo, useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { useDispatch } from 'react-redux'
 import BigNumber from 'bignumber.js'
-import { intervalToDuration } from 'date-fns'
+import { format, intervalToDuration } from 'date-fns'
 import { defaultTo, filter, path, prop } from 'ramda'
 import { clearSubmitErrors, InjectedFormProps, reduxForm } from 'redux-form'
 import styled from 'styled-components'
@@ -19,6 +19,7 @@ import {
   TextGroup
 } from 'blockchain-info-components'
 import { ErrorCartridge } from 'components/Cartridge'
+import { Flex } from 'components/Flex'
 import { FlyoutWrapper, Row } from 'components/Flyout'
 import { getPeriodSubTitleText, getPeriodTitleText } from 'components/Flyout/model'
 import Form from 'components/Form/Form'
@@ -52,6 +53,8 @@ import {
   getPaymentMethodDetails
 } from '../model'
 import { Props as OwnProps, SuccessStateType } from '.'
+import { RecurringBuyLabel, StyledCheckboxInput } from './CheckoutConfirm.styles'
+import { useRecurringBuySection } from './hooks'
 
 const { FORM_BS_CHECKOUT_CONFIRM } = model.components.buySell
 
@@ -179,11 +182,24 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
   const [isActiveFeeTooltip, setFeeToolTip] = useState(true)
   const dispatch = useDispatch()
 
+  const { setPeriod, showRecurringBuySection } = useRecurringBuySection({
+    initialPeriod: props.formValues?.period,
+    paymentType: props.order.paymentType
+  })
+
+  const recurringBuyWeekday = useMemo(() => format(new Date(), 'EEEE'), [])
+
   const [isGooglePayReady] = useDefer3rdPartyScript('https://pay.google.com/gp/p/js/pay.js', {
     attributes: {
       nonce: window.nonce
     }
   })
+
+  const handleOnCheckRecurringBuy: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (event) =>
+      setPeriod(event.target.checked ? RecurringBuyPeriods.WEEKLY : RecurringBuyPeriods.ONE_TIME),
+    [setPeriod]
+  )
 
   const orderType = getOrderType(props.order)
   const baseAmount = getBaseAmount(props.order)
@@ -211,8 +227,6 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
 
   const cardDetails =
     (requiresTerms && props.cards.filter((card) => card.id === paymentMethodId)[0]) || null
-
-  const isCardPayment = requiresTerms && cardDetails
 
   const totalAmount = fiatToString({
     unit: counterCurrency as FiatType,
@@ -568,6 +582,43 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
           </RowTextWrapper>
         </RowText>
       </RowItem>
+
+      {showRecurringBuySection && (
+        <RecurringBuyLabel htmlFor='recurring-buy-checkbox'>
+          <RowItem>
+            <Flex justifyContent='space-between' alignItems='center' style={{ width: '100%' }}>
+              <Flex flexDirection='column'>
+                <RowText>
+                  <FormattedMessage
+                    id='modals.simplebuy.investRate.label'
+                    defaultMessage='Invest {rate}?'
+                    values={{ rate: 'weekly' }}
+                  />
+                </RowText>
+                <RowText>
+                  <AdditionalText>
+                    <FormattedMessage
+                      id='modals.simplebuy.investRate.description'
+                      defaultMessage='Buy {fiat} every {weekday}. Cancel anytime.'
+                      values={{
+                        fiat: displayFiat(props.order, props.order.inputQuantity),
+                        weekday: recurringBuyWeekday
+                      }}
+                    />
+                  </AdditionalText>
+                </RowText>
+              </Flex>
+
+              <StyledCheckboxInput
+                type='checkbox'
+                id='recurring-buy-checkbox'
+                name='recurring-buy'
+                onChange={handleOnCheckRecurringBuy}
+              />
+            </Flex>
+          </RowItem>
+        </RecurringBuyLabel>
+      )}
 
       <Bottom>
         {getLockRuleMessaging(showLock, days, props.order.paymentType)}

--- a/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.ts
+++ b/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.ts
@@ -108,6 +108,9 @@ export const getShowTermsAndConditions = (state: RootState) =>
 export const getCoinViewV2 = (state: RootState) =>
   getWebOptions(state).map(path(['featureFlags', 'coinViewV2']))
 
+export const getRecurringBuysInCheckoutPage = (state: RootState) =>
+  getWebOptions(state).map(path(['featureFlags', 'recurringBuysInCheckoutPage']))
+
 // SSO creating exchange users under the hood
 // for all wallet logins and signup
 export const getCreateExchangeUserOnSignupOrLogin = (state: RootState) =>


### PR DESCRIPTION
- Removed the recurring buy option on create order
- Creates the recurring buy after the order payment is successful
- Add toggle to include recurring buy on checkout page

https://user-images.githubusercontent.com/99212903/185391419-0c638c70-e48f-4910-aa8b-dca7ea0c6de0.mov


