### PR TITLE
Do not refetch user eligibility when opening the buy modal nor when adding a bank

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/cache/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/cache/selectors.ts
@@ -2,7 +2,7 @@ import { path, prop } from 'ramda'
 
 import { crypto as wCrypto } from '@core'
 
-export const getLastAnnouncementState = (state): string | undefined =>
+export const getLastAnnouncementState = (state): object | undefined =>
   path(['cache', 'announcements'], state)
 export const getCache = (state) => prop('cache', state)
 export const getEmail = (state): string | undefined => path(['cache', 'lastEmail'], state)

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/sagas.ts
@@ -407,11 +407,6 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
 
     // get current user tier
     const isUserTier2 = yield call(isTier2)
-    yield put(actions.custodial.fetchProductEligibilityForUser())
-    yield take([
-      actions.custodial.fetchProductEligibilityForUserSuccess.type,
-      actions.custodial.fetchProductEligibilityForUserFailure.type
-    ])
 
     const products = selectors.custodial.getProductEligibilityForUser(yield select()).getOrElse({
       custodialWallets: { canDepositCrypto: false, enabled: false },

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/buySell/sagas.ts
@@ -46,7 +46,6 @@ import { isNabuError, NabuError } from 'services/errors'
 import { getExtraKYCCompletedStatus } from 'services/sagas/extraKYC'
 
 import { actions as cacheActions } from '../../cache/slice'
-import { actions as custodialActions } from '../../custodial/slice'
 import profileSagas from '../../modules/profile/sagas'
 import brokerageSagas from '../brokerage/sagas'
 import { convertBaseToStandard, convertStandardToBase } from '../exchange/services'
@@ -1936,19 +1935,12 @@ export default ({ api, coreSagas, networks }: { api: APIType; coreSagas: any; ne
     // get current user tier
     const isUserTier2 = yield call(isTier2)
 
-    // loading modal here before dong product eligibility check
+    // loading modal here before doing product eligibility check
     // so buy flyout can load right away
     if (isUserTier2) {
       yield put(actions.modals.showModal(ModalName.SIMPLE_BUY_MODAL, { origin }))
       yield put(A.setStep({ step: 'INITIAL_LOADING' }))
     }
-
-    // FIXME: This call is causing the modal to be very slow, abstract this to somewhere other than here
-    yield put(actions.custodial.fetchProductEligibilityForUser())
-    yield take([
-      custodialActions.fetchProductEligibilityForUserSuccess.type,
-      custodialActions.fetchProductEligibilityForUserFailure.type
-    ])
 
     const products = selectors.custodial.getProductEligibilityForUser(yield select()).getOrElse({
       buy: { enabled: false, maxOrdersLeft: 0, reasonNotEligible: undefined },

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/swap/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/swap/slice.ts
@@ -3,7 +3,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import Remote from '@core/remote'
 import {
-  BSPaymentTypes,
   CoinType,
   CrossBorderLimits,
   CrossBorderLimitsPayload,
@@ -234,6 +233,5 @@ const swapSlice = createSlice({
   }
 })
 
-const { actions, reducer } = swapSlice
-const swapSliceReducer = reducer
+const { actions, reducer: swapSliceReducer } = swapSlice
 export { actions, swapSliceReducer }

--- a/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/Page/index.js
+++ b/packages/blockchain-wallet-v4-frontend/src/layouts/Wallet/Page/index.js
@@ -1,5 +1,4 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
+import React, { useRef } from 'react'
 import styled from 'styled-components'
 
 const Wrapper = styled.div`
@@ -16,33 +15,13 @@ const Wrapper = styled.div`
   }
 `
 
-class PageContainer extends React.Component {
-  componentDidUpdate(prevProps) {
-    if (prevProps.children.props.url !== this.props.children.props.url) {
-      try {
-        /* eslint-disable-next-line react/no-find-dom-node */
-        ReactDOM.findDOMNode(this).scrollTop = 0
-      } catch (e) {
-        /* eslint-disable-next-line */
-        console.log(e)
-      }
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.timeout) {
-      clearTimeout(this.timeout)
-    }
-  }
-
-  render() {
-    return (
-      /* eslint-disable-next-line react/no-string-refs */
-      <Wrapper ref='page' center={this.props.center}>
-        {this.props.children}
-      </Wrapper>
-    )
-  }
+const PageContainer = ({ center, children }) => {
+  const ref = useRef('page')
+  return (
+    <Wrapper ref={ref} center={center}>
+      {children}
+    </Wrapper>
+  )
 }
 
 export default PageContainer

--- a/packages/blockchain-wallet-v4-frontend/src/middleware/analyticsMiddleware/index.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/middleware/analyticsMiddleware/index.ts
@@ -3,7 +3,6 @@
 
 import { Coin } from '@core/utils'
 import { actions, actionTypes as AT } from 'data'
-import { convertBaseToStandard } from 'data/components/exchange/services'
 import {
   BankDWStepType,
   InterestStep,
@@ -33,7 +32,6 @@ import {
 import {
   buyPaymentMethodSelectedPaymentTypeDictionary,
   buySellClickedOriginDictionary,
-  getNetworkFee,
   getOriginalTimestamp,
   interestDepositClickedOriginDictionary,
   linkBankClickedOriginDictionary,
@@ -43,7 +41,6 @@ import {
   sendReceiveClickedOriginDictionary,
   settingsHyperlinkClickedDestinationDictionary,
   settingsTabClickedDestinationDictionary,
-  swapClickedOriginDictionary,
   upgradeVerificationClickedOriginDictionary
 } from 'middleware/analyticsMiddleware/utils'
 
@@ -250,14 +247,13 @@ const analyticsMiddleware = () => (store) => (next) => (action) => {
       }
       case actions.modals.showModal.type: {
         const state = store.getState()
-        const nabuId = state.profile.userData.getOrElse({})?.id ?? null
-        const email = state.profile.userData.getOrElse({})?.emailVerified
-          ? state.profile.userData.getOrElse({})?.email ?? null
-          : null
-        const tier = state.profile.userData.getOrElse({})?.tiers?.current ?? null
+        const userData = state.profile.getOrElse({})
+
+        const nabuId = userData.id ?? null
+        const email = userData.emailVerified ? userData.email : null
+        const tier = userData.tiers?.current ?? null
 
         const modalName: ModalName = action.payload.type
-
         switch (modalName) {
           case ModalName.SIMPLE_BUY_MODAL: {
             const rawOrigin = action.payload.props.origin

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ActiveRewardsBanner/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ActiveRewardsBanner/index.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux'
 import { actions } from 'data'
 import { useRemote } from 'hooks'
 
-import { getActiveRewardsAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { getData } from './ActiveRewardsBanner.selectors'
 import ActiveRewardsBanner from './ActiveRewardsBanner.template'
 
@@ -19,7 +19,7 @@ const ActiveRewardsBannerContainer = () => {
   if (!data || error || isLoading || isNotAsked) return null
 
   const onClickClose = () => {
-    dispatch(actions.cache.announcementDismissed(getActiveRewardsAnnouncement()))
+    dispatch(actions.cache.announcementDismissed(ANNOUNCEMENTS.ACTIVE_REWARDS))
   }
 
   return <ActiveRewardsBanner onClickClose={onClickClose} rate={data.rate} />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/AppleAndGooglePayBanner/AppleAndGooglePayBanner.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/AppleAndGooglePayBanner/AppleAndGooglePayBanner.tsx
@@ -5,7 +5,7 @@ import { MobilePaymentType } from '@core/types'
 import { actions, selectors } from 'data'
 import { useApplePay, useRemote } from 'hooks'
 
-import { getAppleAndGooglePayAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { AppleAndGooglePayBannerView } from './components'
 
 export const AppleAndGooglePayBanner = () => {
@@ -27,10 +27,10 @@ export const AppleAndGooglePayBanner = () => {
   }, [paymentMethods])
 
   const onClickClose = useCallback(() => {
-    return dispatch(actions.cache.announcementDismissed(getAppleAndGooglePayAnnouncement()))
+    return dispatch(actions.cache.announcementDismissed(ANNOUNCEMENTS.APPLE_GOOGLE_PAY))
   }, [dispatch])
 
-  const handleOnClick = useCallback(async () => {
+  const handleOnClick = useCallback(() => {
     const isApplePayEnabled = isApplePayAvailable && isApplePayFeatureFlagEnabled
 
     const mobilePaymentMethod = isApplePayEnabled

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/BuyCrypto/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/BuyCrypto/index.tsx
@@ -10,7 +10,7 @@ import { actions, selectors } from 'data'
 import { RootState } from 'data/rootReducer'
 import { media } from 'services/styles'
 
-import { getBuyCryptoAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { BannerButton, CloseLink, IconWrapper, Row } from '../styles'
 
 const Wrapper = styled.div`
@@ -63,8 +63,6 @@ const BuyCrypto = ({ buySellActions, cacheActions, fiatCurrency }: Props) => {
     })
   }, [buySellActions, fiatCurrency])
 
-  const completeAnnouncement = getBuyCryptoAnnouncement()
-
   return (
     <Wrapper>
       <Row>
@@ -91,7 +89,7 @@ const BuyCrypto = ({ buySellActions, cacheActions, fiatCurrency }: Props) => {
       </BannerButton>
       <CloseLink
         data-e2e='newCoinCloseButton'
-        onClick={() => cacheActions.announcementDismissed(completeAnnouncement)}
+        onClick={() => cacheActions.announcementDismissed(ANNOUNCEMENTS.BUY_CRIPTO)}
       >
         <Icon size='20px' color='grey400' name='close-circle' />
       </CloseLink>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CoinRename/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CoinRename/index.tsx
@@ -9,7 +9,7 @@ import { Button, Icon, Text } from 'blockchain-info-components'
 import { actions, selectors } from 'data'
 import { media } from 'services/styles'
 
-import { getCoinRenameAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 
 const Wrapper = styled.div`
   display: flex;
@@ -72,7 +72,7 @@ const CoinRename = ({ buySellActions, cacheActions, coinRename }: Props) => {
   if (!coinRename) return null
   if (!window.coins[coinRename]) return null
 
-  const newCoinAnnouncement = getCoinRenameAnnouncement(coinRename)
+  const newCoinAnnouncement = ANNOUNCEMENTS.COIN_RENAME(coinRename)
   const { coinfig } = window.coins[coinRename]
   const { displaySymbol, symbol } = coinfig
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CompleteYourProfile/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CompleteYourProfile/index.tsx
@@ -13,7 +13,7 @@ import { RootState } from 'data/rootReducer'
 import { Analytics } from 'data/types'
 import { media } from 'services/styles'
 
-import { getCompleteProfileAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { BannerButton, CloseLink } from '../styles'
 import { getData } from './selectors'
 
@@ -91,8 +91,6 @@ const CompleteYourProfile = ({
     })
   }, [modalActions])
 
-  const completeAnnouncement = getCompleteProfileAnnouncement()
-
   return (
     <Wrapper>
       <Row>
@@ -132,7 +130,7 @@ const CompleteYourProfile = ({
 
       <CloseLink
         data-e2e='newCoinCloseButton'
-        onClick={() => cacheActions.announcementDismissed(completeAnnouncement)}
+        onClick={() => cacheActions.announcementDismissed(ANNOUNCEMENTS.COMPLETE_PROFILE)}
       >
         <Icon size='20px' color='grey400' name='close-circle' />
       </CloseLink>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ContinueToGold/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ContinueToGold/index.tsx
@@ -10,7 +10,7 @@ import { Image, Text } from 'blockchain-info-components'
 import { actions } from 'data'
 import { media } from 'services/styles'
 
-import { getContinueToGoldAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { BannerButton, CloseLink, Row } from '../styles'
 
 const Wrapper = styled.div`
@@ -61,7 +61,6 @@ const Copy = styled(Text)`
 `
 
 const ContinueToGold = ({ cacheActions, verifyIdentity }: Props) => {
-  const completeAnnouncement = getContinueToGoldAnnouncement()
   return (
     <Wrapper>
       <Row>
@@ -91,7 +90,7 @@ const ContinueToGold = ({ cacheActions, verifyIdentity }: Props) => {
       </BannerButton>
       <CloseLink
         data-e2e='newCoinCloseButton'
-        onClick={() => cacheActions.announcementDismissed(completeAnnouncement)}
+        onClick={() => cacheActions.announcementDismissed(ANNOUNCEMENTS.CONTINUE_TO_GOLD)}
       >
         <IconCloseCircleV2
           label='close'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/FinishKyc/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/FinishKyc/index.tsx
@@ -8,7 +8,7 @@ import { Icon, Text } from 'blockchain-info-components'
 import { actions } from 'data'
 import { media } from 'services/styles'
 
-import { getKYCFinishAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { BannerButton, CloseLink, Row } from '../styles'
 
 const Wrapper = styled.div`
@@ -63,7 +63,6 @@ const Copy = styled(Text)`
 `
 
 const FinishKyc = (props: Props) => {
-  const completeAnnouncement = getKYCFinishAnnouncement()
   return (
     <Wrapper>
       <StyledRow>
@@ -101,7 +100,7 @@ const FinishKyc = (props: Props) => {
       </BannerButton>
       <CloseLink
         data-e2e='newCoinCloseButton'
-        onClick={() => props.cacheActions.announcementDismissed(completeAnnouncement)}
+        onClick={() => props.cacheActions.announcementDismissed(ANNOUNCEMENTS.KYC_FINISH)}
       >
         <Icon size='20px' color='grey400' name='close-circle' />
       </CloseLink>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/NewCurrency/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/NewCurrency/index.tsx
@@ -9,7 +9,7 @@ import { Button, Icon, Text } from 'blockchain-info-components'
 import { actions, selectors } from 'data'
 import { media } from 'services/styles'
 
-import { getNewCoinAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 
 const Wrapper = styled.div`
   display: flex;
@@ -72,7 +72,7 @@ const NewCurrency = ({ buySellActions, cacheActions, coinListing }: Props) => {
   if (!coinListing) return null
   if (!window.coins[coinListing]) return null
 
-  const newCoinAnnouncement = getNewCoinAnnouncement(coinListing)
+  const newCoinAnnouncement = ANNOUNCEMENTS.NEW_COIN(coinListing)
   const { coinfig } = window.coins[coinListing]
   const { name, symbol } = coinfig
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/RecurringBuys/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/RecurringBuys/index.tsx
@@ -11,7 +11,7 @@ import { RootState } from 'data/rootReducer'
 import { RecurringBuyOrigins } from 'data/types'
 import { media } from 'services/styles'
 
-import { getRecurringBuyAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { BannerButton, CloseLink } from '../styles'
 
 const Wrapper = styled.div`
@@ -77,8 +77,6 @@ const RecurringBuys = (props: Props) => {
     props.recurringBuyActions.learnMoreLinkClicked(RecurringBuyOrigins.DASHBOARD_PROMO)
   }
 
-  const completeAnnouncement = getRecurringBuyAnnouncement()
-
   return (
     <Wrapper>
       <Row>
@@ -110,7 +108,7 @@ const RecurringBuys = (props: Props) => {
       </BannerButton>
       <CloseLink
         data-e2e='newCoinCloseButton'
-        onClick={() => props.cacheActions.announcementDismissed(completeAnnouncement)}
+        onClick={() => props.cacheActions.announcementDismissed(ANNOUNCEMENTS.RECURRING_BUY)}
       >
         <Icon size='20px' color='grey400' name='close-circle' />
       </CloseLink>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/RewardsBanner/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/RewardsBanner/index.tsx
@@ -12,8 +12,10 @@ import { actions } from 'data'
 import { Analytics } from 'data/types'
 import { media } from 'services/styles'
 
-import { getEarnRewardsAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { BannerButton, CloseLink, IconWrapper, Row } from '../styles'
+
+const { BANNER_REWARDS_CLICKED, BANNER_REWARDS_VIEWED } = Analytics
 
 const Wrapper = styled.div`
   display: flex;
@@ -56,7 +58,6 @@ const StartEarningRewards: React.FC<Props> = (props) => {
   const {
     analyticsActions: { trackEvent }
   } = props
-  const { BANNER_REWARDS_CLICKED, BANNER_REWARDS_VIEWED } = Analytics
 
   useEffect(() => {
     trackEvent({
@@ -77,8 +78,6 @@ const StartEarningRewards: React.FC<Props> = (props) => {
       }
     })
   }
-
-  const completeAnnouncement = getEarnRewardsAnnouncement()
 
   return (
     <Wrapper>
@@ -108,7 +107,7 @@ const StartEarningRewards: React.FC<Props> = (props) => {
       </LinkContainer>
       <CloseLink
         data-e2e='newCoinCloseButton'
-        onClick={() => props.cacheActions.announcementDismissed(completeAnnouncement)}
+        onClick={() => props.cacheActions.announcementDismissed(ANNOUNCEMENTS.EARN_REWARDS)}
       >
         <IconCloseCircleV2
           label='close'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ServicePriceUnavailable/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ServicePriceUnavailable/index.tsx
@@ -9,7 +9,7 @@ import { Icon, Text } from 'blockchain-info-components'
 import { actions } from 'data'
 import { media } from 'services/styles'
 
-import { getServicePriceUnavailableAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { CloseLink } from '../styles'
 
 const Wrapper = styled.div`
@@ -52,7 +52,6 @@ const Description = styled(Text)`
 `
 
 const ServicePriceUnavailable = ({ cacheActions }: Props) => {
-  const completeAnnouncement = getServicePriceUnavailableAnnouncement()
   return (
     <Wrapper>
       <MessageWrapper>
@@ -74,7 +73,7 @@ const ServicePriceUnavailable = ({ cacheActions }: Props) => {
       </MessageWrapper>
       <CloseLink
         data-e2e='newCoinCloseButton'
-        onClick={() => cacheActions.announcementDismissed(completeAnnouncement)}
+        onClick={() => cacheActions.announcementDismissed(ANNOUNCEMENTS.SERVICE_PRICE_UNAVAILABLE)}
       >
         <Icon size='20px' color='grey400' name='close-circle' />
       </CloseLink>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/StakingBanner/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/StakingBanner/index.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux'
 import { actions } from 'data'
 import { useRemote } from 'hooks'
 
-import { getStakingAnnouncement } from '../selectors'
+import ANNOUNCEMENTS from '../constants'
 import { getData } from './StakingBanner.selectors'
 import StakingBanner from './StakingBanner.template'
 
@@ -19,7 +19,7 @@ const StakingBannerContainer = () => {
   if (!data || error || isLoading || isNotAsked) return null
 
   const onClickClose = () => {
-    dispatch(actions.cache.announcementDismissed(getStakingAnnouncement()))
+    dispatch(actions.cache.announcementDismissed(ANNOUNCEMENTS.STAKING))
   }
 
   return <StakingBanner onClickClose={onClickClose} rate={data.rate} />

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/constants.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/constants.ts
@@ -1,0 +1,17 @@
+const ANNOUNCEMENTS = {
+  ACTIVE_REWARDS: `active-rewards-homepage`,
+  APPLE_GOOGLE_PAY: `apple-and-google-pay`,
+  BUY_CRIPTO: `buy-crypto-homepage`,
+  COIN_RENAME: (coin: string) => `${coin}-rename`,
+  COMPLETE_PROFILE: `complete-profile-homepage`,
+  CONTINUE_TO_GOLD: `continue-to-gold-homepage`,
+  EARN_REWARDS: `earn-rewards-homepage`,
+  KYC_FINISH: `kyc-finish-homepage`,
+  NEW_COIN: (coin: string) => `${coin}-homepage`,
+  RECURRING_BUY: `recurring-buys-homepage`,
+  SANCTIONS: `sanctions-homepage`,
+  SERVICE_PRICE_UNAVAILABLE: `service-price-unavailable-homepage`,
+  STAKING: `staking-homepage`
+}
+
+export default ANNOUNCEMENTS

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { memo, useEffect } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 import styled from 'styled-components'
@@ -28,21 +28,21 @@ const BannerWrapper = styled.div`
 `
 
 const BANNER_DICT = {
-  activeRewards: ActiveRewardsBanner,
-  appleAndGooglePay: AppleAndGooglePayBanner,
-  buyCrypto: BuyCrypto,
-  coinRename: CoinRename,
-  completeYourProfile: CompleteYourProfile,
-  continueToGold: ContinueToGold,
-  earnRewards: RewardsBanner,
-  finishKyc: FinishKyc,
-  newCurrency: NewCurrency,
-  recurringBuys: RecurringBuys,
-  resubmit: KycResubmit,
-  sanctions: Sanctions,
-  sbOrder: BSOrderBanner,
-  servicePriceUnavailable: ServicePriceUnavailable,
-  staking: StakingBanner
+  activeRewards: <ActiveRewardsBanner />,
+  appleAndGooglePay: <AppleAndGooglePayBanner />,
+  buyCrypto: <BuyCrypto />,
+  coinRename: <CoinRename />,
+  completeYourProfile: <CompleteYourProfile />,
+  continueToGold: <ContinueToGold />,
+  earnRewards: <RewardsBanner />,
+  finishKyc: <FinishKyc />,
+  newCurrency: <NewCurrency />,
+  recurringBuys: <RecurringBuys />,
+  resubmit: <KycResubmit />,
+  sanctions: <Sanctions />,
+  sbOrder: <BSOrderBanner />,
+  servicePriceUnavailable: <ServicePriceUnavailable />,
+  staking: <StakingBanner />
 }
 
 const Banners = (props: Props) => {
@@ -69,13 +69,7 @@ const Banners = (props: Props) => {
 
   if (!bannerToShow) return null
 
-  const Banner = BANNER_DICT[bannerToShow]
-
-  return (
-    <BannerWrapper>
-      <Banner />
-    </BannerWrapper>
-  )
+  return <BannerWrapper>{BANNER_DICT[bannerToShow]}</BannerWrapper>
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -87,4 +81,4 @@ const connector = connect(null, mapDispatchToProps)
 
 type Props = ConnectedProps<typeof connector>
 
-export default connector(Banners)
+export default connector(memo(Banners))

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { bindActionCreators, Dispatch } from 'redux'
 import styled from 'styled-components'
@@ -27,9 +27,27 @@ const BannerWrapper = styled.div`
   margin-bottom: 25px;
 `
 
+const BANNER_DICT = {
+  activeRewards: ActiveRewardsBanner,
+  appleAndGooglePay: AppleAndGooglePayBanner,
+  buyCrypto: BuyCrypto,
+  coinRename: CoinRename,
+  completeYourProfile: CompleteYourProfile,
+  continueToGold: ContinueToGold,
+  earnRewards: RewardsBanner,
+  finishKyc: FinishKyc,
+  newCurrency: NewCurrency,
+  recurringBuys: RecurringBuys,
+  resubmit: KycResubmit,
+  sanctions: Sanctions,
+  sbOrder: BSOrderBanner,
+  servicePriceUnavailable: ServicePriceUnavailable,
+  staking: StakingBanner
+}
+
 const Banners = (props: Props) => {
   const { buySellActions, interestActions } = props
-  const { data, error, isLoading, isNotAsked } = useRemote(getData)
+  const { data, hasError, isLoading, isNotAsked } = useRemote(getData)
 
   useEffect(() => {
     interestActions.fetchInterestEligible()
@@ -45,104 +63,19 @@ const Banners = (props: Props) => {
     }
   }, [])
 
-  if (!data || error || isNotAsked || isLoading) return null
+  if (!data || hasError || isNotAsked || isLoading) return null
 
   const { bannerToShow } = data
 
-  switch (bannerToShow) {
-    case 'resubmit':
-      return (
-        <BannerWrapper>
-          <KycResubmit />
-        </BannerWrapper>
-      )
-    case 'activeRewards':
-      return (
-        <BannerWrapper>
-          <ActiveRewardsBanner />
-        </BannerWrapper>
-      )
-    case 'staking':
-      return (
-        <BannerWrapper>
-          <StakingBanner />
-        </BannerWrapper>
-      )
-    case 'appleAndGooglePay':
-      return (
-        <BannerWrapper>
-          <AppleAndGooglePayBanner />
-        </BannerWrapper>
-      )
-    case 'finishKyc':
-      return (
-        <BannerWrapper>
-          <FinishKyc />
-        </BannerWrapper>
-      )
-    case 'servicePriceUnavailable':
-      return (
-        <BannerWrapper>
-          <ServicePriceUnavailable />
-        </BannerWrapper>
-      )
-    case 'sbOrder':
-      return (
-        <BannerWrapper>
-          <BSOrderBanner />
-        </BannerWrapper>
-      )
-    case 'coinRename':
-      return (
-        <BannerWrapper>
-          <CoinRename />
-        </BannerWrapper>
-      )
-    case 'newCurrency':
-      return (
-        <BannerWrapper>
-          <NewCurrency />
-        </BannerWrapper>
-      )
-    case 'buyCrypto':
-      return (
-        <BannerWrapper>
-          <BuyCrypto />
-        </BannerWrapper>
-      )
-    case 'continueToGold':
-      return (
-        <BannerWrapper>
-          <ContinueToGold />
-        </BannerWrapper>
-      )
-    case 'completeYourProfile':
-      return (
-        <BannerWrapper>
-          <CompleteYourProfile />
-        </BannerWrapper>
-      )
-    case 'recurringBuys':
-      return (
-        <BannerWrapper>
-          <RecurringBuys />
-        </BannerWrapper>
-      )
-    case 'sanctions':
-      return (
-        <BannerWrapper>
-          <Sanctions />
-        </BannerWrapper>
-      )
-    case 'earnRewards':
-      return (
-        <BannerWrapper>
-          <RewardsBanner />
-        </BannerWrapper>
-      )
-    default:
-      return null
-  }
+  if (!bannerToShow) return null
+
+  const Banner = BANNER_DICT[bannerToShow]
+
+  return (
+    <BannerWrapper>
+      <Banner />
+    </BannerWrapper>
+  )
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -154,4 +87,4 @@ const connector = connect(null, mapDispatchToProps)
 
 type Props = ConnectedProps<typeof connector>
 
-export default connector(memo(Banners))
+export default connector(Banners)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
@@ -18,7 +18,7 @@ import ANNOUNCEMENTS from './constants'
 const { DOC_RESUBMISSION_REASONS, KYC_STATES } = model.profile
 const { EXPIRED, GENERAL } = DOC_RESUBMISSION_REASONS
 
-export type BannerType =
+type BannerType =
   | 'resubmit'
   | 'sbOrder'
   | 'finishKyc'

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/selectors.ts
@@ -13,7 +13,11 @@ import { model, selectors } from 'data'
 import { RootState } from 'data/rootReducer'
 import { ProductEligibilityForUser, UserDataType } from 'data/types'
 
-const { EXPIRED, GENERAL } = model.profile.DOC_RESUBMISSION_REASONS
+import ANNOUNCEMENTS from './constants'
+
+const { DOC_RESUBMISSION_REASONS, KYC_STATES } = model.profile
+const { EXPIRED, GENERAL } = DOC_RESUBMISSION_REASONS
+
 export type BannerType =
   | 'resubmit'
   | 'sbOrder'
@@ -23,7 +27,6 @@ export type BannerType =
   | 'continueToGold'
   | 'sanctions'
   | 'recurringBuys'
-  | 'sanctions'
   | 'coinListing'
   | 'coinRename'
   | 'servicePriceUnavailable'
@@ -35,37 +38,13 @@ export type BannerType =
   | 'activeRewards'
   | null
 
-export const getNewCoinAnnouncement = (coin: string) => `${coin}-homepage`
-export const getCoinRenameAnnouncement = (coin: string) => `${coin}-rename`
-
-export const getCompleteProfileAnnouncement = () => `complete-profile-homepage`
-export const getAppleAndGooglePayAnnouncement = () => `apple-and-google-pay`
-export const getSanctionsAnnouncement = () => `sanctions-homepage`
-export const getBuyCryptoAnnouncement = () => `buy-crypto-homepage`
-export const getRecurringBuyAnnouncement = () => `recurring-buys-homepage`
-export const getEarnRewardsAnnouncement = () => `earn-rewards-homepage`
-export const getStakingAnnouncement = () => `staking-homepage`
-export const getActiveRewardsAnnouncement = () => `active-rewards-homepage`
-export const getServicePriceUnavailableAnnouncement = () => `service-price-unavailable-homepage`
-export const getKYCFinishAnnouncement = () => `kyc-finish-homepage`
-export const getContinueToGoldAnnouncement = () => `continue-to-gold-homepage`
-
 const showBanner = (flag: boolean, banner: string, announcementState) => {
-  return (
-    flag &&
-    (!announcementState ||
-      !announcementState[banner] ||
-      (announcementState[banner] && !announcementState[banner].dismissed))
-  )
+  return flag && !announcementState?.[banner]?.dismissed
 }
 
 export const getData = (state: RootState) => {
   const announcementState = selectors.cache.getLastAnnouncementState(state)
-  let isVerifiedId = false
-  let isBankOrCardLinked = false
-  let isBuyCrypto = false
 
-  // @ts-ignore
   const showDocResubmitBanner = selectors.modules.profile
     .getKycDocResubmissionStatus(state)
     .map(anyPass([equals(GENERAL), equals(EXPIRED)]))
@@ -73,17 +52,15 @@ export const getData = (state: RootState) => {
 
   const isUserActive =
     selectors.modules.profile.getUserActivationState(state).getOrElse('') !== 'NONE'
-  const isKycStateNone =
-    // @ts-ignore
-    selectors.modules.profile.getUserKYCState(state).getOrElse('') === 'NONE'
+  const isKycStateNone = selectors.modules.profile.getUserKYCState(state).getOrElse('') === 'NONE'
 
   const showCompleteYourProfile = selectors.core.walletOptions
     .getCompleteYourProfile(state)
     .getOrElse(false) as boolean
-  const completeProfileAnnouncement = getCompleteProfileAnnouncement()
+
   const showCompleteYourProfileBanner = showBanner(
     !!showCompleteYourProfile,
-    completeProfileAnnouncement,
+    ANNOUNCEMENTS.COMPLETE_PROFILE,
     announcementState
   )
 
@@ -104,23 +81,20 @@ export const getData = (state: RootState) => {
     NotAsked: () => false,
     Success: () => true
   })
+
   const userData = userDataR.getOrElse({
     address: { country: '' },
     tags: {},
     tiers: { current: 0 }
   } as UserDataType)
 
-  const { KYC_STATES } = model.profile
-  const isKycPendingOrVerified =
-    userData.kycState === KYC_STATES.PENDING ||
-    userData.kycState === KYC_STATES.UNDER_REVIEW ||
-    userData.kycState === KYC_STATES.VERIFIED
+  const isKycPendingOrVerified = [
+    KYC_STATES.PENDING,
+    KYC_STATES.UNDER_REVIEW,
+    KYC_STATES.VERIFIED
+  ].includes(userData.kycState)
 
   const isKycRejected = userData.kycState === KYC_STATES.REJECTED
-
-  if (isKycPendingOrVerified) {
-    isVerifiedId = true
-  }
 
   // continueToGold
   const limits = selectors.components.buySell.getLimits(state).getOrElse({
@@ -133,29 +107,29 @@ export const getData = (state: RootState) => {
   const isRecurringBuy = selectors.core.walletOptions
     .getFeatureFlagRecurringBuys(state)
     .getOrElse(false) as boolean
-  const recurringBuyAnnouncement = getRecurringBuyAnnouncement()
+
   const showRecurringBuyBanner = showBanner(
     isRecurringBuy,
-    recurringBuyAnnouncement,
+    ANNOUNCEMENTS.RECURRING_BUY,
     announcementState
   )
 
   // newCurrency
   const newCoinListing = selectors.core.walletOptions.getNewCoinListing(state).getOrElse('')
-  const newCoinAnnouncement = getNewCoinAnnouncement(newCoinListing)
+  const newCoinAnnouncement = ANNOUNCEMENTS.NEW_COIN(newCoinListing)
   const isNewCurrency = showBanner(!!newCoinListing, newCoinAnnouncement, announcementState)
 
   // coinRename
   const coinRename = selectors.core.walletOptions.getCoinRename(state).getOrElse('')
-  const coinRenameAnnouncement = getCoinRenameAnnouncement(coinRename)
+  const coinRenameAnnouncement = ANNOUNCEMENTS.COIN_RENAME(coinRename)
   const showRenameBanner = showBanner(!!coinRename, coinRenameAnnouncement, announcementState)
 
   // servicePriceUnavailable
   const isServicePriceUnavailable = selectors.core.data.coins.getIsServicePriceDown(state)
-  const servicePriceUnavailableAnnouncement = getServicePriceUnavailableAnnouncement()
+
   const showServicePriceUnavailableBanner = showBanner(
     !!isServicePriceUnavailable,
-    servicePriceUnavailableAnnouncement,
+    ANNOUNCEMENTS.SERVICE_PRICE_UNAVAILABLE,
     announcementState
   )
 
@@ -163,84 +137,73 @@ export const getData = (state: RootState) => {
   const paymentMethods = selectors.components.buySell
     .getBSPaymentMethods(state)
     .getOrElse({} as BSPaymentMethodsType)
+
   const isAnyBankLinked =
     paymentMethods?.methods?.length > 0 &&
     paymentMethods.methods.find(
       (method) => method.eligible && method.type === BSPaymentTypes.LINK_BANK
     )
-  if (cards?.length > 0 || isAnyBankLinked) {
-    isBankOrCardLinked = true
-  }
+
+  const isBankOrCardLinked = cards?.length > 0 || isAnyBankLinked
 
   // user have some balance
   const balances = selectors.components.buySell.getBSBalances(state).getOrElse({} as BSBalancesType)
-  if (!isEmpty(balances)) {
-    if (
-      Object.values(balances).some(
-        (balance) => balance?.available && Number(balance?.available) > 0
-      )
-    ) {
-      isBuyCrypto = true
-    }
-  }
+  const isBuyCrypto = Object.values(balances).some(
+    (balance) => balance?.available && Number(balance?.available) > 0
+  )
 
   // buy crypto
-  const buyCryptoAnnouncement = getBuyCryptoAnnouncement()
   const buyCryptoBannerCondition = userData?.tiers?.current !== 2 || isKycStateNone
   const showBuyCryptoBanner = showBanner(
     buyCryptoBannerCondition,
-    buyCryptoAnnouncement,
+    ANNOUNCEMENTS.BUY_CRIPTO,
     announcementState
   )
 
-  const isProfileCompleted = isVerifiedId && isBankOrCardLinked && isBuyCrypto
+  const isProfileCompleted = isKycPendingOrVerified && isBankOrCardLinked && isBuyCrypto
 
   // earnRewards
   const interestEligible = selectors.components.interest.getInterestEligible(state).getOrElse({})
   const isEarnRewardsPromoBannerFeatureFlagEnabled = selectors.core.walletOptions
     .getRewardsPromoBannerEnabled(state)
     .getOrElse(false) as boolean
-  const isUserEligibleToEarnRewards =
-    !isEmpty(interestEligible) && Object.values(interestEligible).some((obj) => !!obj?.eligible)
+  const isUserEligibleToEarnRewards = Object.values(interestEligible).some((obj) => !!obj?.eligible)
   const isEarnRewardsPromoBannerEnabled = !!(
     isEarnRewardsPromoBannerFeatureFlagEnabled && isUserEligibleToEarnRewards
   )
-  const earnRewardsAnnouncement = getEarnRewardsAnnouncement()
+
   const showEarnRewardsBanner = showBanner(
     isEarnRewardsPromoBannerEnabled,
-    earnRewardsAnnouncement,
+    ANNOUNCEMENTS.EARN_REWARDS,
     announcementState
   )
 
   // Apple and Google Pay
-  const appleAndGooglePayAnnouncement = getAppleAndGooglePayAnnouncement()
   const isAppleAndGooglePayPromoBannerFeatureFlagEnabled = selectors.core.walletOptions
     .getAppleAndGooglePayPromoBannerEnabled(state)
     .getOrElse(false) as boolean
 
   const showAppleAndGooglePayBanner = showBanner(
     isAppleAndGooglePayPromoBannerFeatureFlagEnabled,
-    appleAndGooglePayAnnouncement,
+    ANNOUNCEMENTS.APPLE_GOOGLE_PAY,
     announcementState
   )
 
   // Staking
-  const stakingAnnouncement = getStakingAnnouncement()
   const stakingEligible = selectors.components.interest.getStakingEligible(state).getOrElse({})
-  const isUserStakingEligible =
-    !isEmpty(stakingEligible) && Object.values(stakingEligible).some((obj) => !!obj?.eligible)
+
+  const isUserStakingEligible = Object.values(stakingEligible).some((obj) => !!obj?.eligible)
   const isStakingPromoBannerFeatureFlagEnabled = selectors.core.walletOptions
     .getStakingPromoBannerEnabled(state)
     .getOrElse(false) as boolean
 
   const showStakingBanner = showBanner(
     isStakingPromoBannerFeatureFlagEnabled && isUserStakingEligible,
-    stakingAnnouncement,
+    ANNOUNCEMENTS.STAKING,
     announcementState
   )
 
   // active rewards
-  const activeRewardsAnnouncement = getActiveRewardsAnnouncement()
   const activeRewardsEligible = selectors.components.interest
     .getActiveRewardsEligible(state)
     .getOrElse({})
@@ -253,27 +216,24 @@ export const getData = (state: RootState) => {
 
   const showActiveRewardsBanner = showBanner(
     isActiveRewardsPromoBannerFeatureFlagEnabled && isUserActiveRewardsEligible,
-    activeRewardsAnnouncement,
+    ANNOUNCEMENTS.ACTIVE_REWARDS,
     announcementState
   )
 
   // Continue to Gold
   const continueToGold =
-    (userData?.tiers?.current === TIER_TYPES.SILVER ||
-      userData?.tiers?.current === TIER_TYPES.SILVER_PLUS) &&
-    limits?.max &&
+    [TIER_TYPES.SILVER, TIER_TYPES.SILVER_PLUS].includes(userData?.tiers?.current) &&
     Number(limits?.max) > 0
-  const continueToGoldAnnouncement = getContinueToGoldAnnouncement()
+
   const showContinueToGoldBanner = showBanner(
     !!continueToGold,
-    continueToGoldAnnouncement,
+    ANNOUNCEMENTS.CONTINUE_TO_GOLD,
     announcementState
   )
 
   // KYC finish banner
-  const kycFinishAnnouncement = getKYCFinishAnnouncement()
   const showFinishKYC = isKycStateNone && isUserActive && !isFirstLogin
-  const showKYCFinishBanner = showBanner(showFinishKYC, kycFinishAnnouncement, announcementState)
+  const showKYCFinishBanner = showBanner(showFinishKYC, ANNOUNCEMENTS.KYC_FINISH, announcementState)
 
   const stakingEligibleR = selectors.components.interest.getStakingEligible(state)
   const activeRewardsEligibleR = selectors.components.interest.getActiveRewardsEligible(state)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Actions/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/PriceChart/Actions/template.tsx
@@ -32,25 +32,29 @@ const Actions = ({
   cryptoCurrency,
   swapActions
 }: Props) => {
+  const onBuyClick = () => {
+    buySellActions.showModal({
+      cryptoCurrency,
+      orderType: OrderType.BUY,
+      origin: 'PriceChart'
+    })
+    analyticsActions.trackEvent({
+      key: Analytics.PRICE_GRAPH_BUY_CLICKED,
+      properties: {}
+    })
+  }
+
+  const onSwapClick = () => {
+    swapActions.showModal({ origin: 'PriceChart' })
+    analyticsActions.trackEvent({
+      key: Analytics.PRICE_GRAPH_SWAP_CLICKED,
+      properties: {}
+    })
+  }
+
   return (
     <Wrapper>
-      <BuyTradeButton
-        data-e2e='buyButton'
-        height='42px'
-        nature='primary'
-        onClick={() => {
-          analyticsActions.trackEvent({
-            key: Analytics.PRICE_GRAPH_BUY_CLICKED,
-            properties: {}
-          })
-
-          buySellActions.showModal({
-            cryptoCurrency,
-            orderType: OrderType.BUY,
-            origin: 'PriceChart'
-          })
-        }}
-      >
+      <BuyTradeButton data-e2e='buyButton' height='42px' nature='primary' onClick={onBuyClick}>
         <Text color='white' size='16px' lineHeight='24px' weight={600}>
           <FormattedMessage
             id='price.chart.buy.coin'
@@ -63,14 +67,7 @@ const Actions = ({
         data-e2e='swapButton'
         height='42px'
         nature='empty-secondary'
-        onClick={() => {
-          analyticsActions.trackEvent({
-            key: Analytics.PRICE_GRAPH_SWAP_CLICKED,
-            properties: {}
-          })
-
-          swapActions.showModal({ origin: 'PriceChart' })
-        }}
+        onClick={onSwapClick}
       >
         <Text color='blue600' size='16px' lineHeight='24px' weight={600}>
           <FormattedMessage


### PR DESCRIPTION
The `fetchProductEligibilityForUser` is being done when the user logs in, so it can be safely called without re-fetching it when loading the modal