### PR TITLE
Feat/stak 88/manage screen

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Tooltips/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Tooltips/index.js
@@ -288,7 +288,7 @@ class Tooltips extends React.PureComponent {
         <Tooltip id='modals.staking.summary.fee.tooltip'>
           <FormattedMessage
             id='modals.staking.summary.fee.description.tooltip'
-            defaultMessage='Rewards rates are determined by each protocol minus a Blockchain.com fee. Users receive the displayed rate.'
+            defaultMessage='Rates are determined by each protocol minus a Blockchain.com fee. Users receive the displayed rate.'
           />
         </Tooltip>
         <Tooltip id='modals.staking.bonding.pending.tooltip'>

--- a/packages/blockchain-wallet-v4-frontend/src/components/Tooltips/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Tooltips/index.js
@@ -288,7 +288,7 @@ class Tooltips extends React.PureComponent {
         <Tooltip id='modals.staking.summary.fee.tooltip'>
           <FormattedMessage
             id='modals.staking.summary.fee.description.tooltip'
-            defaultMessage='Rewards rates are determined by each protocol minus a fee. Users receive the displayed rate.'
+            defaultMessage='Rewards rates are determined by each protocol minus a Blockchain.com fee. Users receive the displayed rate.'
           />
         </Tooltip>
         <Tooltip id='modals.staking.bonding.pending.tooltip'>

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
@@ -412,9 +412,14 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
         pendingTransactions.push({ amount: amount.value, date: insertedAt, type: 'TRANSACTIONS' })
       })
 
+      let totalBondingAmount = 0
+
       bondingDeposits.forEach(({ amount, bondingDays, bondingStartDate }) => {
+        totalBondingAmount += Number(amount)
         pendingTransactions.push({ amount, bondingDays, date: bondingStartDate, type: 'BONDING' })
       })
