### PR TITLE
feat(ErrorBoundary): track caught errors

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/providers/ErrorBoundaryProvider/index.test.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/providers/ErrorBoundaryProvider/index.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+import { Provider } from 'react-redux'
+import { BrowserRouter } from 'react-router-dom'
+import { render } from '@testing-library/react'
+import configureStore from 'redux-mock-store'
+import { ThemeProvider } from 'styled-components'
+
+import { Palette } from 'blockchain-info-components'
+import { Analytics } from 'data/analytics/types'
+
+import ErrorBoundary from './index'
+
+const setup = (children: React.ReactNode) => {
+  const store = configureStore()({
+    auth: {}
+  })
+
+  render(
+    <BrowserRouter>
+      <IntlProvider locale='en' messages={{}}>
+        <ThemeProvider theme={Palette('default')}>
+          <Provider store={store}>
+            <ErrorBoundary>{children}</ErrorBoundary>
+          </Provider>
+        </ThemeProvider>
+      </IntlProvider>
+    </BrowserRouter>
+  )
+
+  return {
+    store
+  }
+}
+
+describe('ErrorBoundary', () => {
+  describe('when children did not throw error', () => {
+    const ComponentWithoutError = () => {
+      return null
+    }
+
+    it('should not dispatch any actions', () => {
+      const { store } = setup(<ComponentWithoutError />)
+
+      expect(store.getActions()).toEqual([])
+    })
+  })
+
+  describe('when children throw error', () => {
+    const ComponentWithError = () => {
+      throw new Error('Some client error')
+    }
+
+    it('should dispatch event tracking with correct payload', () => {
+      const { store } = setup(<ComponentWithError />)
+
+      expect(store.getActions()).toEqual([
+        {
+          payload: {
+            key: Analytics.CLIENT_ERROR,
+            properties: {
+              error: 'FATAL_ERROR',
+              source: 'CLIENT',
+              title: 'Some client error'
+            }
+          },
+          type: 'trackEvent'
+        }
+      ])
+    })
+  })
+
+  it.todo('other test cases')
+})

--- a/packages/blockchain-wallet-v4-frontend/src/providers/ErrorBoundaryProvider/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/providers/ErrorBoundaryProvider/index.tsx
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router-dom'
 import { bindActionCreators } from 'redux'
 
 import { actions, selectors } from 'data'
+import { Analytics } from 'data/analytics/types'
 
 import NewVersionAvailable from './newversion.template'
 import ErrorModal from './template'
@@ -19,6 +20,15 @@ class ErrorBoundary extends React.Component<Props, { error: null | TypeError }> 
   componentDidCatch(error) {
     this.setState({
       error
+    })
+
+    this.props.analyticsActions.trackEvent({
+      key: Analytics.CLIENT_ERROR,
+      properties: {
+        error: 'FATAL_ERROR',
+        source: 'CLIENT',
+        title: error.message
+      }
     })
   }
 
@@ -51,8 +61,7 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = (dispatch) => ({
-  authActions: bindActionCreators(actions.auth, dispatch),
-  routerActions: bindActionCreators(actions.router, dispatch)
+  analyticsActions: bindActionCreators(actions.analytics, dispatch)
 })
 
 const connector = connect(mapStateToProps, mapDispatchToProps)


### PR DESCRIPTION
## Description
Currently we are not tracking errors that are coming from our components and crash the whole React tree. We already have an error boundary that displays an error modal, so we shall track caught errors there too.