### PR TITLE
feat(Buy): remove usage of order information from checkout screen

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/AvailabilityRows/hooks/useValue.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/AvailabilityRows/hooks/useValue.ts
@@ -3,8 +3,13 @@ import { add, format } from 'date-fns'
 
 import { DepositTerms, DisplayMode } from 'data/types'
 
-const useValue = (type: 'Trade' | 'Withdraw', depositTerms: DepositTerms) => {
+const useValue = (type: 'Trade' | 'Withdraw', depositTerms?: DepositTerms) => {
   const { formatMessage } = useIntl()
+
+  if (!depositTerms) {
+    return undefined
+  }
+
   const minutesMax = depositTerms[`availableTo${type}MinutesMax`]
   const minutesMin = depositTerms[`availableTo${type}MinutesMin`]
   const displayMode = depositTerms[`availableTo${type}DisplayMode`]

--- a/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/AvailabilityRows/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Brokerage/AvailabilityRows/types.ts
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { DepositTerms } from 'data/types'
 
 type AvailabilityRowsProps = {
-  depositTerms: DepositTerms
+  depositTerms?: DepositTerms
 }
 
 export type AvailabilityRowsComponent = FC<AvailabilityRowsProps>

--- a/packages/blockchain-wallet-v4-frontend/src/components/NetworkWarning/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/NetworkWarning/selectors.ts
@@ -5,7 +5,7 @@ import { selectors } from 'data'
 
 const getCoinNetworkIfExistsOnMultiple = (
   coinfig: CoinfigType,
-  coins: Record<string, { coinfig: CoinfigType }>,
+  coins: Coins,
   evmCompatibleCoinSymbols: string[]
 ) => {
   // Non-native asset

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
@@ -1449,7 +1449,7 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
     }
   }
 
-  const fetchBuyQuote = function* ({ payload }: ReturnType<typeof A.fetchBuyQuote>) {
+  const fetchBuyQuote = function* ({ payload }: ReturnType<typeof A.startPollBuyQuote>) {
     while (true) {
       try {
         const { amount, pair, paymentMethod, paymentMethodId } = payload
@@ -1473,8 +1473,11 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
         })
         yield put(
           A.fetchBuyQuoteSuccess({
+            amount,
             fee: quote.feeDetails.fee.toString(),
             pair,
+            paymentMethod,
+            paymentMethodId,
             quote,
             rate: parseInt(quote.price),
             refreshConfig

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/slice.ts
@@ -214,15 +214,6 @@ const buySellSlice = createSlice({
     fetchBalanceSuccess: (state, action: PayloadAction<BSBalancesType>) => {
       state.balances = Remote.Success(action.payload)
     },
-    fetchBuyQuote: (
-      state,
-      action: PayloadAction<{
-        amount: string
-        pair: BSPairsType
-        paymentMethod: BSPaymentTypes
-        paymentMethodId?: BSCardType['id']
-      }>
-    ) => {},
     fetchBuyQuoteFailure: (state, action: PayloadAction<PartialClientErrorProperties>) => {
       state.buyQuote = Remote.Failure(action.payload)
     },

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/types.ts
@@ -153,9 +153,15 @@ export type RefreshConfig = {
 }
 
 export type BuyQuoteStateType = {
+  amount: string
   fee: string
   pair: string
+  paymentMethod: BSPaymentTypes
+  paymentMethodId?: BSCardType['id']
   quote: BuyQuoteType
+  /**
+   * @deprecated
+   */
   rate: number
   refreshConfig: RefreshConfig
 }

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/ConfirmButton.test.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/ConfirmButton.test.tsx
@@ -3,7 +3,7 @@ import { IntlProvider } from 'react-intl'
 import { render, screen } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components'
 
-import { MobilePaymentType, OrderType } from '@core/network/api/buySell/types'
+import { MobilePaymentType } from '@core/network/api/buySell/types'
 import { Palette } from 'blockchain-info-components'
 
 import { useCountDown } from '../hooks/useCountDown'
@@ -19,7 +19,6 @@ const makeDefaultProps = (): Props => ({
   isAcceptedTerms: true,
   isGooglePayReady: false,
   isSubmitting: false,
-  orderType: OrderType.BUY,
   refreshConfig: {
     date: new Date(1653436800000),
     totalMs: 23000
@@ -35,7 +34,7 @@ const setup = (props: Props) =>
     </IntlProvider>
   )
 
-const getBuyButton = () =>
+const getBuyButton = (): HTMLButtonElement =>
   screen.getByRole('button', {
     name: 'Buy Now'
   })
@@ -46,7 +45,7 @@ describe('ConfirmButton', () => {
   it('should display submit button', () => {
     setup(makeDefaultProps())
 
-    const button = getButton()
+    const button = getBuyButton()
 
     expect(button).toBeVisible()
     expect(button).toBeEnabled()
@@ -58,34 +57,6 @@ describe('ConfirmButton', () => {
     setup(props)
 
     expect(useCountDown).toHaveBeenCalledWith(props.refreshConfig.date, props.refreshConfig.totalMs)
-  })
-
-  describe('when orderType is buy', () => {
-    it('should display buy button', () => {
-      setup({
-        ...makeDefaultProps(),
-        orderType: OrderType.BUY
-      })
-
-      const button = getBuyButton()
-
-      expect(button).toBeVisible()
-    })
-  })
-
-  describe('when orderType is sell', () => {
-    it('should display sell button', () => {
-      setup({
-        ...makeDefaultProps(),
-        orderType: OrderType.SELL
-      })
-
-      const button = screen.getByRole('button', {
-        name: 'Sell Now'
-      })
-
-      expect(button).toBeVisible()
-    })
   })
 
   describe('when isSubmitting is true', () => {

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/ConfirmButton.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/ConfirmButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
-import { MobilePaymentType, OrderType } from '@core/types'
+import { MobilePaymentType } from '@core/types'
 import { Button, HeartbeatLoader } from 'blockchain-info-components'
 import { RefreshConfig } from 'data/types'
 
@@ -12,7 +12,6 @@ export type Props = {
   isGooglePayReady: boolean
   isSubmitting: boolean
   mobilePaymentMethod?: MobilePaymentType
-  orderType: keyof typeof OrderType
   refreshConfig: RefreshConfig
 }
 
@@ -37,11 +36,7 @@ export const ConfirmButton = (props: Props) => {
       {props.isSubmitting || isCompletingSoon ? (
         <HeartbeatLoader height='16px' width='16px' color='white' />
       ) : (
-        <FormattedMessage
-          id='buttons.buy_sell_now'
-          defaultMessage='{orderType} Now'
-          values={{ orderType: props.orderType === OrderType.BUY ? 'Buy' : 'Sell' }}
-        />
+        <FormattedMessage id='buttons.buy_now' defaultMessage='Buy Now' />
       )}
     </Button>
   )

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/models/quoteSummaryViewModel.test.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/models/quoteSummaryViewModel.test.ts
@@ -1,0 +1,131 @@
+import { BSPaymentTypes } from '@core/types'
+import { DisplayMode, SettlementReason, SettlementType } from 'data/components/brokerage/types'
+import { BuyQuoteStateType } from 'data/components/buySell/types'
+
+import * as QuoteSummaryViewModel from './quoteSummaryViewModel'
+
+const makeQuoteState = (): BuyQuoteStateType => ({
+  amount: '1500',
+  fee: '49',
+  pair: 'BTC-USD',
+  paymentMethod: BSPaymentTypes.FUNDS,
+  paymentMethodId: '1',
+  quote: {
+    depositTerms: {
+      availableToTradeDisplayMode: DisplayMode.DAY_RANGE,
+      availableToTradeMinutesMax: 0,
+      availableToTradeMinutesMin: 0,
+      availableToWithdrawDisplayMode: DisplayMode.DAY_RANGE,
+      availableToWithdrawMinutesMax: 0,
+      availableToWithdrawMinutesMin: 0,
+      creditCurrency: 'USD',
+      settlementReason: SettlementReason.GENERIC,
+      settlementType: SettlementType.REGULAR,
+      withdrawalLockDays: 0
+    },
+    feeDetails: {
+      fee: '49',
+      feeFlags: [],
+      feeWithoutPromo: '49'
+    },
+    networkFee: '0',
+    price: '5717',
+    quoteCreatedAt: '2023-01-04T13:42:02.199Z',
+    quoteExpiresAt: '2023-01-04T13:44:02.199Z',
+    quoteId: '062ad992-7cb9-44b3-9f01-71f97ccf19b5',
+    quoteMarginPercent: 0.5,
+    resultAmount: '81954',
+    sampleDepositAddress: null,
+    settlementDetails: {
+      availability: 'REGULAR',
+      reason: 'GENERIC'
+    },
+    staticFee: '0'
+  },
+  rate: 5717,
+  refreshConfig: {
+    date: new Date(1672839832199),
+    totalMs: 109891
+  }
+})
+
+const makeCoins = (): Coins => ({
+  BTC: {
+    coinfig: {
+      displaySymbol: 'BTC',
+      name: 'Bitcoin',
+      precision: 8,
+      products: [],
+      symbol: 'BTC',
+      type: {
+        logoPngUrl:
+          'https://raw.githubusercontent.com/blockchain/coin-definitions/master/extensions/blockchains/bitcoin/info/logo.png',
+        minimumOnChainConfirmations: 2,
+        name: 'COIN' as const,
+        websiteUrl: 'https://bitcoin.org'
+      }
+    }
+  },
+  USD: {
+    coinfig: {
+      displaySymbol: 'USD',
+      name: 'US Dollar',
+      precision: 2,
+      products: [],
+      symbol: 'USD',
+      type: {
+        logoPngUrl: '',
+        name: 'FIAT' as const,
+        websiteUrl: ''
+      }
+    }
+  }
+})
+
+describe('quoteSummaryViewModel', () => {
+  describe('make', () => {
+    it('should return make and return quote view model with correct values', () => {
+      const quoteState = makeQuoteState()
+      const coins = makeCoins()
+      const viewModel = QuoteSummaryViewModel.make(quoteState, coins)
+
+      expect(viewModel).toEqual({
+        cryptoDisplaySymbol: 'BTC',
+        depositTerms: quoteState.quote.depositTerms,
+        feeText: '$0.49',
+        fiatCode: 'USD',
+        fiatMinusExplicitFeeText: '$14.51',
+        isTermsConsentRequired: false,
+        oneCoinPrice: '$17,491.69',
+        paymentMethod: quoteState.paymentMethod,
+        paymentMethodId: quoteState.paymentMethodId,
+        refreshConfig: quoteState.refreshConfig,
+        totalCryptoText: '0.00081954 BTC',
+        totalFiatText: '$15.00'
+      })
+    })
+
+    it.each([
+      [BSPaymentTypes.PAYMENT_CARD, true],
+      [BSPaymentTypes.USER_CARD, true],
+      [BSPaymentTypes.BANK_ACCOUNT, false],
+      [BSPaymentTypes.FUNDS, false]
+    ])(
+      'should require terms consent for card payments',
+      (paymentMethod, isTermsConsentRequired) => {
+        const quoteState = {
+          ...makeQuoteState(),
+          paymentMethod
+        }
+        const coins = makeCoins()
+        const viewModel = QuoteSummaryViewModel.make(quoteState, coins)
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            isTermsConsentRequired
+          })
+        )
+      }
+    )
+  })
+})

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/models/quoteSummaryViewModel.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/models/quoteSummaryViewModel.ts
@@ -1,0 +1,131 @@
+import { BigNumber } from 'bignumber.js'
+
+import { fiatToString } from '@core/exchange/utils'
+import { BSPaymentTypes, BuyQuoteType } from '@core/network/api/buySell/types'
+import { getCoinFromPair, getFiatFromPair } from 'data/components/buySell/model'
+import { BuyQuoteStateType } from 'data/components/buySell/types'
+import { convertBaseToStandard } from 'data/components/exchange/services'
+
+const getDepositTerms = (quote: BuyQuoteType) => quote.depositTerms
+
+const makeCryptoDisplaySymbol = ({ coins, pair }: { coins: Coins; pair: string }) => {
+  const cryptoCode = getCoinFromPair(pair)
+
+  return coins[cryptoCode]?.coinfig?.displaySymbol || cryptoCode
+}
+
+/**
+ * @return Price of one coin in fiat (e.g. how much is 1 BTC).
+ */
+const makeOneCoinPrice = ({ pair, quote }: { pair: string; quote: BuyQuoteType }) => {
+  const fiatCode = getFiatFromPair(pair)
+  const cryptoCode = getCoinFromPair(pair)
+
+  const priceStandard = convertBaseToStandard(cryptoCode, quote.price)
+
+  return fiatToString({
+    unit: fiatCode,
+    value: new BigNumber(1).dividedBy(new BigNumber(priceStandard)).toString()
+  })
+}
+
+const makeFeeText = ({ pair, quote }: { pair: string; quote: BuyQuoteType }) => {
+  const fiatCode = getFiatFromPair(pair)
+  const { fee } = quote.feeDetails
+
+  return fiatToString({
+    unit: fiatCode,
+    value: convertBaseToStandard('FIAT', fee)
+  })
+}
+
+const makeFiatMinusExplicitFeeText = ({
+  amountBase,
+  pair,
+  quote
+}: {
+  amountBase: string
+  pair: string
+  quote: BuyQuoteType
+}) => {
+  const fiatCode = getFiatFromPair(pair)
+  const amountStandard = convertBaseToStandard('FIAT', amountBase)
+  const feeStandard = convertBaseToStandard('FIAT', quote.feeDetails.fee)
+
+  return fiatToString({
+    unit: fiatCode,
+    value: new BigNumber(amountStandard).minus(new BigNumber(feeStandard)).toString()
+  })
+}
+
+/**
+ * @returns Total fiat spent (both on crypto and fees).
+ */
+const makeTotalFiatText = ({ amountBase, pair }: { amountBase: string; pair: string }) => {
+  const fiatCode = getFiatFromPair(pair)
+
+  return fiatToString({
+    unit: fiatCode,
+    value: convertBaseToStandard('FIAT', amountBase)
+  })
+}
+
+/**
+ * @returns Total amount of crypto to be received.
+ */
+const makeTotalCryptoText = ({
+  coins,
+  pair,
+  quote
+}: {
+  coins: Coins
+  pair: string
+  quote: BuyQuoteType
+}) => {
+  const { resultAmount } = quote
+
+  const cryptoCode = getCoinFromPair(pair)
+  const cryptoDisplaySymbol = makeCryptoDisplaySymbol({
+    coins,
+    pair
+  })
+  const cryptoAmountStandard = convertBaseToStandard(cryptoCode, resultAmount)
+
+  return `${cryptoAmountStandard} ${cryptoDisplaySymbol}`
+}
+
+const makeIsTermsConsentRequired = (paymentMethod: BSPaymentTypes) =>
+  [BSPaymentTypes.PAYMENT_CARD, BSPaymentTypes.USER_CARD].includes(paymentMethod)
+
+export const make = (quoteState: BuyQuoteStateType, coins: Coins) => {
+  const { amount, pair, paymentMethod, paymentMethodId, quote, refreshConfig } = quoteState
+
+  return {
+    cryptoDisplaySymbol: makeCryptoDisplaySymbol({ coins, pair }),
+    depositTerms: getDepositTerms(quote),
+    feeText: makeFeeText({ pair, quote }),
+    fiatCode: getFiatFromPair(pair),
+    fiatMinusExplicitFeeText: makeFiatMinusExplicitFeeText({
+      amountBase: amount,
+      pair,
+      quote
+    }),
+    isTermsConsentRequired: makeIsTermsConsentRequired(paymentMethod),
+    oneCoinPrice: makeOneCoinPrice({
+      pair,
+      quote
+    }),
+    paymentMethod,
+    paymentMethodId,
+    refreshConfig,
+    totalCryptoText: makeTotalCryptoText({
+      coins,
+      pair,
+      quote
+    }),
+    totalFiatText: makeTotalFiatText({
+      amountBase: amount,
+      pair
+    })
+  }
+}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/selectors.ts
@@ -1,13 +1,21 @@
 import { lift } from 'ramda'
+import { createSelector } from 'reselect'
 
 import { ExtractSuccess } from '@core/types'
 import { selectors } from 'data'
 import { RootState } from 'data/rootReducer'
 
+import * as QuoteSummaryViewModel from './models/quoteSummaryViewModel'
+
+const selectQuoteSummaryViewModel = createSelector(
+  [selectors.components.buySell.getBuyQuoteMemoizedByOrder, selectors.core.data.coins.getCoins],
+  (quoteR, coins) => quoteR.map((quoteState) => QuoteSummaryViewModel.make(quoteState, coins))
+)
+
 export const getData = (state: RootState) => {
   const bankAccountsR = selectors.components.brokerage.getBankTransferAccounts(state)
 
-  const quoteR = selectors.components.buySell.getBuyQuoteMemoizedByOrder(state)
+  const quoteSummaryViewModelR = selectQuoteSummaryViewModel(state)
   const sbBalancesR = selectors.components.buySell.getBSBalances(state)
   const sddEligibleR = selectors.components.buySell.getSddEligible(state)
   const userSDDTierR = selectors.components.buySell.getUserSddEligibleTier(state)
@@ -23,7 +31,7 @@ export const getData = (state: RootState) => {
   return lift(
     (
       bankAccounts: ExtractSuccess<typeof bankAccountsR>,
-      quote: ExtractSuccess<typeof quoteR>,
+      quoteSummaryViewModel: ExtractSuccess<typeof quoteSummaryViewModelR>,
       sbBalances: ExtractSuccess<typeof sbBalancesR>,
       userData: ExtractSuccess<typeof userDataR>,
       withdrawLockCheck: ExtractSuccess<typeof withdrawLockCheckR>,
@@ -38,14 +46,14 @@ export const getData = (state: RootState) => {
       isSddFlow: sddEligible.eligible || userSDDTier === 3,
       isUserSddVerified,
       order,
-      quote,
+      quoteSummaryViewModel,
       sbBalances,
       userData,
       withdrawLockCheck
     })
   )(
     bankAccountsR,
-    quoteR,
+    quoteSummaryViewModelR,
     sbBalancesR,
     userDataR,
     withdrawLockCheckR,

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
@@ -7,8 +7,7 @@ import { defaultTo, filter, path, prop } from 'ramda'
 import { clearSubmitErrors, InjectedFormProps, reduxForm } from 'redux-form'
 import styled from 'styled-components'
 
-import { coinToString, fiatToString } from '@core/exchange/utils'
-import { BSPaymentTypes, FiatType, MobilePaymentType, WalletFiatType } from '@core/types'
+import { BSPaymentTypes, MobilePaymentType, WalletFiatType } from '@core/types'
 import { CheckBoxInput, Icon, Link, Text, TextGroup } from 'blockchain-info-components'
 import AvailabilityRows from 'components/Brokerage/AvailabilityRows'
 import { ErrorCartridge } from 'components/Cartridge'
@@ -17,16 +16,7 @@ import { getPeriodSubTitleText, getPeriodTitleText } from 'components/Flyout/mod
 import Form from 'components/Form/Form'
 import { GenericNabuErrorFlyout } from 'components/GenericNabuErrorFlyout'
 import { model } from 'data'
-import {
-  getBaseAmount,
-  getBaseCurrency,
-  getCounterAmount,
-  getCounterCurrency,
-  getFiatFromPair,
-  getOrderType,
-  getPaymentMethodId
-} from 'data/components/buySell/model'
-import { convertBaseToStandard } from 'data/components/exchange/services'
+import { getFiatFromPair } from 'data/components/buySell/model'
 import {
   AddBankStepType,
   Analytics,
@@ -40,12 +30,7 @@ import {
 import { useDefer3rdPartyScript, useSardineContext } from 'hooks'
 import { isNabuError } from 'services/errors'
 
-import {
-  displayFiat,
-  getLockRuleMessaging,
-  getPaymentMethod,
-  getPaymentMethodDetails
-} from '../model'
+import { getLockRuleMessaging, getPaymentMethod, getPaymentMethodDetails } from '../model'
 import { QuoteCountDown } from '../QuoteCountDown'
 import { Props as OwnProps, SuccessStateType } from '.'
 import { ConfirmButton } from './ConfirmButton'
@@ -191,27 +176,7 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
     }
   })
 
-  const orderType = getOrderType(props.order)
-  const baseAmount = getBaseAmount(props.order)
-  const baseCurrency = getBaseCurrency(props.order)
-  const baseCurrencyCoinfig = window.coins[baseCurrency]?.coinfig
-  const baseCurrencyDisplay = baseCurrencyCoinfig?.displaySymbol || baseCurrency
-  const counterAmount = getCounterAmount(props.order)
-  const counterCurrency = getCounterCurrency(props.order)
-  const paymentMethodId = getPaymentMethodId(props.order)
-
-  const quoteRate = fiatToString({
-    unit: counterCurrency as FiatType,
-    value:
-      (1 /
-        parseFloat(props.quote.rate.toString()) /
-        parseFloat(convertBaseToStandard(baseCurrency, props.quote.rate.toString()))) *
-      parseFloat(props.quote.rate.toString())
-  })
-
-  const requiresTerms =
-    props.order.paymentType === BSPaymentTypes.PAYMENT_CARD ||
-    props.order.paymentType === BSPaymentTypes.USER_CARD
+  const { paymentMethodId } = props.quoteSummaryViewModel
 
   const [bankAccount] = filter(
     (b: BankTransferAccountType) => b.state === 'ACTIVE' && b.id === paymentMethodId,
@@ -224,12 +189,9 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
     : 0
 
   const cardDetails =
-    (requiresTerms && props.cards.filter((card) => card.id === paymentMethodId)[0]) || null
-
-  const totalAmount = fiatToString({
-    unit: counterCurrency as FiatType,
-    value: counterAmount
-  })
+    (props.quoteSummaryViewModel.isTermsConsentRequired &&
+      props.cards.filter((card) => card.id === paymentMethodId)[0]) ||
+    null
 
   useEffect(() => {
     props.analyticsActions.trackEvent({
@@ -239,26 +201,10 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
   }, [])
 
   useEffect(() => {
-    if (!requiresTerms) {
+    if (!props.quoteSummaryViewModel.isTermsConsentRequired) {
       setAcceptTerms(true)
     }
-  }, [requiresTerms])
-
-  useEffect(() => {
-    props.buySellActions.fetchBuyQuote({
-      amount: props.order.inputQuantity,
-      pair: props.order.pair,
-      paymentMethod:
-        props.order.paymentType === undefined ? BSPaymentTypes.FUNDS : props.order.paymentType,
-      paymentMethodId: props.order.paymentMethodId
-    })
-  }, [
-    props.buySellActions,
-    props.order.inputQuantity,
-    props.order.pair,
-    props.order.paymentMethodId,
-    props.order.paymentType
-  ])
+  }, [props.quoteSummaryViewModel.isTermsConsentRequired])
 
   const handleCancel = () => {
     props.buySellActions.cancelOrder(props.order)
@@ -432,19 +378,19 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
         </TopText>
         <QuoteCountDownWrapper>
           <QuoteCountDown
-            date={props.quote.refreshConfig.date}
-            totalMs={props.quote.refreshConfig.totalMs}
+            date={props.quoteSummaryViewModel.refreshConfig.date}
+            totalMs={props.quoteSummaryViewModel.refreshConfig.totalMs}
           />
         </QuoteCountDownWrapper>
         <Amount data-e2e='sbTotalAmount'>
           <div>
             <Text size='32px' weight={600} color='grey800'>
-              {`${baseAmount} ${baseCurrencyDisplay}`}
+              {props.quoteSummaryViewModel.totalCryptoText}
             </Text>
           </div>
           <div>
             <Text size='20px' weight={600} color='grey600' style={{ marginTop: '8px' }}>
-              {totalAmount}
+              {props.quoteSummaryViewModel.totalFiatText}
             </Text>
           </div>
         </Amount>
@@ -459,7 +405,7 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
                   id='modals.simplebuy.confirm.coin_price'
                   defaultMessage='{coin} Price'
                   values={{
-                    coin: baseCurrencyDisplay
+                    coin: props.quoteSummaryViewModel.cryptoDisplaySymbol
                   }}
                 />
               </RowText>
@@ -472,7 +418,7 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
                 />
               </IconWrapper>
             </RowIcon>
-            <RowText data-e2e='sbExchangeRate'>{quoteRate}</RowText>
+            <RowText data-e2e='sbExchangeRate'>{props.quoteSummaryViewModel.oneCoinPrice}</RowText>
           </TopRow>
           {isActiveCoinTooltip && (
             <ToolTipText>
@@ -526,15 +472,16 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
           <RowTextWrapper>
             {getPaymentMethod({
               bankAccount,
+              fiatCode: props.quoteSummaryViewModel.fiatCode,
               mobilePaymentMethod: props.mobilePaymentMethod,
-              order: props.order
+              paymentType: props.quoteSummaryViewModel.paymentMethod
             })}
             <AdditionalText>
               {!props.mobilePaymentMethod
                 ? getPaymentMethodDetails({
                     bankAccount,
                     cardDetails,
-                    order: props.order
+                    paymentType: props.quoteSummaryViewModel.paymentMethod
                   })
                 : null}
             </AdditionalText>
@@ -547,24 +494,8 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
             <FormattedMessage id='modals.simplebuy.confirm.purchase' defaultMessage='Purchase' />
           </RowText>
           <RowText>
-            <RowTextWrapper data-e2e='sbFee'>
-              {props.order.fee && props.formValues?.fix === 'FIAT'
-                ? displayFiat(
-                    props.order,
-                    (parseInt(props.order.inputQuantity) - parseInt(props.order.fee)).toString()
-                  )
-                : props.order.fee && props.formValues?.fix === 'CRYPTO'
-                ? coinToString({
-                    unit: { symbol: props.order.outputCurrency },
-                    value: convertBaseToStandard(
-                      props.order.outputCurrency,
-                      parseInt(props.order.outputQuantity) - parseInt(props.order.fee)
-                    )
-                  })
-                : `${displayFiat(
-                    props.order,
-                    (parseInt(props.order.inputQuantity) - parseInt(props.quote.fee)).toString()
-                  )} ${props.order.inputCurrency}`}
+            <RowTextWrapper data-e2e='sbPurchase'>
+              {props.quoteSummaryViewModel.fiatMinusExplicitFeeText}
             </RowTextWrapper>
           </RowText>
         </RowItem>
@@ -584,16 +515,7 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
                   />
                 </IconWrapper>
               </RowIcon>
-              <RowText data-e2e='sbFee'>
-                {props.order.fee && props.formValues?.fix === 'FIAT'
-                  ? displayFiat(props.order, props.order.fee)
-                  : props.order.fee && props.formValues?.fix === 'CRYPTO'
-                  ? coinToString({
-                      unit: { symbol: props.order.inputCurrency },
-                      value: convertBaseToStandard(props.order.inputCurrency, props.order.fee)
-                    })
-                  : `${displayFiat(props.order, props.quote.fee)} ${props.order.inputCurrency}`}
-              </RowText>
+              <RowText data-e2e='sbFee'>{props.quoteSummaryViewModel.feeText}</RowText>
             </TopRow>
             {isActiveFeeTooltip && (
               <ToolTipText>
@@ -619,33 +541,33 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
         </RowText>
         <RowText>
           <RowTextWrapper>
-            <div data-e2e='sbFiatBuyAmount'>{totalAmount}</div>
-            <AdditionalText>{`${baseAmount} ${baseCurrencyDisplay}`}</AdditionalText>
+            <div data-e2e='sbFiatBuyAmount'>{props.quoteSummaryViewModel.totalFiatText}</div>
+            <AdditionalText>{props.quoteSummaryViewModel.totalCryptoText}</AdditionalText>
           </RowTextWrapper>
         </RowText>
       </RowItem>
 
-      {props.availableToTradeWithdraw && props.quote.quote.depositTerms && (
-        <AvailabilityRows depositTerms={props.quote.quote.depositTerms} />
+      {props.availableToTradeWithdraw && (
+        <AvailabilityRows depositTerms={props.quoteSummaryViewModel.depositTerms} />
       )}
 
       <Bottom>
         {getLockRuleMessaging({
-          coin: baseCurrencyDisplay,
+          coin: props.quoteSummaryViewModel.cryptoDisplaySymbol,
           days,
           paymentAccount: getPaymentMethodDetails({
             bankAccount,
             cardDetails,
-            order: props.order
+            paymentType: props.quoteSummaryViewModel.paymentMethod
           }),
-          paymentType: props.order.paymentType,
-          quoteRate,
+          paymentType: props.quoteSummaryViewModel.paymentMethod,
+          quoteRate: props.quoteSummaryViewModel.oneCoinPrice,
           showLockRule: showLock,
-          totalAmount,
-          withdrawalLockDays: props.quote.quote?.depositTerms?.withdrawalLockDays || days
+          totalAmount: props.quoteSummaryViewModel.totalFiatText,
+          withdrawalLockDays: props.quoteSummaryViewModel.depositTerms?.withdrawalLockDays || days
         })}
 
-        {requiresTerms && (
+        {props.quoteSummaryViewModel.isTermsConsentRequired && (
           <Info>
             <InfoTerms size='12px' weight={500} color='grey900' data-e2e='sbAcceptTerms'>
               <CheckBoxInput
@@ -681,8 +603,7 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
             isAcceptedTerms={acceptTerms}
             isGooglePayReady={isGooglePayReady}
             isSubmitting={props.submitting}
-            orderType={orderType}
-            refreshConfig={props.quote.refreshConfig}
+            refreshConfig={props.quoteSummaryViewModel.refreshConfig}
           />
         </ButtonWrapper>
 

--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/model.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/model.tsx
@@ -13,7 +13,7 @@ import {
   MobilePaymentType
 } from '@core/types'
 import { Link, TextGroup } from 'blockchain-info-components'
-import { getBaseCurrency, getCounterCurrency, getOrderType } from 'data/components/buySell/model'
+import { getCounterCurrency } from 'data/components/buySell/model'
 import { convertBaseToStandard } from 'data/components/exchange/services'
 import { BankTransferAccountType } from 'data/types'
 
@@ -146,22 +146,16 @@ export const BuyOrSell = (props: {
   )
 }
 
-export const getOrderDestination = (order: BSOrderType) => {
-  const orderType = getOrderType(order)
-  const baseCurrency = getBaseCurrency(order)
-  const counterCurrency = getCounterCurrency(order)
-
-  return orderType === 'BUY' ? `${baseCurrency} Trading Account` : `${counterCurrency} Account`
-}
-
 export const getPaymentMethod = ({
   bankAccount,
+  fiatCode,
   mobilePaymentMethod,
-  order
+  paymentType
 }: {
   bankAccount: BankTransferAccountType
+  fiatCode: string
   mobilePaymentMethod?: MobilePaymentType
-  order: BSOrderType
+  paymentType: BSPaymentTypes | undefined
 }) => {
   if (mobilePaymentMethod === MobilePaymentType.APPLE_PAY) {
     return <FormattedMessage id='buttons.apple_pay' defaultMessage='Apple Pay' />
@@ -171,30 +165,13 @@ export const getPaymentMethod = ({
     return <FormattedMessage id='buttons.google_pay' defaultMessage='Google Pay' />
   }
 
-  const baseCurrency = getBaseCurrency(order)
-  const counterCurrency = getCounterCurrency(order)
-  const orderType = getOrderType(order)
-
-  switch (order.paymentType) {
+  switch (paymentType) {
     case BSPaymentTypes.PAYMENT_CARD:
       return (
         <FormattedMessage id='modals.simplebuy.confirm.payment_card' defaultMessage='Credit Card' />
       )
     case BSPaymentTypes.FUNDS:
-      if (orderType === 'BUY') {
-        return window.coins[counterCurrency]?.coinfig.name ?? counterCurrency
-      }
-      const coinName = window.coins[baseCurrency]?.coinfig.name ?? baseCurrency
-
-      return (
-        <FormattedMessage
-          id='modals.simplebuy.confirm.funds_trading_account'
-          defaultMessage='{coin} Trading Account'
-          values={{
-            coin: coinName
-          }}
-        />
-      )
+      return window.coins[fiatCode]?.coinfig.name ?? fiatCode
 
     case BSPaymentTypes.BANK_TRANSFER:
       const effectiveBankAccount = (bankAccount && bankAccount.details) || defaultBankInfo
@@ -222,13 +199,13 @@ export const displayFiat = (order: BSOrderType, amt: string) => {
 export const getPaymentMethodDetails = ({
   bankAccount,
   cardDetails,
-  order
+  paymentType
 }: {
   bankAccount: BankTransferAccountType
   cardDetails: BSCardType | null
-  order: BSOrderType
+  paymentType: BSPaymentTypes | undefined
 }) => {
-  switch (order.paymentType) {
+  switch (paymentType) {
     case BSPaymentTypes.PAYMENT_CARD:
       return `${cardDetails?.card?.type || ''} ***${cardDetails?.card?.number || ''}`
     case BSPaymentTypes.BANK_TRANSFER:

--- a/packages/blockchain-wallet-v4-frontend/src/modals/RecurringBuys/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/RecurringBuys/CheckoutConfirm/template.success.tsx
@@ -113,8 +113,16 @@ const Success = ({
 
         <CheckoutRow
           title={<FormattedMessage id='checkout.payment_method' defaultMessage='Payment Method' />}
-          text={getPaymentMethod({ bankAccount: {} as BankTransferAccountType, order })}
-          additionalText={getPaymentMethodDetails({ bankAccount, cardDetails, order })}
+          text={getPaymentMethod({
+            bankAccount: {} as BankTransferAccountType,
+            fiatCode: getCounterCurrency(order),
+            paymentType: order.paymentType
+          })}
+          additionalText={getPaymentMethodDetails({
+            bankAccount,
+            cardDetails,
+            paymentType: order.paymentType
+          })}
         />
 
         <CheckoutRow

--- a/packages/blockchain-wallet-v4/src/network/api/buySell/types.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/buySell/types.ts
@@ -468,18 +468,19 @@ export type BuyQuoteType = {
     feeFlags: []
     feeWithoutPromo: string
   }
-  networkFee: null
+  networkFee: string | null
   price: string
   quoteCreatedAt: string
   quoteExpiresAt: string
   quoteId: string
   quoteMarginPercent: number
+  resultAmount: string
   sampleDepositAddress: null
   settlementDetails: {
     availability: string
     reason: PlaidSettlementErrorReasons
   }
-  staticFee: null
+  staticFee: string | null
 }
 
 export enum TermType {

--- a/typings/window.d.ts
+++ b/typings/window.d.ts
@@ -1,6 +1,12 @@
 import { CoinfigType } from '@core/types'
 
 declare global {
+  type Coins = {
+    [key in string]: {
+      coinfig: CoinfigType // all coin configs for app
+    }
+  }
+
   interface Window {
     APP_VERSION: string // build injected app version
     ApplePaySession?: ApplePaySession
@@ -12,11 +18,7 @@ declare global {
     SARDINE_ENVIRONMENT: string // sardine environment sandbox or production
     _Sardine: any // Sardine integration
     _SardineContext: any // Sardine integration
-    coins: {
-      [key in string]: {
-        coinfig: CoinfigType // all coin configs for app
-      }
-    }
+    coins: Coins
     grecaptcha: any // google recaptcha sets this on window
     history?: {
       pushState: any


### PR DESCRIPTION
## Description
In order to get rid of order creation on checkout step, we need to make sure that none information from order response is used on the checkout step. This PR replaces usage of order information with quote.

To simplify the component, all calculation and formatting logic was extracted from a component to a view model.

## Testing Steps
Go to Buy flow, and proceed to Checkout confirmation step. Given the same quote, all the displayed values should be the same as before.

