### PR TITLE
fix(browser-detection): bypass motorola edge issue

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/services/browser/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/services/browser/index.tsx
@@ -7,10 +7,17 @@ export const getBrowserNameAndVersion = () => {
 
 export const isBrowserSupported = () => {
   const browser = Bowser.getParser(window.navigator.userAgent)
-
   // let search crawlers through for SEO purposes
   if (browser.getPlatformType() === 'bot') return true
-
+  // handle edge case where user's mobile device is motoroal edge
+  // and bowser assumes it is microsoft edge
+  if (
+    browser.getOSName() === 'Android' &&
+    (browser.getOSVersion() === '12' || browser.getOSVersion() === '11') &&
+    browser.getBrowserName() === 'Microsoft Edge'
+  ) {
+    return true
+  }
   return browser.satisfies({
     chrome: '>80', // chromium
     chromium: '>80', // chromium


### PR DESCRIPTION
## Description (optional)
Handles literal edge case (haha!) where Android user is trying to verify their login. Motorola Edge device came out last year, bowser assumes string 'edge' in user agent means it's a Microsoft Edge browser. There's no version attached to it though, so version is undefined and `browser.satisfies` returns false for all checks. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

