### PR TITLE
fix(dex-tokens): filter DEX coins list

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/dex/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/dex/index.ts
@@ -5,7 +5,7 @@ import {
   getDexUserEligibility
 } from './requests'
 
-export type { DexChain, DexSwapQuote, DexToken } from './types'
+export type { DexChain, DexSwapQuote, DexToken, DexTokenWithBalance } from './types'
 
 export default ({ apiUrl, authorizedGet, authorizedPost, get, post }) => {
   return {

--- a/packages/blockchain-wallet-v4/src/network/api/dex/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/dex/types.ts
@@ -1,5 +1,7 @@
 // TODO: Split this file into domains
-import { CoinType } from '@core/types'
+import type { BigNumber } from 'bignumber.js'
+
+import type { CoinType } from '@core/types'
 
 // single only is supported now
 export type DexVenueName = 'ZEROX'
@@ -24,6 +26,7 @@ export type DexTokenNotNative = DexTokenCommon & {
 }
 
 export type DexToken = DexTokenNative | DexTokenNotNative
+export type DexTokenWithBalance = DexToken & { balance: number | BigNumber }
 
 export type DexChain = {
   chainId: number


### PR DESCRIPTION
## Description (optional)
Atm we have a larger list from DEX backend than we are able to get balances for on FE. Temporary solution is to remove these tokens from the list. Later that problem will be solved. More context here: https://blockc.slack.com/archives/C03C60CF89L/p1672318734848579
