### PR TITLE
fix(recurringBuy): filter out inactive recurring buys from response

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/recurringBuy/slice.test.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/recurringBuy/slice.test.ts
@@ -1,0 +1,32 @@
+import Remote from '@core/remote'
+import {
+  RecurringBuyItemState,
+  RecurringBuyRegisteredList
+} from 'data/components/recurringBuy/types'
+
+import { actions, reducer } from './slice'
+
+const makeRecurringBuys = (id: string, isActive: boolean) =>
+  ({
+    id,
+    state: isActive ? RecurringBuyItemState.ACTIVE : RecurringBuyItemState.INACTIVE
+  } as RecurringBuyRegisteredList)
+
+describe('Recurring buys reducer', () => {
+  describe('when registeredListSuccess action received', () => {
+    it('should store only active recurring buys', () => {
+      const activeBuys = [makeRecurringBuys('1', true), makeRecurringBuys('2', true)]
+      const inactiveBuys = [makeRecurringBuys('3', false), makeRecurringBuys('4', false)]
+
+      expect(
+        reducer(undefined, actions.registeredListSuccess([...activeBuys, ...inactiveBuys]))
+      ).toEqual(
+        expect.objectContaining({
+          registeredList: Remote.of(activeBuys)
+        })
+      )
+    })
+  })
+
+  it.todo('other cases')
+})

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/recurringBuy/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/recurringBuy/slice.ts
@@ -2,7 +2,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import Remote from '@core/remote'
-import { ModalOriginType, RecurringBuyOrigins, SetPeriodPayload } from 'data/types'
+import {
+  ModalOriginType,
+  RecurringBuyItemState,
+  RecurringBuyOrigins,
+  SetPeriodPayload
+} from 'data/types'
 
 import {
   RecurringBuyNextPayment,
@@ -46,7 +51,9 @@ const recurringBuySlice = createSlice({
       state.registeredList = Remote.Loading
     },
     registeredListSuccess: (state, action: PayloadAction<RecurringBuyRegisteredList[]>) => {
-      state.registeredList = Remote.Success(action.payload)
+      state.registeredList = Remote.Success(
+        action.payload.filter(({ state }) => state === RecurringBuyItemState.ACTIVE)
+      )
     },
     removeRecurringBuy: (state, action: PayloadAction<RecurringBuyRegisteredList['id']>) => {},
     setActive: (state, action: PayloadAction<RecurringBuyRegisteredList>) => {


### PR DESCRIPTION
## Description
Due to Back-End change, inactive recurring orders are returned in the recurring orders list response. Right now, if user deletes a recurring buy order - it still appears on the page. The solution is to implement filtering on our side.

