### PR TITLE
fix(coin-selection): demote 0 confirmation utxos

### DIFF
--- a/packages/blockchain-wallet-v4/src/coinSelection/coin.js
+++ b/packages/blockchain-wallet-v4/src/coinSelection/coin.js
@@ -37,6 +37,27 @@ export class Coin extends Type {
     return this.value - coin.value
   }
 
+  // Option 1
+  // descent: sort((a, b) => a.descentCompareWeighted(b), coins)
+  descentCompareWeighted(coin) {
+    if (this.confirmations === 0 && coin.confirmations !== 0) {
+      return 1
+    }
+    if (this.confirmations !== 0 && coin.confirmations === 0) {
+      return -1
+    }
+    return coin.value - this.value
+  }
+
+  // Option 2
+  // ascent: sort((a, b) => a.ascentCompareWeighted(b), coins)
+  ascentCompareWeighted(coin) {
+    if (this.confirmations === 0 && coin.confirmations !== 0) {
+      return 1
+    }
+    return this.value - coin.value
+  }
+
   ge(coin) {
     return this.value >= coin.value
   }
@@ -102,6 +123,7 @@ export const address = Coin.define('address')
 export const priv = Coin.define('priv')
 export const change = Coin.define('change')
 export const path = Coin.define('path')
+export const confirmations = Coin.define('confirmations')
 
 export const selectValue = view(value)
 export const selectScript = view(script)
@@ -111,11 +133,13 @@ export const selectAddress = view(address)
 export const selectPriv = view(priv)
 export const selectChange = view(change)
 export const selectPath = view(path)
+export const selectConfirmations = view(confirmations)
 
 export const fromJS = (o, network) => {
   return new Coin({
     address: o.address ? o.address : scriptToAddress(o.script, network),
     change: o.change || false,
+    confirmations: o.confirmations,
     index: o.tx_output_n,
     path: o.path,
     priv: o.priv,

--- a/packages/blockchain-wallet-v4/src/coinSelection/coinSelection.spec.js
+++ b/packages/blockchain-wallet-v4/src/coinSelection/coinSelection.spec.js
@@ -247,6 +247,65 @@ describe('Coin Selection', () => {
     })
   })
 
+  describe('compare', () => {
+    it('should return the right selection for descentDraw', () => {
+      const inputs = map(Coin.fromJS, [
+        { confirmations: 1, value: 1 },
+        { confirmations: 1, value: 20000 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 300000 },
+        { confirmations: 1, value: 50000 },
+        { confirmations: 1, value: 30000 }
+      ])
+      const result = inputs.sort((a, b) => a.descentCompareWeighted(b))
+      const expected = [300000, 50000, 30000, 20000, 1, 0, 0]
+      expect(result.map((x) => x.value)).toEqual(expected)
+    })
+    it('should return the right selection with demoted coins for descentDraw', () => {
+      const inputs = map(Coin.fromJS, [
+        { confirmations: 1, value: 1 },
+        { confirmations: 1, value: 20000 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 300000 },
+        { confirmations: 0, value: 50000 },
+        { confirmations: 1, value: 30000 }
+      ]) //
+      const result = inputs.sort((a, b) => a.descentCompareWeighted(b))
+      const expected = [300000, 30000, 20000, 1, 0, 0, 50000]
+      expect(result.map((x) => x.value)).toEqual(expected)
+    })
+    it('should return the right selection for ascentDraw', () => {
+      const inputs = map(Coin.fromJS, [
+        { confirmations: 1, value: 1 },
+        { confirmations: 1, value: 20000 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 300000 },
+        { confirmations: 1, value: 50000 },
+        { confirmations: 1, value: 30000 }
+      ])
+      const result = inputs.sort((a, b) => a.ascentCompareWeighted(b))
+      const expected = [0, 0, 1, 20000, 30000, 50000, 300000]
+      expect(result.map((x) => x.value)).toEqual(expected)
+    })
+    it('should return the right selection with demoted coins for ascentDraw', () => {
+      const inputs = map(Coin.fromJS, [
+        { confirmations: 1, value: 1 },
+        { confirmations: 1, value: 20000 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 300000 },
+        { confirmations: 0, value: 50000 },
+        { confirmations: 1, value: 30000 }
+      ])
+      const result = inputs.sort((a, b) => a.ascentCompareWeighted(b))
+      const expected = [0, 0, 1, 20000, 30000, 300000, 50000]
+      expect(result.map((x) => x.value)).toEqual(expected)
+    })
+  })
+
   describe('descentDraw', () => {
     it('should return the right selection', () => {
       const inputs = map(Coin.fromJS, [
@@ -268,6 +327,27 @@ describe('Coin Selection', () => {
       // change = inputs - outputs - fee
       //          300000 - 100000 - 12430 = 187570
       expect(selection.outputs.map((x) => x.value)).toEqual([100000, 187570])
+    })
+    it('should demote unconfirmed coins', () => {
+      const inputs = map(Coin.fromJS, [
+        { confirmations: 1, value: 1 },
+        { confirmations: 1, value: 20000 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 1, value: 0 },
+        { confirmations: 0, value: 300000 },
+        { confirmations: 1, value: 50000 },
+        { confirmations: 1, value: 30000 }
+      ])
+      const targets = map(Coin.fromJS, [{ value: 1000 }])
+      const selection = cs.descentDraw(targets, 55, inputs, 'change-address')
+      expect(selection.inputs.map((x) => x.value)).toEqual([50000])
+
+      // (overhead + inputs + outputs) * feePerByte
+      // (10 + (1 * 148) + (2 * 34)) * 55 = 12430
+      expect(selection.fee).toEqual(12430)
+      // change = inputs - outputs - fee
+      //          50000 - 1000 - 12430 = 36570
+      expect(selection.outputs.map((x) => x.value)).toEqual([1000, 36570])
     })
   })
 

--- a/packages/blockchain-wallet-v4/src/coinSelection/index.js
+++ b/packages/blockchain-wallet-v4/src/coinSelection/index.js
@@ -204,14 +204,15 @@ export const descentDraw = (targets, feePerByte, coins, changeAddress) =>
   findTarget(
     targets,
     feePerByte,
-    sort((a, b) => b.compare(a), coins),
+    sort((a, b) => a.descentCompareWeighted(b), coins),
     changeAddress
   )
+
 // ascentDraw :: [Coin(x), ..., Coin(y)] -> Number -> [Coin(a), ..., Coin(b)] -> Selection
 export const ascentDraw = (targets, feePerByte, coins, changeAddress) =>
   findTarget(
     targets,
     feePerByte,
-    sort((a, b) => a.compare(b), coins),
+    sort((a, b) => a.ascentCompareWeighted(b), coins),
     changeAddress
   )


### PR DESCRIPTION
## Description (optional)
Demote utxos with 0 confirmation in btc send coin selection

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

