### PR TITLE
fix(create-user): create user if credentials empty in metadata

### DIFF
--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -38,6 +38,7 @@
         "applePayPaymentMethod": true,
         "appleAndGooglePayPromoBanner": true,
         "bindIntegrationArEnabled": true,
+        "createNabuUserAtLogin": true,
         "coinViewV2": false,
         "isCreditCardOptimizationEnabled": true,
         "recurringBuysInCheckoutPage": true,

--- a/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/auth/sagas.ts
@@ -61,7 +61,7 @@ export default ({ api, coreSagas, networks }) => {
 
   const LOGIN_FORM = 'login'
 
-  const authNabu = function* () {
+  const authNabu = function* (firstLogin?: boolean) {
     yield put(
       actions.components.identityVerification.fetchSupportedCountries({ scope: CountryScope.KYC })
     )
@@ -69,7 +69,7 @@ export default ({ api, coreSagas, networks }) => {
       identityVerificationActions.setSupportedCountriesSuccess.type,
       identityVerificationActions.setSupportedCountriesFailure.type
     ])
-    yield put(actions.modules.profile.signIn())
+    yield put(actions.modules.profile.signIn(firstLogin))
   }
 
   const exchangeResetPassword = function* (action) {
@@ -324,13 +324,12 @@ export default ({ api, coreSagas, networks }) => {
       yield call(coreSagas.data.xlm.fetchLedgerDetails)
       yield call(coreSagas.data.xlm.fetchData)
 
-      yield call(authNabu)
+      yield call(authNabu, firstLogin)
       if (product === ProductAuthOptions.EXCHANGE && (recovery || !firstLogin)) {
         return yield put(
           actions.modules.profile.authAndRouteToExchangeAction(ExchangeAuthOriginType.Login)
         )
       }
-
       const guid = yield select(selectors.core.wallet.getGuid)
       if (firstLogin && !isAccountReset && !recovery) {
         // create nabu user

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/actions.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/actions.ts
@@ -124,7 +124,8 @@ export const setLinkToExchangeAccountDeepLink = (deeplink): ProfileActionTypes =
   type: AT.SET_LINK_TO_EXCHANGE_ACCOUNT_DEEPLINK
 })
 // event, not used by reducer, not yet typed
-export const signIn = () => ({
+export const signIn = (firstLogin) => ({
+  payload: { firstLogin },
   type: AT.SIGN_IN
 })
 export const shareWalletAddressesWithExchange = (): ProfileActionTypes => ({

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/sagaRegister.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/sagaRegister.ts
@@ -22,7 +22,6 @@ export default ({ api, coreSagas, networks }) => {
   })
 
   return function* profileSaga() {
-    // @ts-ignore
     yield takeLatest(AT.SIGN_IN, signIn)
     yield takeLatest(AT.CLEAR_SESSION, clearSession)
     yield takeLatest(AT.CREATE_USER, createUser)

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/sagaRegister.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/sagaRegister.ts
@@ -22,6 +22,7 @@ export default ({ api, coreSagas, networks }) => {
   })
 
   return function* profileSaga() {
+    // @ts-ignore
     yield takeLatest(AT.SIGN_IN, signIn)
     yield takeLatest(AT.CLEAR_SESSION, clearSession)
     yield takeLatest(AT.CREATE_USER, createUser)

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/sagas.ts
@@ -546,6 +546,9 @@ export default ({ api, coreSagas, networks }) => {
       const { firstLogin } = payload
       const email = (yield select(selectors.core.settings.getEmail)).getOrFail('No email')
       const guid = yield select(selectors.core.wallet.getGuid)
+      const createNewUser = (yield select(
+        selectors.core.walletOptions.createNabuUserAtLogin
+      )).getOrElse(false)
       // TODO: in future only fetch unified credentials
       const unifiedNabuCredentialsR = yield select(
         selectors.core.kvStore.unifiedCredentials.getNabuCredentials
@@ -574,7 +577,7 @@ export default ({ api, coreSagas, networks }) => {
           })
         )
       }
-      if (!firstLogin && (!nabuUserId || !nabuLifetimeToken)) {
+      if (!firstLogin && createNewUser && (!nabuUserId || !nabuLifetimeToken)) {
         yield call(createUser)
       }
       if (!nabuUserId || !nabuLifetimeToken) {

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/sagas.ts
@@ -541,7 +541,7 @@ export default ({ api, coreSagas, networks }) => {
     }
   }
 
-  const signIn = function* ({ payload }) {
+  const signIn = function* ({ payload }: ReturnType<typeof A.signIn>) {
     try {
       const { firstLogin } = payload
       const email = (yield select(selectors.core.settings.getEmail)).getOrFail('No email')

--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/types.ts
@@ -314,6 +314,13 @@ interface ShareWalletAddressWithExchangeSuccessAction {
   type: typeof AT.SHARE_WALLET_ADDRESSES_WITH_EXCHANGE_SUCCESS
 }
 
+interface SigninActionType {
+  payload?: {
+    firstLogin?: boolean
+  }
+  type: typeof AT.SIGN_IN
+}
+
 export type ProfileActionTypes =
   | AuthAndRouteToExchangeAction
   | ClearProfileStateAction
@@ -347,3 +354,4 @@ export type ProfileActionTypes =
   | ShareWalletAddressWithExchangeFailureAction
   | ShareWalletAddressWithExchangeLoadingAction
   | ShareWalletAddressWithExchangeSuccessAction
+  | SigninActionType

--- a/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.ts
+++ b/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.ts
@@ -162,3 +162,7 @@ export const getSecureEmailSmsUpdate = (state: RootState) =>
 // dex feature flag
 export const getDexProductEnabled = (state: RootState) =>
   getWebOptions(state).map(path(['featureFlags', 'dex']))
+
+// crates nabu user at login if credentials aren't in metadata
+export const createNabuUserAtLogin = (state: RootState) =>
+  getWebOptions(state).map(path(['featureFlags', 'createNabuUserAtLogin']))


### PR DESCRIPTION
## Description (optional)
Addresses issue reported by Peter - we only call `/users` to create or get a nabu user if it's the users first login. This is an issue for older wallets (created pre-nabu) since login throws an error like this. 
![Screen Shot 2022-09-24 at 12 28 28 PM (1) (1)](https://user-images.githubusercontent.com/14954836/192168328-6e277471-5741-4bda-8bae-df75c5462208.png)


Main fix is we pass `firstLogin` boolean from loginRoutineSaga into nabu profile signIn function. If it's false but nabu credentials are empty, we call the createUser saga. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

