### PR TITLE
fix(buy): poll confirmed buy fund order

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
@@ -1002,13 +1002,10 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
       const confirmedOrder: BSOrderType = yield call(api.confirmBSOrder, {
         order
       })
-      yield put(actions.form.stopSubmit(FORM_BS_CHECKOUT_CONFIRM))
+
+      yield call(confirmOrderPoll, A.confirmOrderPoll(confirmedOrder))
+
       yield put(A.fetchOrders())
-      yield put(A.confirmOrderSuccess(confirmedOrder))
-
-      yield put(cacheActions.removeLastUsedAmount({ pair: confirmedOrder.pair }))
-
-      yield put(A.setStep({ step: 'ORDER_SUMMARY' }))
     } catch (e) {
       if (isNabuError(e)) {
         yield put(actions.form.stopSubmit(FORM_BS_CHECKOUT_CONFIRM, { _error: e }))


### PR DESCRIPTION
## Description
Order processing became asynchronous in Feynman, thus, we need to poll for order completion. Making this change for funds orders only for now as requirements for other payment types are not clear right now.

## Testing Steps
Select funds payment method and place an order. You should see success screen instead of pending.

