### PR TITLE
fix(EnterAmount): fetch orders for default method to be available

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/index.tsx
@@ -44,6 +44,7 @@ const EnterAmount = (props: Props) => {
       props.brokerageActions.fetchBankTransferAccounts()
       props.buySellActions.fetchCards(false)
       props.buySellActions.fetchSDDEligibility()
+      props.buySellActions.fetchOrders()
     }
 
     // data was successful but paymentMethods was DEFAULT_BS_METHODS


### PR DESCRIPTION
## Description
If the Enter Amount screen is accessed directly (e.g. by clicking Buy Bitcoin on home page), orders have to be fetched for default method to be available and Enter Amount screen to load.

## Testing Steps
Click buy on home or coin page.

