### PR TITLE
feat(Prices): change default sorting on Prices page

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/selectors.ts
@@ -4,6 +4,8 @@ import { ExtractSuccess } from '@core/types'
 import { createDeepEqualSelector } from '@core/utils'
 import { selectors } from 'data'
 
+import { sortCoins } from './utils'
+
 export const getData = createDeepEqualSelector(
   [
     selectors.prices.getAllCoinPrices,
@@ -44,9 +46,11 @@ export const getData = createDeepEqualSelector(
       })
 
       // filter out undefined coins, zero value coins and coins with inflated marketcaps
-      return coinPricesList?.filter((coin) => {
+      const filteredCoinPricesList = coinPricesList.filter((coin) => {
         return coin.price && coin.price !== 0 && coin.coin !== 'HOKK'
       })
+
+      return sortCoins(filteredCoinPricesList)
     }
 
     return lift(transform)(coinPricesR, coinPricesPreviousR)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/template.success.tsx
@@ -23,10 +23,6 @@ export const TableBodyWrapper = styled.div`
   overflow: hidden;
 `
 
-const initialState = {
-  sortBy: [{ desc: true, id: 'marketCap' }]
-}
-
 const PricesTable = (props: Props) => {
   const {
     buySellActions,
@@ -64,11 +60,7 @@ const PricesTable = (props: Props) => {
     {
       columns,
       data,
-      initialState,
-      ...{
-        disableMultiSort: true,
-        disableSortRemove: true
-      }
+      disableMultiSort: true
     },
     useGlobalFilter,
     useSortBy

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/utils.test.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/utils.test.ts
@@ -1,0 +1,31 @@
+import { sortCoins } from './utils'
+
+describe('sortCoins', () => {
+  it('should sort by trading asset and market cap descending, and name ascending', function () {
+    const coins = [
+      {
+        marketCap: 1_000_000_000_000,
+        name: 'A no name token',
+        products: []
+      },
+      {
+        marketCap: 143_384_797_008,
+        name: 'Ethereum (ETH)',
+        products: ['CustodialWalletBalance' as const]
+      },
+      {
+        marketCap: 331_609_356_886,
+        name: 'A same market cap but different name Bitcoin (BTC)',
+        products: ['CustodialWalletBalance' as const]
+      },
+      {
+        marketCap: 331_609_356_886,
+        name: 'Bitcoin (BTC)',
+        products: ['CustodialWalletBalance' as const]
+      }
+    ]
+
+    const sortedCoins = sortCoins(coins)
+    expect(sortedCoins).toEqual([coins[2], coins[3], coins[1], coins[0]])
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Prices/utils.ts
@@ -1,0 +1,21 @@
+import { ascend, descend, prop, sortWith } from 'ramda'
+
+import { CoinfigType } from '@core/redux/walletOptions/types'
+
+export const sortCoins = <
+  T extends {
+    marketCap: number
+    name: string
+    products: CoinfigType['products']
+  }
+>(
+  coins: T[]
+) =>
+  sortWith<T>(
+    [
+      descend((coin) => coin.products.includes('CustodialWalletBalance')),
+      descend(prop('marketCap')),
+      ascend(prop('name'))
+    ],
+    coins
+  )


### PR DESCRIPTION
## Description
Replaces existing default sort by just market cap with the following sort order:
1. Trading Assets
2. Descending by Market Cap
3. Ascending Alphabetically


