### PR TITLE
fix(Home): fix the way how linear domain is padded

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Chart/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Chart/template.success.tsx
@@ -15,6 +15,8 @@ import { fiatToString } from '@core/exchange/utils'
 import { CoinType, FiatType } from '@core/types'
 import { Color } from 'blockchain-info-components'
 
+import { padLinearDomain } from './utils'
+
 type Data = [number, number]
 
 const formatDate = timeFormat("%b %d, '%y")
@@ -80,17 +82,14 @@ const Chart = ({ coin, currency, data }: OwnProps) => {
     [width, data]
   )
 
-  const yScale = useMemo(
-    () =>
-      scaleLinear({
-        domain: [
-          (min(data, getXValue) || 0) - height / 5,
-          (max(data, getXValue) || 0) + height / 5
-        ],
-        range: [height, 0]
-      }),
-    [height, data]
-  )
+  const yScale = useMemo(() => {
+    const domain: [number, number] = [min(data, getXValue) || 0, max(data, getXValue) || 0]
+
+    return scaleLinear({
+      domain: padLinearDomain(domain, 0.1),
+      range: [height, 0]
+    })
+  }, [height, data])
 
   const handleTooltip = useCallback(
     (event: EventType) => {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Chart/utils.test.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Chart/utils.test.ts
@@ -1,0 +1,12 @@
+import { padLinearDomain } from './utils'
+
+describe('Chart utils', () => {
+  describe('padLinearDomain', () => {
+    it.each([
+      [[0, 8] as [number, number], 0.5, [-2, 10]],
+      [[0, 8] as [number, number], 0.25, [-1, 9]]
+    ])('should correctly pad domain %#', (domain, k, expected) => {
+      expect(padLinearDomain(domain, k)).toEqual(expected)
+    })
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Chart/utils.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Chart/utils.ts
@@ -1,0 +1,8 @@
+/**
+ * @returns Linear domain with padding applied.
+ */
+export const padLinearDomain = ([x0, x1]: [number, number], k: number) => {
+  const dx = ((x1 - x0) * k) / 2
+
+  return [x0 - dx, x1 + dx]
+}


### PR DESCRIPTION
## Description
Application of padding relative to the height of the chart was causing issue with scale for assets with lower price. Thus, the padding values should be relative to the values domain.

| Before  | After |
| ------------- | ------------- |
| <img width="818" alt="Screenshot 2022-10-25 at 14 20 22" src="https://user-images.githubusercontent.com/114945181/197784288-621dbb2e-6adc-4c3b-8a70-f1627ecd4f39.png"> | <img width="818" alt="Screenshot 2022-10-25 at 14 20 26" src="https://user-images.githubusercontent.com/114945181/197784339-2d6c2da6-cf70-45ec-973e-c5a75e577bf1.png">  |
| <img width="818" alt="Screenshot 2022-10-25 at 14 20 31" src="https://user-images.githubusercontent.com/114945181/197784436-64390f81-3055-412c-b897-a072e2e92ae9.png">  | <img width="818" alt="Screenshot 2022-10-25 at 14 20 35" src="https://user-images.githubusercontent.com/114945181/197784527-f6b02521-a099-4370-9261-17ce3be0593c.png">  |