### PR TITLE
feat(account-recovery): add events for 2fa confirmation

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/analytics/types/accountRecovery.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/analytics/types/accountRecovery.ts
@@ -1,6 +1,9 @@
 // Account Recovery Events
 export enum Events {
   ACCOUNT_RECOVERY_2FA_ACTIVATION = 'Account Recovery 2FA Activation',
+  ACCOUNT_RECOVERY_2FA_CONFIRMED = 'Account Recovery 2FA Confirmed',
+  ACCOUNT_RECOVERY_2FA_DISMISSED = 'Account Recovery 2FA Dismissed',
+  ACCOUNT_RECOVERY_2FA_PROMPTED = 'Account Recovery 2FA Prompted',
   ACCOUNT_RECOVERY_EMAIL_CLICKED = 'Account Recovery Email Clicked',
   ACCOUNT_RECOVERY_EMAIL_SENT = 'Account Recovery Email Sent',
   ACCOUNT_RECOVERY_FORGOT_PASSWORD_VIEWED = 'Account Recovery Forgot Password Viewed',
@@ -21,6 +24,9 @@ export enum Events {
 type AccountRecoveryActions = {
   key:
     | Events.ACCOUNT_RECOVERY_2FA_ACTIVATION
+    | Events.ACCOUNT_RECOVERY_2FA_PROMPTED
+    | Events.ACCOUNT_RECOVERY_2FA_DISMISSED
+    | Events.ACCOUNT_RECOVERY_2FA_CONFIRMED
     | Events.ACCOUNT_RECOVERY_EMAIL_CLICKED
     | Events.ACCOUNT_RECOVERY_EMAIL_SENT
     | Events.ACCOUNT_RECOVERY_FORGOT_PASSWORD_VIEWED

--- a/packages/blockchain-wallet-v4-frontend/src/data/analytics/types/login.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/analytics/types/login.ts
@@ -3,6 +3,7 @@ export enum Events {
   LOGIN_2FA_PAGE_VIEWED = '2fa Page Viewed',
   LOGIN_CLICKED = 'Login Clicked',
   LOGIN_DEVICE_VERIFIED = 'Device Verified',
+  LOGIN_FORGOT_PASSWORD_CLICKED = 'Forgot Your Password Clicked',
   LOGIN_HELP_CLICKED = 'Login Help Clicked',
   LOGIN_IDENTIFIER_ENTERED = 'Login Identifier Entered',
   LOGIN_IDENTIFIER_FAILED = 'Login Identifier Failed',
@@ -32,6 +33,7 @@ type LoginActions = {
     | Events.LOGIN_RECOVERY_OPTION_SELECTED
     | Events.LOGIN_PASSWORD_DENIED
     | Events.LOGIN_HELP_CLICKED
+    | Events.LOGIN_FORGOT_PASSWORD_CLICKED
     | Events.LOGIN_DEVICE_VERIFIED
     | Events.LOGIN_IDENTIFIER_ENTERED
     | Events.LOGIN_IDENTIFIER_FAILED

--- a/packages/blockchain-wallet-v4-frontend/src/data/signup/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/signup/sagas.ts
@@ -476,6 +476,12 @@ export default ({ api, coreSagas, networks }) => {
         yield put(actions.form.change(RECOVER_FORM, 'step', ResetFormSteps.NEW_PASSWORD))
         yield put(actions.alerts.displaySuccess(C.TWOFA_VERIFIED))
         yield put(actions.signup.verifyTwoFaForRecoverySuccess(true))
+        yield put(
+          actions.analytics.trackEvent({
+            key: Analytics.ACCOUNT_RECOVERY_2FA_CONFIRMED,
+            properties: {}
+          })
+        )
       }
       if (!verified) {
         yield put(actions.signup.verifyTwoFaForRecoveryFailure(true))

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Wallet/SkipTwoFAVerificationRecovery/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Wallet/SkipTwoFAVerificationRecovery/index.tsx
@@ -1,17 +1,21 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { connect } from 'react-redux'
+import { connect, ConnectedProps } from 'react-redux'
 import { Button } from '@blockchain-com/constellation'
 import { bindActionCreators, compose } from 'redux'
 
 import { Modal, ModalBody, Text } from 'blockchain-info-components'
 import { actions } from 'data'
-import { RecoverSteps } from 'data/types'
+import { Analytics, RecoverSteps } from 'data/types'
 import modalEnhancer from 'providers/ModalEnhancer'
 
-const TwoFASkipWarning = (props) => {
+const TwoFASkipWarning = (props: Props) => {
   const skip = () => {
     props.closeAll()
+    props.analyticsActions.trackEvent({
+      key: Analytics.ACCOUNT_RECOVERY_2FA_DISMISSED,
+      properties: {}
+    })
     props.formActions.change('recover', 'step', RecoverSteps.NEW_PASSWORD)
   }
   return (
@@ -67,12 +71,20 @@ const TwoFASkipWarning = (props) => {
 }
 
 const mapDispatchToProps = (dispatch) => ({
+  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   formActions: bindActionCreators(actions.form, dispatch)
 })
 
+const connector = connect(null, mapDispatchToProps)
+
+type Props = ConnectedProps<typeof connector> & {
+  closeAll: () => void
+}
+
 const enhance = compose<React.ComponentType>(
+  connect(null, mapDispatchToProps),
   modalEnhancer('SKIP_TWOFA_CONFIRMATION_WARNING'),
-  connect(null, mapDispatchToProps)
+  connector
 )
 
 export default enhance(TwoFASkipWarning)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/components/NeedHelpLink/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/components/NeedHelpLink/index.tsx
@@ -14,7 +14,7 @@ const NeedHelpLink = ({ analyticsActions, origin, platform, product, unified }: 
     to={product === ProductAuthOptions.WALLET || unified ? '/recover' : '/help-exchange'}
     onClick={() => {
       analyticsActions.trackEvent({
-        key: Analytics.LOGIN_HELP_CLICKED,
+        key: Analytics.LOGIN_FORGOT_PASSWORD_CLICKED,
         properties: {
           device_origin: platform,
           origin,

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/TwoFAConfirmation/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/RecoverWallet/ResetAccount/TwoFAConfirmation/index.tsx
@@ -13,7 +13,7 @@ import PasswordBox from 'components/Form/PasswordBox'
 import TextBox from 'components/Form/TextBox'
 import { selectors } from 'data'
 import { ModalName } from 'data/modals/types'
-import { RecoverSteps } from 'data/types'
+import { Analytics, RecoverSteps } from 'data/types'
 import { useRemote } from 'hooks'
 import { required } from 'services/forms'
 import { removeWhitespace } from 'services/forms/normalizers'
@@ -33,9 +33,23 @@ const ResponsiveRow = styled(Row)`
 `
 
 const TwoFAConfirmation = (props: Props) => {
+  const {
+    accountRecoveryData,
+    analyticsActions,
+    busy,
+    formValues,
+    invalid,
+    setStep,
+    signupActions,
+    submitting
+  } = props
+  useEffect(() => {
+    analyticsActions.trackEvent({
+      key: Analytics.ACCOUNT_RECOVERY_2FA_PROMPTED,
+      properties: {}
+    })
+  }, [])
   const { hasError } = useRemote(selectors.signup.getRecoveryTwoFAVerification)
-  const { accountRecoveryData, busy, formValues, invalid, setStep, signupActions, submitting } =
-    props
   const authType = accountRecoveryData && accountRecoveryData?.two_fa_type
   const placeholder = authType === 4 ? '_ _ _  _ _ _' : authType === 5 ? '_ _ _ _ _' : null
   // authType 5 is mobile sms code, 5 characters


### PR DESCRIPTION
## Description (optional)
- Adds missing 2FA events for account recovery
- Changes 'Login Helped Clicked' -> 'Forgot Password Clicked'

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

