### PR TITLE
feat/FWN-1879-rearrange-buy-checkout-step-elements

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/BuySell/CheckoutConfirm/template.success.tsx
@@ -73,13 +73,7 @@ const QuoteCountDownWrapper = styled.div`
   margin-top: 28px;
 `
 const Amount = styled.div`
-  display: flex;
-  flex-direction: column;
   margin-top: 8px;
-  > div {
-    display: flex;
-    flex-direction: row;
-  }
 `
 const RowItem = styled(Row)`
   display: flex;
@@ -383,16 +377,9 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
           />
         </QuoteCountDownWrapper>
         <Amount data-e2e='sbTotalAmount'>
-          <div>
-            <Text size='32px' weight={600} color='grey800'>
-              {props.quoteSummaryViewModel.totalCryptoText}
-            </Text>
-          </div>
-          <div>
-            <Text size='20px' weight={600} color='grey600' style={{ marginTop: '8px' }}>
-              {props.quoteSummaryViewModel.totalFiatText}
-            </Text>
-          </div>
+          <Text size='32px' weight={600} color='grey800'>
+            {props.quoteSummaryViewModel.totalCryptoText}
+          </Text>
         </Amount>
       </FlyoutWrapper>
 
@@ -496,6 +483,7 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
           <RowText>
             <RowTextWrapper data-e2e='sbPurchase'>
               {props.quoteSummaryViewModel.fiatMinusExplicitFeeText}
+              <AdditionalText>{props.quoteSummaryViewModel.totalCryptoText}</AdditionalText>
             </RowTextWrapper>
           </RowText>
         </RowItem>
@@ -542,7 +530,6 @@ const Success: React.FC<InjectedFormProps<{ form: string }, Props> & Props> = (p
         <RowText>
           <RowTextWrapper>
             <div data-e2e='sbFiatBuyAmount'>{props.quoteSummaryViewModel.totalFiatText}</div>
-            <AdditionalText>{props.quoteSummaryViewModel.totalCryptoText}</AdditionalText>
           </RowTextWrapper>
         </RowText>
       </RowItem>


### PR DESCRIPTION
## Description
1. Remove the fiat estimation in the header and just have the Crypto Amount
2. Add the Crypto Amount under the ‘Purchase’ fiat amount in the secondary font
3. Remove the crypto amount from the ‘Total’ row. This should just be in fiat

| Before  | After |
| ------------- | ------------- |
| <img width="476" alt="before" src="https://user-images.githubusercontent.com/114945181/213151328-e5ccb743-7ea9-4cc8-82e1-80c67cb433a9.png">  | <img width="476" alt="after" src="https://user-images.githubusercontent.com/114945181/213151357-46a0dfd6-66bd-4dd6-9073-812a1a3d86db.png">  |

