### PR TITLE
fix(xlm): typo for send wallet balance

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxXlmAddresses/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/SelectBoxXlmAddresses/selectors.ts
@@ -28,7 +28,7 @@ export const getData = (
     if (has('balance', wallet)) {
       const xlmDisplay = Exchange.displayCoinToCoin({
         coin: 'XLM',
-        value: wallet.balnace
+        value: wallet.balance
       })
       return `${wallet.label} (${xlmDisplay})`
     }


### PR DESCRIPTION
## Description (optional)
Fixes issue that causes xlm PKW to show 0 balance for send

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

