### PR TITLE
fix(mobile-payments): avoid passing payment method id to order creation request

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas/createBuyOrder.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas/createBuyOrder.ts
@@ -8,22 +8,22 @@ import { getBsCheckoutFormValues } from '../selectors'
 import { actions } from '../slice'
 import { assembleBuyOrderInputDto } from '../utils/assembleBuyOrderInputDto'
 
-type FundsOrderPayload = {
+type FundsOrMobilePaymentPayload = {
   quoteState: BuyQuoteStateType
 }
 
-type OtherPaymentOrderPayload = {
+type OtherPaymentTypePayload = {
   paymentMethodId: BSCardType['id']
   quoteState: BuyQuoteStateType
 }
 
-type Payload = FundsOrderPayload | OtherPaymentOrderPayload
+type Payload = FundsOrMobilePaymentPayload | OtherPaymentTypePayload
 
 const stopQuoteRefresh = function* () {
   yield* put(actions.stopPollBuyQuote())
 }
 
-const isOtherPaymentPayload = (payload: Payload): payload is OtherPaymentOrderPayload =>
+const isOtherPaymentPayload = (payload: Payload): payload is OtherPaymentTypePayload =>
   'paymentMethodId' in payload && payload.paymentMethodId !== undefined
 
 export const createOrder = function* (payload: Payload) {


### PR DESCRIPTION
## Description
Gpay orders are failing when beneficiary id is passed as payment method id to the request. Thus, we shall avoid doing that even though from client perspective it would make sense to pass it since it is also passed to quote (before order creation) and confirmation (after order creation).

## Testing Steps
Buy flow using mobile payment options to be tested.