+
+      if (totalBondingAmount > 0) yield put(A.setTotalBondingDeposits(totalBondingAmount))
 
       if (pendingTransactions.length > 0) {
         pendingTransactions.sort((a, b) => {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.ts
@@ -383,7 +383,7 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
 
   const fetchPendingStakingTransactions = function* ({
     payload
-  }: ReturnType<typeof A.fetchEarnTransactions>) {
+  }: ReturnType<typeof A.fetchPendingStakingTransactions>) {
     const { coin } = payload
 
     try {
@@ -409,7 +409,12 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
       const pendingTransactions: PendingTransactionType[] = []
 
       filteredTransactions.forEach(({ amount, insertedAt }) => {
-        pendingTransactions.push({ amount: amount.value, date: insertedAt, type: 'TRANSACTIONS' })
+        const baseAmount = Exchange.convertCoinToCoin({
+          baseToStandard: false,
+          coin,
+          value: new BigNumber(amount.value).toNumber()
+        })
+        pendingTransactions.push({ amount: baseAmount, date: insertedAt, type: 'TRANSACTIONS' })
       })
 
       let totalBondingAmount = 0

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/sagas.utils.ts
@@ -77,7 +77,7 @@ export default ({ coreSagas, networks }: { coreSagas: any; networks: any }) => {
     const userCurrency = (yield select(selectors.core.settings.getCurrency)).getOrFail(
       'Failed to get user currency'
     )
-    const minFiat = minDepositAmount
+    const minFiat = Number(convertBaseToStandard('FIAT', minDepositAmount))
     const maxFiat = Exchange.convertCoinToFiat({
       coin,
       currency: userCurrency,
@@ -92,7 +92,7 @@ export default ({ coreSagas, networks }: { coreSagas: any; networks: any }) => {
       coin,
       currency: walletCurrency,
       rates,
-      value: Number(convertBaseToStandard('FIAT', minFiat))
+      value: minFiat
     })
 
     return {

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/selectors.ts
@@ -110,6 +110,9 @@ export const getEarnTransactions = (state: RootState) => state.components.intere
 export const getPendingStakingTransactions = (state: RootState) =>
   state.components.interest.pendingStakingTransactions
 
+export const getTotalBondingDeposits = (state: RootState) =>
+  state.components.interest.totalBondingDeposits
+
 export const getEarnDepositLimits = (state: RootState) =>
   state.components.interest.earnDepositLimits
 

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/slice.ts
@@ -69,6 +69,7 @@ const initialState: InterestState = {
     name: 'WARNING'
   },
   stakingTransactionsNextPage: null,
+  totalBondingDeposits: 0,
   transactions: [],
   transactionsReport: Remote.NotAsked,
   underSanctionsMessage: null,
@@ -505,6 +506,9 @@ const interestSlice = createSlice({
     ) => {
       state.stakingTransactionsNextPage = action.payload.nextPage
     },
+    setTotalBondingDeposits: (state, action: PayloadAction<number>) => {
+      state.totalBondingDeposits = action.payload
+    },
 
     setUnderSanctions: (state, action: PayloadAction<{ message: string | null }>) => {
       state.underSanctionsMessage = action.payload.message
@@ -623,6 +627,7 @@ export const {
   setRewardsTransactionsNextPage,
   setStakingModal,
   setStakingTransactionsNextPage,
+  setTotalBondingDeposits,
   setWithdrawalMinimumsFailure,
   setWithdrawalMinimumsLoading,
   setWithdrawalMinimumsSuccess,

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/types.ts
@@ -75,6 +75,13 @@ export type InterestStep = keyof typeof InterestSteps
 
 export type StakingStep = keyof typeof StakingSteps
 
+export enum StakingStepsType {
+  'WARNING',
+  'DEPOSIT',
+  'DEPOSIT_SUCCESS',
+  'ACCOUNT_SUMMARY'
+}
+
 export type InterestTransactionsReportType = Array<Array<string>>
 
 export type InterestHistoryCoinFormType = { coin: CoinType | 'ALL' }

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/interest/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/interest/types.ts
@@ -136,6 +136,7 @@ export interface InterestState {
     name: StakingStep
   }
   stakingTransactionsNextPage?: string | null
+  totalBondingDeposits: number
   transactions: Array<EarnTransactionType>
   transactionsReport: RemoteDataType<string, Array<EarnTransactionType>>
   underSanctionsMessage: string | null

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.BalanceDropdown.template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.BalanceDropdown.template.tsx
@@ -1,0 +1,79 @@
+import React, { useRef } from 'react'
+import { FormattedMessage } from 'react-intl'
+import { Flex, SemanticColors, Text } from '@blockchain-com/constellation'
+
+import { CoinType, FiatType } from '@core/types'
+import CoinDisplay from 'components/Display/CoinDisplay'
+import FiatDisplay from 'components/Display/FiatDisplay'
+import { useOnClickOutside } from 'services/misc'
+
+import { BalanceDropdownContainer, CoinToggleButton } from './AccountSummary.model'
+
+const BalanceDropdown = ({
+  coin,
+  handleBalanceDropdown,
+  handleCoinToggled,
+  isCoinDisplayed,
+  stakingBalance,
+  totalBondingDeposits,
+  walletCurrency
+}: OwnProps) => {
+  const ref = useRef(null)
+  useOnClickOutside(ref, handleBalanceDropdown)
+  const renderRows = (balance: number, isStaking: boolean) => (
+    <Flex justifyContent='space-between' gap={8}>
+      <Text as='p' color={SemanticColors.title} variant='paragraph2'>
+        {isStaking ? (
+          <FormattedMessage defaultMessage='Staked' id='copy.staked' />
+        ) : (
+          <FormattedMessage defaultMessage='Bonding' id='copy.bonding' />
+        )}
+      </Text>
+      <Text as='p' color={SemanticColors.body} variant='paragraph1'>
+        {isCoinDisplayed ? (
+          <CoinDisplay
+            coin={coin}
+            color='grey700'
+            cursor='inherit'
+            size='14px'
+            weight={500}
+            data-e2e={`${coin} balance`}
+          >
+            {balance}
+          </CoinDisplay>
+        ) : (
+          <FiatDisplay coin={coin} color='grey700' size='14px' weight={500}>
+            {balance}
+          </FiatDisplay>
+        )}
+      </Text>
+    </Flex>
+  )
+  return (
+    <BalanceDropdownContainer ref={ref}>
+      {renderRows(Number(stakingBalance) - totalBondingDeposits, true)}
+      {renderRows(totalBondingDeposits, false)}
+      <CoinToggleButton onClick={handleCoinToggled}>
+        <FormattedMessage
+          defaultMessage='Show in {currency}'
+          id='modals.staking.balancedropdown.button'
+          values={{
+            currency: isCoinDisplayed ? walletCurrency : coin
+          }}
+        />
+      </CoinToggleButton>
+    </BalanceDropdownContainer>
+  )
+}
+
+export default BalanceDropdown
+
+type OwnProps = {
+  coin: CoinType
+  handleBalanceDropdown: () => void
+  handleCoinToggled: () => void
+  isCoinDisplayed: boolean
+  stakingBalance: string
+  totalBondingDeposits: number
+  walletCurrency: FiatType
+}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.Detail.template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.Detail.template.tsx
@@ -7,7 +7,6 @@ import { DetailsContainer } from './AccountSummary.model'
 
 const Details = ({
   handleClick,
-  rate,
   subText,
   subValue,
   text,
@@ -21,7 +20,7 @@ const Details = ({
         <Flex flexDirection='row' gap={4}>
           {text}{' '}
           {textTooltipId && (
-            <TooltipHost id={textTooltipId} values={{ rate }}>
+            <TooltipHost id={textTooltipId}>
               <IconInformation name='info' size='small' color={SemanticColors.muted} />
             </TooltipHost>
           )}
@@ -54,7 +53,6 @@ const Details = ({
 )
 type DetailsType = {
   handleClick?: () => void
-  rate?: number
   subText?: ReactNode
   subValue?: ReactNode | number | string
   text: ReactNode

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.Detail.template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.Detail.template.tsx
@@ -17,8 +17,8 @@ const Details = ({
   <DetailsContainer $hasHandleClick={!!handleClick} onClick={handleClick}>
     <Flex alignItems='center' gap={4} justifyContent='space-between'>
       <Text color='grey900' size='14px' weight={600}>
-        <Flex flexDirection='row' gap={4}>
-          {text}{' '}
+        <Flex flexDirection='row' gap={8}>
+          {text}
           {textTooltipId && (
             <TooltipHost id={textTooltipId}>
               <IconInformation name='info' size='small' color={SemanticColors.muted} />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.Detail.template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.Detail.template.tsx
@@ -5,12 +5,26 @@ import { Text, TooltipHost } from 'blockchain-info-components'
 
 import { DetailsContainer } from './AccountSummary.model'
 
-const Details = ({ handleClick, subText, subValue, text, tooltipId, value }: DetailsType) => (
+const Details = ({
+  handleClick,
+  rate,
+  subText,
+  subValue,
+  text,
+  textTooltipId,
+  tooltipId,
+  value
+}: DetailsType) => (
   <DetailsContainer $hasHandleClick={!!handleClick} onClick={handleClick}>
     <Flex alignItems='center' gap={4} justifyContent='space-between'>
       <Text color='grey900' size='14px' weight={600}>
         <Flex flexDirection='row' gap={4}>
-          {text}
+          {text}{' '}
+          {textTooltipId && (
+            <TooltipHost id={textTooltipId} values={{ rate }}>
+              <IconInformation name='info' size='small' color={SemanticColors.muted} />
+            </TooltipHost>
+          )}
         </Flex>
       </Text>
       <Text color='grey900' size='14px' weight={600}>
@@ -40,9 +54,11 @@ const Details = ({ handleClick, subText, subValue, text, tooltipId, value }: Det
 )
 type DetailsType = {
   handleClick?: () => void
+  rate?: number
   subText?: ReactNode
   subValue?: ReactNode | number | string
   text: ReactNode
+  textTooltipId?: string
   tooltipId?: string
   value: ReactNode | number | string
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.model.tsx
@@ -24,6 +24,7 @@ export const Row = styled.div`
   display: flex;
 `
 export const Container = styled(Row)`
+  position: relative;
   flex-direction: column;
   min-height: 48px;
   justify-content: space-between;
@@ -35,6 +36,10 @@ export const Container = styled(Row)`
 
   &:last-child {
     margin-left: 32px;
+  }
+
+  svg:hover {
+    cursor: pointer;
   }
 `
 export const DetailsWrapper = styled.div`
@@ -107,5 +112,38 @@ export const SubmitButton = styled(Button)`
   &:hover {
     background-color: ${PaletteColors['blue-000']};
     border-color: ${SemanticColors.primary};
+  }
+`
+export const BalanceDropdownContainer = styled.div`
+  position: absolute;
+  top: 84px;
+  display: flex;
+  flex-direction: column;
+  padding-top: 8px;
+  box-shadow: 0px 4px 32px rgba(5, 24, 61, 0.4);
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: white;
+  min-width: 260px;
+
+  & > div {
+    padding: 6px 16px;
+  }
+`
+export const CoinToggleButton = styled.button`
+  border: none;
+  border-top: 1px solid ${SemanticColors['background-light']};
+  padding: 12px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: white;
+  color: ${SemanticColors.primary};
+  font-size: 16px;
+  font-weight: 600;
+
+  &:hover {
+    background-color: ${SemanticColors['background-light']};
+    cursor: pointer;
   }
 `

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.selectors.ts
@@ -11,37 +11,25 @@ export const getCurrency = (state: RootState) => {
 export const getData = (state: RootState) => {
   const accountBalancesR = selectors.components.interest.getStakingAccountBalance(state)
   const pendingTransactionsR = selectors.components.interest.getPendingStakingTransactions(state)
-  const stakingLimitsR = selectors.components.interest.getStakingLimits(state)
   const earnEDDStatusR = selectors.components.interest.getEarnEDDStatus(state)
   const stakingEligibleR = selectors.components.interest.getStakingEligible(state)
   const stakingRatesR = selectors.components.interest.getStakingRates(state)
-  const flagEDDInterestFileUpload = selectors.core.walletOptions
-    .getEDDInterestFileUpload(state)
-    .getOrElse(false)
+  const totalBondingDeposits = selectors.components.interest.getTotalBondingDeposits(state)
 
   return lift(
     (
       accountBalances: ExtractSuccess<typeof accountBalancesR>,
       earnEDDStatus: ExtractSuccess<typeof earnEDDStatusR>,
       pendingTransactions: ExtractSuccess<typeof pendingTransactionsR>,
-      stakingLimits: ExtractSuccess<typeof stakingLimitsR>,
       stakingRates: ExtractSuccess<typeof stakingRatesR>,
       stakingEligible: ExtractSuccess<typeof stakingEligibleR>
     ) => ({
       accountBalances,
       earnEDDStatus,
-      flagEDDInterestFileUpload,
       pendingTransactions,
       stakingEligible,
-      stakingLimits,
-      stakingRates
+      stakingRates,
+      totalBondingDeposits
     })
-  )(
-    accountBalancesR,
-    earnEDDStatusR,
-    pendingTransactionsR,
-    stakingLimitsR,
-    stakingRatesR,
-    stakingEligibleR
-  )
+  )(accountBalancesR, earnEDDStatusR, pendingTransactionsR, stakingRatesR, stakingEligibleR)
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.template.success.tsx
@@ -4,6 +4,9 @@ import {
   Flex,
   IconChevronDownV2,
   IconChevronUpV2,
+  IconTriangleDown,
+  IconTriangleUp,
+  PaletteColors,
   SemanticColors
 } from '@blockchain-com/constellation'
 import { format } from 'date-fns'
@@ -21,6 +24,7 @@ import { EarnStepMetaData, PendingTransactionType } from 'data/types'
 
 import { EDDMessageContainer } from '../Staking.model'
 import { OwnProps as ParentProps } from '.'
+import BalanceDropdown from './AccountSummary.BalanceDropdown.template'
 import Detail from './AccountSummary.Detail.template'
 import {
   Bottom,
@@ -39,17 +43,23 @@ const AccountSummary: React.FC<Props> = (props) => {
   const {
     accountBalances,
     coin,
+    handleBalanceDropdown,
     handleClose,
+    handleCoinToggled,
     handleDepositClick,
     handleEDDSubmitInfo,
     handleTransactionsToggled,
+    isBalanceDropdownToggled,
+    isCoinDisplayed,
     isEDDRequired,
     isTransactionsToggled,
     pendingTransactions,
     showSupply,
     stakingEligible,
     stakingRates,
-    stepMetadata
+    stepMetadata,
+    totalBondingDeposits,
+    walletCurrency
   } = props
 
   const { coinfig } = window.coins[coin]
@@ -84,6 +94,17 @@ const AccountSummary: React.FC<Props> = (props) => {
           <>
             <Row>
               <Container>
+                {isBalanceDropdownToggled && (
+                  <BalanceDropdown
+                    coin={coin}
+                    handleBalanceDropdown={handleBalanceDropdown}
+                    handleCoinToggled={handleCoinToggled}
+                    isCoinDisplayed={isCoinDisplayed}
+                    stakingBalance={account?.balance || '0'}
+                    totalBondingDeposits={totalBondingDeposits}
+                    walletCurrency={walletCurrency}
+                  />
+                )}
                 <Text color='grey600' size='14px' weight={500} style={{ marginBottom: '5px' }}>
                   <FormattedMessage
                     id='modals.staking.balance'
@@ -93,9 +114,24 @@ const AccountSummary: React.FC<Props> = (props) => {
                 </Text>
                 {account ? (
                   <>
-                    <CoinDisplay coin={coin} color='grey800' size='18px' weight={600}>
-                      {accountBalanceBase}
-                    </CoinDisplay>
+                    <Flex justifyContent='space-between'>
+                      <CoinDisplay coin={coin} color='grey800' size='18px' weight={600}>
+                        {accountBalanceBase}
+                      </CoinDisplay>
+                      {isBalanceDropdownToggled ? (
+                        <IconTriangleUp
+                          color={PaletteColors['grey-400']}
+                          onClick={handleBalanceDropdown}
+                          size='large'
+                        />
+                      ) : (
+                        <IconTriangleDown
+                          color={PaletteColors['grey-400']}
+                          onClick={handleBalanceDropdown}
+                          size='large'
+                        />
+                      )}
+                    </Flex>
                     <FiatDisplay
                       color='grey600'
                       size='14px'
@@ -335,16 +371,20 @@ const AccountSummary: React.FC<Props> = (props) => {
 type OwnProps = {
   accountBalances: EarnAccountBalanceResponseType
   coin: CoinType
-  handleBSClick: (string) => void
+  handleBalanceDropdown: () => void
+  handleCoinToggled: () => void
   handleDepositClick: () => void
   handleEDDSubmitInfo: () => void
   handleTransactionsToggled: () => void
+  isBalanceDropdownToggled: boolean
+  isCoinDisplayed: boolean
   isEDDRequired: boolean
   isTransactionsToggled: boolean
   pendingTransactions: Array<PendingTransactionType>
   stakingEligible: EarnEligibleType
   stakingRates: StakingRatesType['rates']
   stepMetadata: EarnStepMetaData
+  totalBondingDeposits: number
 }
 
 export type Props = OwnProps & ParentProps

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.template.success.tsx
@@ -17,7 +17,7 @@ import {
   EarnEligibleType,
   StakingRatesType
 } from '@core/types'
-import { Button, Icon, Link, Text } from 'blockchain-info-components'
+import { Button, Icon, Text } from 'blockchain-info-components'
 import CoinDisplay from 'components/Display/CoinDisplay'
 import FiatDisplay from 'components/Display/FiatDisplay'
 import { EarnStepMetaData, PendingTransactionType } from 'data/types'
@@ -67,7 +67,7 @@ const AccountSummary: React.FC<Props> = (props) => {
   const accountBalanceBase = account && account.balance
   const stakingBalanceBase = account && account.totalRewards
   const isDepositEnabled = stakingEligible[coin] ? stakingEligible[coin]?.eligible : false
-  const { commission, rate } = stakingRates[coin]
+  const { rate } = stakingRates[coin]
 
   return (
     <Wrapper>
@@ -203,7 +203,6 @@ const AccountSummary: React.FC<Props> = (props) => {
             <FormattedMessage id='modals.interest.summary' defaultMessage='Summary' />
           </Text>
           <Detail
-            subValue={`${commission}%`}
             text={
               <FormattedMessage
                 defaultMessage='Current rate'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/AccountSummary.template.success.tsx
@@ -4,18 +4,14 @@ import {
   Flex,
   IconChevronDownV2,
   IconChevronUpV2,
-  Padding,
   SemanticColors
 } from '@blockchain-com/constellation'
 import { format } from 'date-fns'
 
-import { Exchange } from '@core'
-import { formatFiat } from '@core/exchange/utils'
 import {
   CoinType,
   EarnAccountBalanceResponseType,
   EarnEligibleType,
-  FiatType,
   StakingRatesType
 } from '@core/types'
 import { Button, Icon, Link, Text } from 'blockchain-info-components'
@@ -25,14 +21,13 @@ import { EarnStepMetaData, PendingTransactionType } from 'data/types'
 
 import { EDDMessageContainer } from '../Staking.model'
 import { OwnProps as ParentProps } from '.'
-import Detail from './AccountSummary.detail.template'
+import Detail from './AccountSummary.Detail.template'
 import {
   Bottom,
   Container,
   DetailsWrapper,
   Row,
   StatusIconWrapper,
-  StatusSupplyWrapper,
   StatusWrapper,
   Top,
   TopText,
@@ -44,30 +39,23 @@ const AccountSummary: React.FC<Props> = (props) => {
   const {
     accountBalances,
     coin,
-    flagEDDInterestFileUpload,
     handleClose,
     handleDepositClick,
     handleEDDSubmitInfo,
     handleTransactionsToggled,
-    handleUpLoadDocumentation,
-    handleWithdrawalSupplyInformation,
     isEDDRequired,
     isTransactionsToggled,
     pendingTransactions,
     showSupply,
     stakingEligible,
     stakingRates,
-    stepMetadata,
-    walletCurrency
+    stepMetadata
   } = props
 
   const { coinfig } = window.coins[coin]
   const account = accountBalances && accountBalances[coin]
-  const currencySymbol = Exchange.getSymbol(walletCurrency) as string
-
   const accountBalanceBase = account && account.balance
   const stakingBalanceBase = account && account.totalRewards
-
   const isDepositEnabled = stakingEligible[coin] ? stakingEligible[coin]?.eligible : false
   const { commission, rate } = stakingRates[coin]
 
@@ -98,8 +86,8 @@ const AccountSummary: React.FC<Props> = (props) => {
               <Container>
                 <Text color='grey600' size='14px' weight={500} style={{ marginBottom: '5px' }}>
                   <FormattedMessage
-                    id='modals.staking.balance2'
-                    defaultMessage='Staked {coin}'
+                    id='modals.staking.balance'
+                    defaultMessage='{coin} Balance'
                     values={{ coin }}
                   />
                 </Text>
@@ -179,21 +167,15 @@ const AccountSummary: React.FC<Props> = (props) => {
             <FormattedMessage id='modals.interest.summary' defaultMessage='Summary' />
           </Text>
           <Detail
+            subValue={`${commission}%`}
             text={
               <FormattedMessage
                 defaultMessage='Current rate'
                 id='modals.staking.accountsummary.currentrate'
               />
             }
-            subText={
-              <FormattedMessage
-                defaultMessage='Blockchain.com fee'
-                id='modals.staking.accountsummary.fee'
-              />
-            }
-            tooltipId='modals.staking.summary.fee.tooltip'
+            textTooltipId='modals.staking.summary.fee.tooltip'
             value={`${rate}%`}
-            subValue={`${commission}%`}
           />
           <Detail
             text={
@@ -353,20 +335,16 @@ const AccountSummary: React.FC<Props> = (props) => {
 type OwnProps = {
   accountBalances: EarnAccountBalanceResponseType
   coin: CoinType
-  flagEDDInterestFileUpload: boolean
   handleBSClick: (string) => void
   handleDepositClick: () => void
   handleEDDSubmitInfo: () => void
   handleTransactionsToggled: () => void
-  handleUpLoadDocumentation: () => void
-  handleWithdrawalSupplyInformation: () => void
   isEDDRequired: boolean
   isTransactionsToggled: boolean
   pendingTransactions: Array<PendingTransactionType>
   stakingEligible: EarnEligibleType
   stakingRates: StakingRatesType['rates']
   stepMetadata: EarnStepMetaData
-  walletCurrency: FiatType
 }
 
 export type Props = OwnProps & ParentProps

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/index.tsx
@@ -18,6 +18,8 @@ const PENDING_TRANSACTIONS_MAX = 4
 
 const AccountSummaryContainer = (props: OwnProps) => {
   const [isTransactionsToggled, setIsTransactionsToggled] = useState<boolean>(false)
+  const [isCoinDisplayed, setIsCoinDisplayed] = useState<boolean>(true)
+  const [isBalanceDropdownToggled, setIsBalanceDropdownToggled] = useState<boolean>(false)
   const { coin, handleClose, showSupply, stepMetadata, walletCurrency } = props
   const { data, error, isLoading, isNotAsked } = useRemote(getData)
   const dispatch = useDispatch()
@@ -79,12 +81,12 @@ const AccountSummaryContainer = (props: OwnProps) => {
     setIsTransactionsToggled(!isTransactionsToggled)
   }
 
-  const handleWithdrawalSupplyInformation = () => {
-    dispatch(
-      actions.components.interest.handleWithdrawalSupplyInformation({
-        origin: 'SavingsConfirmation'
-      })
-    )
+  const handleCoinToggled = () => {
+    setIsCoinDisplayed(!isCoinDisplayed)
+  }
+
+  const handleBalanceDropdown = () => {
+    setIsBalanceDropdownToggled(!isBalanceDropdownToggled)
   }
 
   if (error) return <DataError onClick={handleRefresh} />
@@ -93,11 +95,10 @@ const AccountSummaryContainer = (props: OwnProps) => {
   const {
     accountBalances,
     earnEDDStatus: { eddNeeded, eddPassed, eddSubmitted },
-    flagEDDInterestFileUpload,
     pendingTransactions,
     stakingEligible,
-    stakingLimits,
-    stakingRates
+    stakingRates,
+    totalBondingDeposits
   } = data
 
   const isEDDRequired = eddNeeded && !eddSubmitted && !eddPassed
@@ -106,21 +107,23 @@ const AccountSummaryContainer = (props: OwnProps) => {
     <AccountSummary
       accountBalances={accountBalances}
       coin={coin}
-      // @ts-ignore
-      flagEDDInterestFileUpload={flagEDDInterestFileUpload}
+      handleBalanceDropdown={handleBalanceDropdown}
       handleClose={handleClose}
+      handleCoinToggled={handleCoinToggled}
       handleDepositClick={handleDepositClick}
       handleEDDSubmitInfo={handleEDDSubmitInfo}
       handleTransactionsToggled={handleTransactionsToggled}
-      handleWithdrawalSupplyInformation={handleWithdrawalSupplyInformation}
+      isBalanceDropdownToggled={isBalanceDropdownToggled}
+      isCoinDisplayed={isCoinDisplayed}
       isEDDRequired={isEDDRequired}
       isTransactionsToggled={isTransactionsToggled}
       pendingTransactions={pendingTransactions}
       stakingEligible={stakingEligible}
-      stakingLimits={stakingLimits}
       stakingRates={stakingRates}
       showSupply={showSupply}
       stepMetadata={stepMetadata}
+      totalBondingDeposits={totalBondingDeposits}
+      walletCurrency={walletCurrency}
     />
   ) : (
     <Unsupported handleClose={handleClose} walletCurrency={walletCurrency} />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/AccountSummary/index.tsx
@@ -79,15 +79,6 @@ const AccountSummaryContainer = (props: OwnProps) => {
     setIsTransactionsToggled(!isTransactionsToggled)
   }
 
-  const handleUpLoadDocumentation = () => {
-    // confirm if this is the same for staking
-    dispatch(
-      actions.components.interestUploadDocument.showModal({
-        origin: 'InterestUploadDocument'
-      })
-    )
-  }
-
   const handleWithdrawalSupplyInformation = () => {
     dispatch(
       actions.components.interest.handleWithdrawalSupplyInformation({
@@ -121,7 +112,6 @@ const AccountSummaryContainer = (props: OwnProps) => {
       handleDepositClick={handleDepositClick}
       handleEDDSubmitInfo={handleEDDSubmitInfo}
       handleTransactionsToggled={handleTransactionsToggled}
-      handleUpLoadDocumentation={handleUpLoadDocumentation}
       handleWithdrawalSupplyInformation={handleWithdrawalSupplyInformation}
       isEDDRequired={isEDDRequired}
       isTransactionsToggled={isTransactionsToggled}
@@ -131,7 +121,6 @@ const AccountSummaryContainer = (props: OwnProps) => {
       stakingRates={stakingRates}
       showSupply={showSupply}
       stepMetadata={stepMetadata}
-      walletCurrency={walletCurrency}
     />
   ) : (
     <Unsupported handleClose={handleClose} walletCurrency={walletCurrency} />

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Staking/Warning/Warning.template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Staking/Warning/Warning.template.tsx
@@ -40,7 +40,7 @@ const Warning = ({ bondingDays, coin, handleClick, handleClose }: OwnProps) => (
         </Text>
         <Text color='grey600' size='16px' weight={500}>
           <FormattedMessage
-            defaultMessage='Once staked, {coin} funds can’t be unstaked or transferred for an unknown period of time. {br}{br} Your {coin} will also be subject to a bonding period of {bondingDays} {days} before it generates rewards.'
+            defaultMessage='Once staked, {coin} funds can’t be unstaked or transferred for an unknown period of time. {br}{br} This may be up 6 to 12 months away, but could be even longer. {br}{br} Your {coin} will also be subject to a bonding period of {bondingDays} {days} before it generates rewards.'
             id='modals.staking.warning.content.subtitle'
             values={{
               bondingDays,


### PR DESCRIPTION
## Description (optional)
* add a balancedropdown to staking manage screen
* change Staked {token} to {token} balance
* If user has pending transactions between 1 & 4, pending transactions will automatically open
* Show user how many pending transactions they currently have
* rework fee detail row
* update copy on staking warning modal
* fix pending transfer value
* fix minimum amount error value in staking deposit modal

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

