### PR TITLE
fix(address-form): send region as string instead of null

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/identityVerification/sagas.ts
@@ -431,7 +431,7 @@ export default ({ api, coreSagas, networks }) => {
         line1,
         line2,
         postCode,
-        state: state?.code ?? null
+        state: state?.code ?? state
       }
 
       yield call(updateUserAddress, {


### PR DESCRIPTION
## Description (optional)
Fixes bug where we were sending `state:null` if non-US user entered a Region in the address form for KYC.  

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

