### PR TITLE
feat(EnterAmount): remove crypto amount

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { getQuote } from 'blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/validation'
+import { getQuote } from 'blockchain-wallet-v4-frontend/src/modals/BuySell/SellEnterAmount/Checkout/validation'
 import { defaultTo, filter, prop } from 'ramda'
 import { call, cancel, delay, fork, put, race, retry, select, take } from 'redux-saga/effects'
 
@@ -37,7 +37,6 @@ import {
   BankPartners,
   BankTransferAccountType,
   BrokerageModalOriginType,
-  BuyQuoteStateType,
   CustodialSanctionsEnum,
   ModalName,
   ProductEligibilityForUser,
@@ -77,6 +76,7 @@ import {
   ORDER_POLLING,
   SDD_TIER
 } from './model'
+import { createBuyQuoteLoopAndWaitForFirstResult } from './sagas/createBuyQuoteLoopAndWaitForFirstResult'
 import * as S from './selectors'
 import { actions as A } from './slice'
 import * as T from './types'
@@ -346,13 +346,8 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
 
       // since two screens use this order creation saga and they have different
       // forms, detect the order type and set correct form to submitting
-      let buyQuote: BuyQuoteStateType | undefined
-      if (orderType === OrderType.SELL) {
-        yield put(actions.form.startSubmit(FORM_BS_PREVIEW_SELL))
-      } else {
-        buyQuote = S.getBuyQuote(yield select()).getOrFail(BS_ERROR.NO_QUOTE)
-        yield put(actions.form.startSubmit(FORM_BS_CHECKOUT))
-      }
+      const formName = OrderType.SELL ? FORM_BS_PREVIEW_SELL : FORM_BS_CHECKOUT
+      yield put(actions.form.startSubmit(formName))
 
       const fiat = getFiatFromPair(pair.pair)
       const coin = getCoinFromPair(pair.pair)
@@ -418,6 +413,15 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
       }
 
       if (!paymentType) throw new Error(BS_ERROR.NO_PAYMENT_TYPE)
