### PR TITLE
fix(RecurringBuy): check if color exists before passing it to polishe…

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Box/SavedRecurringBuy.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Box/SavedRecurringBuy.tsx
@@ -44,7 +44,11 @@ const SyncIconWrapper = styled.div<{ coin: string }>`
   min-width: 40px;
   border-radius: 20px;
   margin-right: 20px;
-  background-color: ${(props) => lighten(0.35, props.theme[props.coin])};
+  background-color: ${(props) => {
+    const coinColor = props.theme[props.coin]
+
+    return coinColor ? lighten(0.35, coinColor) : props.theme.grey100
+  }};
 `
 
 const SavedRecurringBuy = ({ action, amount, coin, nextPayment, onClick, period }: Props) => {


### PR DESCRIPTION
## Description
Without explicit check for color existence, the application crashes with the following error:

<img width="659" alt="Screen Shot 2022-11-01 at 8 04 30 PM" src="https://user-images.githubusercontent.com/114945181/199751643-6c98f409-1f9f-4c6d-b433-70ed27707c0d.png">
