### PR TITLE
fix(sell): add FF to fallback to payment address for nc sell

### DIFF
--- a/config/mocks/wallet-options-v4.json
+++ b/config/mocks/wallet-options-v4.json
@@ -77,6 +77,7 @@
         "themeEnabled": true,
         "unifiedAccountLogin": true,
         "useAgentHotWalletAddress": true,
+        "useAgentHotWalletAddressForSell": false,
         "useLoqateService": true,
         "useNewPaymentProviders": true,
         "useVgsProvider": true,

--- a/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.ts
+++ b/packages/blockchain-wallet-v4/src/redux/walletOptions/selectors.ts
@@ -210,3 +210,7 @@ export const getShowProveFlow = (state: RootState) =>
 // which deposit address to use for swap
 export const getUseAgentHotWalletAddress = (state: RootState) =>
   getWebOptions(state).map(path(['featureFlags', 'useAgentHotWalletAddress']))
+
+// which deposit address to use for non custodial sell
+export const getUseAgentHotWalletAddressForSell = (state: RootState) =>
+  getWebOptions(state).map(path(['featureFlags', 'useAgentHotWalletAddressForSell']))


### PR DESCRIPTION
## Description (optional)
Adds a feature flag to use address from Payment API in case /custodial/trades API doesn't respect Legal Entity of the user when live

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