+
+      yield call(createBuyQuoteLoopAndWaitForFirstResult, {
+        amount,
+        pair: pair.pair,
+        paymentMethod: paymentType,
+        paymentMethodId
+      })
+
+      const buyQuote = S.getBuyQuote(yield select()).getOrFail(BS_ERROR.NO_QUOTE)
 
       if (buyQuote) {
         const { availability, reason } = buyQuote.quote.settlementDetails
@@ -1721,16 +1725,7 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
   }
 
   const initializeCheckout = function* ({
-    payload: {
-      account,
-      amount,
-      cryptoAmount,
-      fix,
-      orderType,
-      paymentMethodId,
-      paymentMethodType,
-      period
-    }
+    payload: { account, amount, cryptoAmount, fix, orderType, period }
   }: ReturnType<typeof A.initializeCheckout>) {
     try {
       yield call(waitForUserData)
@@ -1738,23 +1733,8 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
       if (!fiatCurrency) throw new Error(BS_ERROR.NO_FIAT_CURRENCY)
       const pair = S.getBSPair(yield select())
       if (!pair) throw new Error(BS_ERROR.NO_PAIR_SELECTED)
-      // Fetch rates
-      if (orderType === OrderType.BUY) {
-        const fakeQuoteAmount = '1000'
 
-        yield put(
-          A.startPollBuyQuote({
-            amount: fakeQuoteAmount,
-            pair: pair.pair,
-            paymentMethod: paymentMethodType,
-            paymentMethodId
-          })
-        )
-        yield race({
-          failure: take(A.fetchBuyQuoteFailure.type),
-          success: take(A.fetchBuyQuoteSuccess.type)
-        })
-      } else if (orderType === OrderType.SELL) {
+      if (orderType === OrderType.SELL) {
         if (!account) throw new Error(BS_ERROR.NO_ACCOUNT)
         yield put(A.fetchSellQuote({ account, pair: pair.pair }))
         yield put(A.startPollSellQuote({ account, pair: pair.pair }))

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas/createBuyQuoteLoopAndWaitForFirstResult.test.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas/createBuyQuoteLoopAndWaitForFirstResult.test.ts
@@ -1,0 +1,54 @@
+import { expectSaga } from 'redux-saga-test-plan'
+
+import { BSPaymentTypes } from '@core/network/api/buySell/types'
+import { createBuyQuoteLoopAndWaitForFirstResult } from 'data/components/buySell/sagas/createBuyQuoteLoopAndWaitForFirstResult'
+import { actions as A } from 'data/components/buySell/slice'
+
+const PAYLOAD = {
+  amount: '5',
+  pair: 'GBP-BTC',
+  paymentMethod: BSPaymentTypes.FUNDS,
+  paymentMethodId: undefined
+}
+
+const EXPECTED_RETURN = undefined
+
+describe('createBuyQuoteLoopAndWaitForFirstResult', () => {
+  it('should start buy quote poll with provided payload', () => {
+    return expectSaga(createBuyQuoteLoopAndWaitForFirstResult, PAYLOAD)
+      .put(A.startPollBuyQuote(PAYLOAD))
+      .silentRun()
+  })
+
+  it('should wait for quote success or failure', () => {
+    return expectSaga(createBuyQuoteLoopAndWaitForFirstResult, PAYLOAD)
+      .not.returns(EXPECTED_RETURN)
+      .silentRun()
+  })
+
+  describe('then', () => {
+    describe('when quote fetch failed', () => {
+      it('should complete', () => {
+        return expectSaga(createBuyQuoteLoopAndWaitForFirstResult, PAYLOAD)
+          .provide({
+            race: () => ({ type: A.fetchBuyQuoteFailure.type })
+          })
+          .returns(EXPECTED_RETURN)
+          .silentRun()
+      })
+    })
+
+    describe('when quote fetch succeeded', () => {
+      it('should complete', () => {
+        return expectSaga(createBuyQuoteLoopAndWaitForFirstResult, PAYLOAD)
+          .provide({
+            race: () => ({
+              type: A.fetchBuyQuoteSuccess.type
+            })
+          })
+          .returns(EXPECTED_RETURN)
+          .silentRun()
+      })
+    })
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas/createBuyQuoteLoopAndWaitForFirstResult.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas/createBuyQuoteLoopAndWaitForFirstResult.ts
@@ -1,0 +1,31 @@
+import { put, race, take } from 'typed-redux-saga'
+
+import { BSCardType, BSPairsType, BSPaymentTypes } from '@core/network/api/buySell/types'
+
+import { actions as A } from '../slice'
+
+export const createBuyQuoteLoopAndWaitForFirstResult = function* ({
+  amount,
+  pair,
+  paymentMethod,
+  paymentMethodId
+}: {
+  amount: string
+  pair: BSPairsType
+  paymentMethod: BSPaymentTypes
+  paymentMethodId?: BSCardType['id']
+}) {
+  yield* put(
+    A.startPollBuyQuote({
+      amount,
+      pair,
+      paymentMethod,
+      paymentMethodId
+    })
+  )
+
+  yield* race({
+    failure: take(A.fetchBuyQuoteFailure.type),
+    success: take(A.fetchBuyQuoteSuccess.type)
+  })
+}

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/selectors.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { getQuote } from 'blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/validation'
+import { getQuote } from 'blockchain-wallet-v4-frontend/src/modals/BuySell/SellEnterAmount/Checkout/validation'
 import memoize from 'fast-memoize'
 import { head, isEmpty, isNil, lift } from 'ramda'
 import { createSelector } from 'reselect'

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/types.ts
@@ -221,8 +221,6 @@ export type InitializeCheckout = {
   orderType: BSOrderActionType
   pair?: BSPairType
   pairs: Array<BSPairType>
-  paymentMethodId?: BSPaymentMethodType['id']
-  paymentMethodType: BSPaymentTypes
   period: RecurringBuyPeriods
 }
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/index.tsx
@@ -17,13 +17,7 @@ import { actions, model, selectors } from 'data'
 import { PartialClientErrorProperties } from 'data/analytics/types/errors'
 import { getValidPaymentMethod } from 'data/components/buySell/model'
 import { RootState } from 'data/rootReducer'
-import {
-  Analytics,
-  BSCheckoutFormValuesType,
-  ModalName,
-  RecurringBuyPeriods,
-  SwapBaseCounterTypes
-} from 'data/types'
+import { Analytics, BSCheckoutFormValuesType, ModalName, RecurringBuyPeriods } from 'data/types'
 import { useRemote } from 'hooks'
 import { isNabuError } from 'services/errors'
 
@@ -42,7 +36,7 @@ const Checkout = (props: Props) => {
     string | PartialClientErrorProperties | undefined,
     ExtractSuccess<ReturnType<typeof getData>>,
     RootState
-  >((state) => getData(state, props))
+  >(getData)
 
   const formValues = useSelector((state: RootState) =>
     selectors.form.getFormValues(FORM_BS_CHECKOUT)(state)
@@ -74,17 +68,6 @@ const Checkout = (props: Props) => {
 
     const method = props.method || props.defaultMethod
 
-    // TODO: sell
-    // need to do kyc check
-    // SELL
-    if (formValues?.orderType === OrderType.SELL) {
-      return props.buySellActions.setStep({
-        sellOrderType: props.swapAccount?.type,
-        step: 'PREVIEW_SELL'
-      })
-    }
-
-    // BUY
     if (isSddFlow) {
       const currentTier = userData?.tiers?.current ?? 0
 
@@ -171,12 +154,10 @@ const Checkout = (props: Props) => {
       account: props.swapAccount,
       amount,
       cryptoAmount,
-      fix: preferences[props.orderType].fix,
-      orderType: props.orderType,
+      fix: preferences[OrderType.BUY].fix,
+      orderType: OrderType.BUY,
       pair: props.pair,
       pairs: props.pairs,
-      paymentMethodId: props.method?.id || props.defaultMethod?.id,
-      paymentMethodType: props.method?.type || props.defaultMethod?.type || BSPaymentTypes.FUNDS,
       period
     })
 
@@ -189,26 +170,20 @@ const Checkout = (props: Props) => {
     if (!data) {
       props.buySellActions.fetchSDDEligibility()
       props.brokerageActions.fetchBankTransferAccounts()
-      props.recurringBuyActions.fetchPaymentInfo()
     }
     // we fetch limits as part of home banners logic at that point we had only fiatCurrency
     // here we have to re-fetch for crypto currency and order type
     props.buySellActions.fetchLimits({
       cryptoCurrency: props.cryptoCurrency,
       currency: props.fiatCurrency,
-      side: props.orderType || OrderType.BUY
+      side: OrderType.BUY
     })
 
-    const swapFromAccount =
-      props.swapAccount?.type === SwapBaseCounterTypes.ACCOUNT
-        ? WalletAccountEnum.NON_CUSTODIAL
-        : WalletAccountEnum.CUSTODIAL
     // fetch cross border limits
     props.buySellActions.fetchCrossBorderLimits({
-      fromAccount:
-        props.orderType === OrderType.BUY ? WalletAccountEnum.CUSTODIAL : swapFromAccount,
-      inputCurrency: props.orderType === OrderType.BUY ? props.fiatCurrency : props.cryptoCurrency,
-      outputCurrency: props.orderType === OrderType.BUY ? props.cryptoCurrency : props.fiatCurrency,
+      fromAccount: WalletAccountEnum.CUSTODIAL,
+      inputCurrency: props.fiatCurrency,
+      outputCurrency: props.cryptoCurrency,
       toAccount: WalletAccountEnum.CUSTODIAL
     } as CrossBorderLimitsPayload)
 
@@ -257,7 +232,6 @@ const Checkout = (props: Props) => {
     <Success
       formValues={formValues}
       isPristine={isPristine}
-      preferences={preferences}
       {...props}
       {...data}
       onSubmit={handleSubmit}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/selectors.ts
@@ -4,19 +4,12 @@ import { BSPaymentTypes, CrossBorderLimits, ExtractSuccess } from '@core/types'
 import { model, selectors } from 'data'
 import { RootState } from 'data/rootReducer'
 
-import { OwnProps } from '.'
-
 const { FORM_BS_CHECKOUT } = model.components.buySell
 
-const getData = (state: RootState, ownProps: OwnProps) => {
-  const isBuyOrder = ownProps.orderType === 'BUY'
-
+const getData = (state: RootState) => {
   const coin = selectors.components.buySell.getCryptoCurrency(state) || 'BTC'
   const formErrors = selectors.form.getFormSyncErrors(FORM_BS_CHECKOUT)(state)
   const paymentR = selectors.components.buySell.getPayment(state)
-  const quoteR = isBuyOrder
-    ? selectors.components.buySell.getBuyQuote(state)
-    : selectors.components.buySell.getSellQuote(state)
   const ratesR = selectors.core.data.misc.getRatesSelector(coin, state)
   const sbBalancesR = selectors.components.buySell.getBSBalances(state)
   const userDataR = selectors.modules.profile.getUserData(state)
@@ -42,7 +35,6 @@ const getData = (state: RootState, ownProps: OwnProps) => {
   return lift(
     (
       cards: ExtractSuccess<typeof cardsR>,
-      quote: ExtractSuccess<typeof quoteR>,
       rates: ExtractSuccess<typeof ratesR>,
       sbBalances: ExtractSuccess<typeof sbBalancesR>,
       userData: ExtractSuccess<typeof userDataR>,
@@ -62,24 +54,13 @@ const getData = (state: RootState, ownProps: OwnProps) => {
       limits: limitsR.getOrElse(undefined),
       payment: paymentR.getOrElse(undefined),
       products,
-      quote,
       rates,
       sbBalances,
       sddEligible,
       sddLimit,
       userData
     })
-  )(
-    cardsR,
-    quoteR,
-    ratesR,
-    sbBalancesR,
-    userDataR,
-    sddEligibleR,
-    sddLimitR,
-    userSDDTierR,
-    productsR
-  )
+  )(cardsR, ratesR, sbBalancesR, userDataR, sddEligibleR, sddLimitR, userSDDTierR, productsR)
 }
 
 export default getData

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/validation.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/Checkout/validation.tsx
@@ -1,136 +1,25 @@
 import BigNumber from 'bignumber.js'
 
-import { UnitType } from '@core/exchange'
-import Currencies from '@core/exchange/currencies'
-import { coinToString, fiatToString } from '@core/exchange/utils'
 import {
   BSBalancesType,
-  BSOrderActionType,
   BSPairType,
   BSPaymentMethodType,
   BSPaymentTypes,
-  BSQuoteType,
-  OrderType,
   PaymentValue,
-  SwapQuoteStateType,
   SwapUserLimitsType
 } from '@core/types'
-import { getCoinFromPair, getFiatFromPair } from 'data/components/buySell/model'
 import { convertBaseToStandard } from 'data/components/exchange/services'
 import { components } from 'data/model'
-import { BSCheckoutFormValuesType, BSFixType, BuyQuoteStateType, SwapAccountType } from 'data/types'
+import { BSCheckoutFormValuesType, SwapAccountType } from 'data/types'
 
 import { Props } from './template.success'
 import { Limits } from './types'
 
 const { LIMIT } = components.buySell
 
-export const getQuote = (
-  pair: string,
-  rate: number | string,
-  fix: BSFixType,
-  baseAmount?: string
-): string => {
-  if (fix === 'FIAT') {
-    const coin = getCoinFromPair(pair)
-    const decimals = window.coins[coin].coinfig.precision
-    const standardRate = convertBaseToStandard('FIAT', rate)
-    return new BigNumber(baseAmount || '0').dividedBy(standardRate).toFixed(decimals)
-  }
-  const fiat = getFiatFromPair(pair)
-  const decimals = Currencies[fiat].units[fiat as UnitType].decimal_digits
-  const standardRate = convertBaseToStandard('FIAT', rate)
-  return new BigNumber(baseAmount || '0').times(standardRate).toFixed(decimals)
-}
-
-export const getBuyQuote = (
-  pair: string,
-  rate: number | string,
-  fix: BSFixType,
-  baseAmount?: string
-) => {
-  const coin = getCoinFromPair(pair)
-  if (fix === 'FIAT') {
-    const decimals = window.coins[coin].coinfig.precision
-    const standardRate = convertBaseToStandard(coin, rate) // BTC, 2278 = 0.00002278
-    // ex. 0.00002756 BTC * 10,000 USD = 0.2756 BTC
-    return new BigNumber(standardRate).times(baseAmount || '0').toFixed(decimals)
-  }
-  const fiat = getFiatFromPair(pair)
-  const decimals = Currencies[fiat].units[fiat as UnitType].decimal_digits
-  const standardRate = convertBaseToStandard(coin, rate)
-  // ex. 0.2756 BTC / 0.00002756 BTC = 10,000 USD
-  return new BigNumber(baseAmount || '0').dividedBy(standardRate).toFixed(decimals)
-}
-
-export const formatQuote = (amt: string, pair: string, fix: BSFixType): string => {
-  if (fix === 'FIAT') {
-    return coinToString({
-      unit: { symbol: getCoinFromPair(pair) },
-      value: amt
-    })
-  }
-  return fiatToString({
-    unit: getFiatFromPair(pair),
-    value: amt
-  })
-}
-
-// used for sell only now, eventually buy as well
-// TODO: use swap2 quote for buy AND sell
-export const getMaxMinSell = (
-  minOrMax: 'min' | 'max',
-  sbBalances: BSBalancesType,
-  orderType: BSOrderActionType,
-  quote: SwapQuoteStateType,
-  pair: BSPairType,
-  payment?: PaymentValue,
-  allValues?: BSCheckoutFormValuesType,
-  method?: BSPaymentMethodType,
-  account?: SwapAccountType
-): { CRYPTO: string; FIAT: string; type: Limits } => {
-  switch (orderType as OrderType) {
-    case OrderType.BUY:
-      // Not implemented
-      return { CRYPTO: '0', FIAT: '0', type: Limits.ABOVE_MAX }
-    case OrderType.SELL:
-      const coin = getCoinFromPair(pair.pair)
-      const { rate } = quote
-      switch (minOrMax) {
-        case 'max':
-          const maxAvailable = account ? account.balance : sbBalances[coin]?.available || '0'
-
-          const maxSell = new BigNumber(pair.sellMax)
-            .dividedBy(rate)
-            .toFixed(window.coins[coin] ? window.coins[coin].coinfig.precision : 2)
-
-          const userMax = Number(payment ? payment.effectiveBalance : maxAvailable)
-          const maxCrypto = Math.min(
-            Number(convertBaseToStandard(coin, userMax)),
-            Number(maxSell)
-          ).toString()
-          const maxFiat = getQuote(pair.pair, rate, 'CRYPTO', maxCrypto)
-          return { CRYPTO: maxCrypto, FIAT: maxFiat, type: Limits.ABOVE_MAX }
-        case 'min':
-          const minCrypto = new BigNumber(pair.sellMin)
-            .dividedBy(rate)
-            .toFixed(window.coins[coin] ? window.coins[coin].coinfig.precision : 2)
-          const minFiat = convertBaseToStandard('FIAT', pair.sellMin)
-
-          return { CRYPTO: minCrypto, FIAT: minFiat, type: Limits.ABOVE_MAX }
-        default:
-          return { CRYPTO: '0', FIAT: '0', type: Limits.ABOVE_MAX }
-      }
-    default:
-      return { CRYPTO: '0', FIAT: '0', type: Limits.ABOVE_MAX }
-  }
-}
-
 export const getMaxMin = (
   minOrMax: 'min' | 'max',
   sbBalances: BSBalancesType,
-  orderType: BSOrderActionType,
-  QUOTE: BSQuoteType | SwapQuoteStateType | BuyQuoteStateType,
   pair: BSPairType,
   payment?: PaymentValue,
   allValues?: BSCheckoutFormValuesType,
@@ -139,166 +28,117 @@ export const getMaxMin = (
   isSddFlow = false,
   sddLimit = LIMIT,
   limits?: SwapUserLimitsType
-): { CRYPTO: string; FIAT: string; type?: Limits } => {
-  let quote: BSQuoteType | SwapQuoteStateType | BuyQuoteStateType
-  switch (orderType as OrderType) {
-    case OrderType.BUY:
-      quote = QUOTE as BSQuoteType | BuyQuoteStateType
-      let limitType = Limits.ABOVE_MAX
-      switch (minOrMax) {
-        case 'max':
-          // we need minimum of all max amounts including limits
-          let limitMaxAmount = Number(pair.buyMax)
-          let limitMaxChanged = false
-          if (limits?.maxOrder) {
-            const buyMaxItem = Number(limitMaxAmount)
-            // 1000.00 => 100000 since all other amounts are in base we do convert this in base
-            const maxOrderBase = convertBaseToStandard('FIAT', limits.maxOrder, false)
+): { type?: Limits; value: string } => {
+  let limitType = Limits.ABOVE_MAX
+  switch (minOrMax) {
+    case 'max':
+      // we need minimum of all max amounts including limits
+      let limitMaxAmount = Number(pair.buyMax)
+      let limitMaxChanged = false
+      if (limits?.maxOrder) {
+        const buyMaxItem = Number(limitMaxAmount)
+        // 1000.00 => 100000 since all other amounts are in base we do convert this in base
+        const maxOrderBase = convertBaseToStandard('FIAT', limits.maxOrder, false)
 
-            const baseMaxLimitAmount = Number(maxOrderBase)
-            if (baseMaxLimitAmount < buyMaxItem && !isSddFlow) {
-              limitMaxAmount = baseMaxLimitAmount
-              limitMaxChanged = true
-            }
-          }
-
-          const defaultMax = {
-            CRYPTO: getBuyQuote(
-              quote.pair,
-              quote.rate,
-              'FIAT',
-              isSddFlow
-                ? convertBaseToStandard('FIAT', Number(sddLimit.max))
-                : convertBaseToStandard('FIAT', pair.buyMax)
-            ),
-            FIAT: isSddFlow
-              ? convertBaseToStandard('FIAT', Number(sddLimit.max))
-              : convertBaseToStandard('FIAT', pair.buyMax),
-            type: limitType
-          }
-
-          // we have to convert in case that this amount is from maxOrder
-          // we have to convert it to Standard since defaultMax is in standard format
-          const defaultMaxCompare = limitMaxChanged
-            ? Number(convertBaseToStandard('FIAT', limitMaxAmount))
-            : limitMaxAmount
-          if (Number(defaultMax.FIAT) > defaultMaxCompare && limitMaxChanged) {
-            defaultMax.FIAT = String(defaultMaxCompare)
-          }
-
-          if (!allValues) return defaultMax
-          if (!method) return defaultMax
-
-          let max = BigNumber.minimum(
-            method.limits.max,
-            isSddFlow ? sddLimit.max : pair.buyMax,
-            isSddFlow ? sddLimit.max : limitMaxAmount
-          ).toString()
-
-          let fundsChangedMax = false
-          if (method.type === BSPaymentTypes.FUNDS && sbBalances && limits?.maxPossibleOrder) {
-            const available = sbBalances[method.currency]?.available || '0'
-            // available is always in minor string
-            const availableStandard = available
-              ? convertBaseToStandard('FIAT', available)
-              : available
-            switch (true) {
-              case !availableStandard:
-              default:
-                max = '0'
-                break
-              case Number(availableStandard) >= Number(limits.maxPossibleOrder):
-                max = limits.maxPossibleOrder
-                limitType = Limits.ABOVE_LIMIT
-                fundsChangedMax = true
-                break
-              case Number(availableStandard) < Number(limits.maxPossibleOrder):
-                max = availableStandard
-                limitType = Limits.ABOVE_BALANCE
-                fundsChangedMax = true
-                break
-            }
-          }
-
-          const maxFiat = !fundsChangedMax ? convertBaseToStandard('FIAT', max) : max
-
-          const maxCrypto = getBuyQuote(quote.pair, quote.rate, 'FIAT', maxFiat)
-
-          return { CRYPTO: maxCrypto, FIAT: maxFiat, type: limitType }
-        case 'min':
-          // we need maximum of all min amounts including limits
-          let limitMinAmount = Number(pair.buyMin)
-          let limitMinChanged = false
-          if (limits?.minOrder) {
-            const minOrderBase = convertBaseToStandard('FIAT', limits.minOrder, false)
-            const baseMinLimitAmount = Number(minOrderBase)
-            if (baseMinLimitAmount > limitMinAmount && !isSddFlow) {
-              limitMinAmount = baseMinLimitAmount
-              limitMinChanged = true
-            }
-          }
-
-          const defaultMin = {
-            CRYPTO: getBuyQuote(
-              quote.pair,
-              quote.rate,
-              'FIAT',
-              isSddFlow
-                ? convertBaseToStandard('FIAT', Number(sddLimit.min))
-                : convertBaseToStandard('FIAT', pair.buyMin)
-            ),
-            FIAT: isSddFlow
-              ? convertBaseToStandard('FIAT', Number(sddLimit.min))
-              : convertBaseToStandard('FIAT', pair.buyMin)
-          }
-
-          const defaultMinCompare = limitMinChanged
-            ? Number(convertBaseToStandard('FIAT', limitMinAmount))
-            : limitMinAmount
-          if (Number(defaultMin.FIAT) < defaultMinCompare && limitMinChanged) {
-            defaultMin.FIAT = String(defaultMinCompare)
-          }
-
-          if (!allValues) return defaultMin
-          if (!method) return defaultMin
-
-          const min = BigNumber.maximum(
-            method.limits.min,
-            pair.buyMin,
-            isSddFlow ? method.limits.min : limitMinAmount
-          ).toString()
-
-          const minFiat = convertBaseToStandard('FIAT', min)
-
-          const minCrypto = getBuyQuote(quote.pair, quote.rate, 'FIAT', minFiat)
-
-          return { CRYPTO: minCrypto, FIAT: minFiat }
-        default:
-          return { CRYPTO: '0', FIAT: '0' }
+        const baseMaxLimitAmount = Number(maxOrderBase)
+        if (baseMaxLimitAmount < buyMaxItem && !isSddFlow) {
+          limitMaxAmount = baseMaxLimitAmount
+          limitMaxChanged = true
+        }
       }
-    case OrderType.SELL:
-      quote = QUOTE as SwapQuoteStateType
-      return getMaxMinSell(
-        minOrMax,
-        sbBalances,
-        orderType,
-        quote,
-        pair,
-        payment,
-        allValues,
-        method,
-        account
-      )
-    default:
-      return { CRYPTO: '0', FIAT: '0' }
-  }
-}
 
-export const useConvertedValue = (orderType: BSOrderActionType, fix: BSFixType): boolean => {
-  return (
-    (orderType === OrderType.BUY && fix === 'CRYPTO') ||
-    (orderType === OrderType.SELL && fix === 'FIAT')
-  )
+      const defaultMax = {
+        type: limitType,
+        value: isSddFlow
+          ? convertBaseToStandard('FIAT', Number(sddLimit.max))
+          : convertBaseToStandard('FIAT', pair.buyMax)
+      }
+
+      // we have to convert in case that this amount is from maxOrder
+      // we have to convert it to Standard since defaultMax is in standard format
+      const defaultMaxCompare = limitMaxChanged
+        ? Number(convertBaseToStandard('FIAT', limitMaxAmount))
+        : limitMaxAmount
+      if (Number(defaultMax.value) > defaultMaxCompare && limitMaxChanged) {
+        defaultMax.value = String(defaultMaxCompare)
+      }
+
+      if (!allValues) return defaultMax
+      if (!method) return defaultMax
+
+      let max = BigNumber.minimum(
+        method.limits.max,
+        isSddFlow ? sddLimit.max : pair.buyMax,
+        isSddFlow ? sddLimit.max : limitMaxAmount
+      ).toString()
+
+      let fundsChangedMax = false
+      if (method.type === BSPaymentTypes.FUNDS && sbBalances && limits?.maxPossibleOrder) {
+        const available = sbBalances[method.currency]?.available || '0'
+        // available is always in minor string
+        const availableStandard = available ? convertBaseToStandard('FIAT', available) : available
+        switch (true) {
+          case !availableStandard:
+          default:
+            max = '0'
+            break
+          case Number(availableStandard) >= Number(limits.maxPossibleOrder):
+            max = limits.maxPossibleOrder
+            limitType = Limits.ABOVE_LIMIT
+            fundsChangedMax = true
+            break
+          case Number(availableStandard) < Number(limits.maxPossibleOrder):
+            max = availableStandard
+            limitType = Limits.ABOVE_BALANCE
+            fundsChangedMax = true
+            break
+        }
+      }
+
+      const maxFiat = !fundsChangedMax ? convertBaseToStandard('FIAT', max) : max
+
+      return { type: limitType, value: maxFiat }
+    case 'min':
+      // we need maximum of all min amounts including limits
+      let limitMinAmount = Number(pair.buyMin)
+      let limitMinChanged = false
+      if (limits?.minOrder) {
+        const minOrderBase = convertBaseToStandard('FIAT', limits.minOrder, false)
+        const baseMinLimitAmount = Number(minOrderBase)
+        if (baseMinLimitAmount > limitMinAmount && !isSddFlow) {
+          limitMinAmount = baseMinLimitAmount
+          limitMinChanged = true
+        }
+      }
+
+      const defaultMin = {
+        value: isSddFlow
+          ? convertBaseToStandard('FIAT', Number(sddLimit.min))
+          : convertBaseToStandard('FIAT', pair.buyMin)
+      }
+
+      const defaultMinCompare = limitMinChanged
+        ? Number(convertBaseToStandard('FIAT', limitMinAmount))
+        : limitMinAmount
+      if (Number(defaultMin.value) < defaultMinCompare && limitMinChanged) {
+        defaultMin.value = String(defaultMinCompare)
+      }
+
+      if (!allValues) return defaultMin
+      if (!method) return defaultMin
+
+      const min = BigNumber.maximum(
+        method.limits.min,
+        pair.buyMin,
+        isSddFlow ? method.limits.min : limitMinAmount
+      ).toString()
+
+      const minFiat = convertBaseToStandard('FIAT', min)
+
+      return { value: minFiat }
+    default:
+      return { value: '0' }
+  }
 }
 
 export const maximumAmount = (
@@ -313,10 +153,8 @@ export const maximumAmount = (
     isSddFlow,
     limits,
     method: selectedMethod,
-    orderType,
     pair,
     payment,
-    quote,
     sbBalances,
     sddLimit,
     swapAccount
@@ -328,8 +166,6 @@ export const maximumAmount = (
   const maxMinAmount = getMaxMin(
     'max',
     sbBalances,
-    orderType,
-    quote,
     pair,
     payment,
     allValues,
@@ -355,10 +191,8 @@ export const minimumAmount = (
     isSddFlow,
     limits,
     method: selectedMethod,
-    orderType,
     pair,
     payment,
-    quote,
     sbBalances,
     sddLimit,
     swapAccount
@@ -370,8 +204,6 @@ export const minimumAmount = (
       getMaxMin(
         'min',
         sbBalances,
-        orderType,
-        quote,
         pair,
         payment,
         allValues,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/EnterAmount/template.success.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { BSPaymentTypes, FiatType, OrderType } from '@core/types'
+import { FiatType } from '@core/types'
 
 import { Props as OwnProps, SuccessStateType } from '.'
 import Checkout from './Checkout'
@@ -13,21 +13,7 @@ const Success = (props: Props) => {
       (method) => method.limits?.max !== '0' && method.currency === props.fiatCurrency
     )
 
-  // Check to see if user can sell into their wallet's preferred currency
-  // Handles the case where we support credit card buy for the currency but not sell, i.e. CAD
-  const sellCurrencyAvailable =
-    props.orderType === OrderType.BUY ||
-    (props.orderType === OrderType.SELL &&
-      props.paymentMethods.methods
-        .filter((method) => method.type === BSPaymentTypes.FUNDS)
-        .map((method) => method.currency)
-        .includes(props.tradingCurrency))
-
-  return isUserEligible && sellCurrencyAvailable ? (
-    <Checkout {...props} />
-  ) : (
-    <Unsupported {...props} />
-  )
+  return isUserEligible ? <Checkout {...props} /> : <Unsupported {...props} />
 }
 
 export type Props = OwnProps & SuccessStateType & { cryptoCurrency: string; fiatCurrency: FiatType }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/Frequency/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/Frequency/index.tsx
@@ -16,10 +16,6 @@ import getData from './selectors'
 const { FORM_BS_CHECKOUT } = model.components.buySell
 
 class Frequency extends PureComponent<Props> {
-  componentDidMount() {
-    this.props.recurringBuyActions.fetchPaymentInfo()
-  }
-
   handleFrequencySelection = (period: RecurringBuyPeriods) => {
     this.props.formActions.change(FORM_BS_CHECKOUT, 'period', period)
     this.props.backToEnterAmount()

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/OrderSummary/index.tsx
@@ -38,7 +38,6 @@ class OrderSummaryContainer extends PureComponent<Props> {
       this.props.buySellActions.fetchCards(false)
       this.props.sendActions.getLockRule()
       this.props.recurringBuyActions.fetchRegisteredList()
-      this.props.recurringBuyActions.fetchPaymentInfo()
     }
 
     this.props.buySellActions.fetchOrders()

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/SellEnterAmount/Checkout/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/SellEnterAmount/Checkout/index.tsx
@@ -175,8 +175,6 @@ const Checkout = (props: Props) => {
       orderType: props.orderType,
       pair: props.pair,
       pairs: props.pairs,
-      paymentMethodId: props.method?.id || props.defaultMethod?.id,
-      paymentMethodType: props.method?.type || props.defaultMethod?.type || BSPaymentTypes.FUNDS,
       period
     })
 
@@ -189,7 +187,6 @@ const Checkout = (props: Props) => {
     if (!data) {
       props.buySellActions.fetchSDDEligibility()
       props.brokerageActions.fetchBankTransferAccounts()
-      props.recurringBuyActions.fetchPaymentInfo()
     }
     // we fetch limits as part of home banners logic at that point we had only fiatCurrency
     // here we have to re-fetch for crypto currency and order type

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/index.tsx
@@ -70,10 +70,10 @@ class BuySell extends PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    /* eslint-disable */
     this.setState({ show: true })
     this.props.custodialActions.fetchProductEligibilityForUser()
-    /* eslint-enable */
+
+    this.props.recurringBuyActions.fetchPaymentInfo()
   }
 
   componentWillUnmount() {
@@ -369,6 +369,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   formActions: bindActionCreators(actions.form, dispatch),
   preferenceActions: bindActionCreators(actions.preferences, dispatch),
   profileActions: bindActionCreators(actions.modules.profile, dispatch),
+  recurringBuyActions: bindActionCreators(actions.components.recurringBuy, dispatch),
   settingsActions: bindActionCreators(actions.modules.settings, dispatch)
 })
 


### PR DESCRIPTION
## Description (optional)
By removing crypto amount and switch between fiat/crypto (consistent with Android/iOS apps) on Buy screen, we finally can remove creation of fake Buy quotes which cause inconsistencies with numbers we are showing to the users.

| Before  | After |
| ------------- | ------------- |
| <img width="476" alt="Screenshot 2022-12-12 at 16 39 02" src="https://user-images.githubusercontent.com/114945181/207106672-8b093e51-25cd-4391-afc3-49f0feb45f7c.png">  | <img width="476" alt="Screenshot 2022-12-13 at 12 52 30" src="https://user-images.githubusercontent.com/114945181/207323193-bd6b197e-e7ff-4118-b03f-bdbffb6c8575.png">  |

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

