### PR TITLE
fix(kyc): dropdown fields now don't overlap with inputs

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Form/FormItem/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Form/FormItem/index.js
@@ -1,15 +1,16 @@
 import React from 'react'
 import styled from 'styled-components'
 
+// Z-INDEX because otherwise the dropdown menu will be behind other inputs when present
 const Wrapper = styled.div`
   position: relative;
   width: ${(props) => props.width || '100%'};
+
+  div.bc__menu {
+    z-index: 900;
+  }
 `
 
-const FormGroup = (props) => {
-  const { children, ...rest } = props
-
-  return <Wrapper {...rest}>{children}</Wrapper>
-}
+const FormGroup = ({ children, ...rest }) => <Wrapper {...rest}>{children}</Wrapper>
 
 export default FormGroup

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Onboarding/KycVerification/ExtraFields/template.success.tsx
@@ -266,7 +266,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
       title: getFormattedMessageComponent(node.id)
     }
     return (
-      <FormGroup>
+      <FormGroup key={node.id}>
         <QuestionTitle>{nodeTranslation.title}</QuestionTitle>
 
         <QuestionDescription>{nodeTranslation.instructions}</QuestionDescription>
@@ -311,7 +311,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
 
     return (
       <>
-        <FormGroup>
+        <FormGroup key={node.id}>
           <QuestionTitle>{nodeTranslation.title}</QuestionTitle>
 
           <QuestionDescription>{nodeTranslation.instructions}</QuestionDescription>
@@ -391,7 +391,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
     }
 
     return (
-      <FormGroup>
+      <FormGroup key={node.id}>
         <QuestionTitle>{nodeTranslation.title}</QuestionTitle>
 
         {displayInstructions && (
@@ -461,7 +461,7 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = (props) => {
     const isOptional = node.children && node.children.some((item) => item.id.includes('UNDEFINED'))
 
     return (
-      <FormGroup>
+      <FormGroup key={node.id}>
         <QuestionTitle>
           {nodeTranslation.title !== '' ? nodeTranslation.title : node.text}
         </QuestionTitle>


### PR DESCRIPTION
There was an issue during some KYC cases where the dropdowns will have some options that didn't register the mouse as they were "behind" other inputs in terms of z-index

Additionally, fixed some react-key related errors. Although the entire file should be refactored moving the "renderXXXcomponent" to separate files

