### PR TITLE
fix(login): change position of error message

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Login/Wallet/EnterEmailOrGuid/index.tsx
@@ -47,8 +47,8 @@ const EnterEmailOrGuid = (props: Props) => {
               component={TextBox}
               data-e2e='loginGuidOrEmail'
               disableSpellcheck
-              errorBottom
-              errorLeft
+              errorTop
+              errorRight
               name='guidOrEmail'
               normalize={removeWhitespace}
               validate={[required, validWalletIdOrEmail]}


### PR DESCRIPTION
Error now shown on the top right
![image](https://github.com/blockchain/blockchain-wallet-v4-frontend/assets/97296851/9ff73983-d2cd-4649-95c6-f539d04596f1)
