### PR TITLE
fix(recovery): dont track recovery as signup

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/signup/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/signup/sagas.ts
@@ -87,15 +87,6 @@ export default ({ api, coreSagas, networks }) => {
       .getAccountRecoveryV2(yield select())
       .getOrElse(false) as boolean
 
-    // pulling this separately to perhaps
-    // solve for 'none' value being seen in amplitude
-    // for country code
-    let countryFromFormValues
-    if (!isAccountReset) {
-      const { country } = yield select(selectors.form.getFormValues(SIGNUP_FORM))
-      countryFromFormValues = country
-    }
-
     const { platform, product } = yield select(selectors.signup.getProductSignupMetadata)
     const isExchangeMobileSignup =
       product === ProductAuthOptions.EXCHANGE &&
@@ -147,17 +138,18 @@ export default ({ api, coreSagas, networks }) => {
         })
         yield put(actions.signup.registerSuccess(undefined))
       }
-
-      yield put(
-        actions.analytics.trackEvent({
-          key: Analytics.ONBOARDING_WALLET_SIGNED_UP,
-          properties: {
-            country: country || countryFromFormValues,
-            country_state: state,
-            device_origin: platform
-          }
-        })
-      )
+      if (!isAccountReset) {
+        yield put(
+          actions.analytics.trackEvent({
+            key: Analytics.ONBOARDING_WALLET_SIGNED_UP,
+            properties: {
+              country,
+              country_state: state,
+              device_origin: platform
+            }
+          })
+        )
+      }
       if (product === ProductAuthOptions.EXCHANGE) {
         yield put(
           actions.analytics.trackEvent({


### PR DESCRIPTION
## Description (optional)
We've decided to not send the 'Wallet Signed Up' event for account recovery. This will solve the issue of wallet signups increasing while email verifications remained the same + `none` country value for some signup events. 

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

