### PR TITLE
fix(get-tier): allow for undefined user

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/modules/profile/selectors.ts
@@ -65,7 +65,7 @@ export const isSilverOrAbove = compose(
 )
 
 export const getCurrentTier = createSelector(getUserData, (userDataR) => {
-  return lift((userData: ExtractSuccess<typeof userDataR>) => userData.tiers.current)(userDataR)
+  return lift((userData: ExtractSuccess<typeof userDataR>) => userData.tiers?.current)(userDataR)
 })
 export const getUserCurrencies = createSelector([getUserData], (userDataR) => {
   return lift((userData: ExtractSuccess<typeof userDataR>) => ({


### PR DESCRIPTION
## Description (optional)
`getCurrentTier` selector expects user data, allows for it to be undefined for wallets without nabu accounts. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

