### PR TITLE
chore(signup): code cleanup

### DIFF
--- a/packages/blockchain-info-components/src/Images/Images.ts
+++ b/packages/blockchain-info-components/src/Images/Images.ts
@@ -199,7 +199,7 @@ const Images = {
   'apple-app-store-badge': appleAppStoreBadge,
   'apple-pay': applePay,
   'arrow-left': arrowLeft,
-  'backgorund-modal-gradient': bgModalGradient,
+  'background-modal-gradient': bgModalGradient,
   bank,
   'bank-empty': bankEmpty,
   'bank-empty-blue': bankEmptyBlue,

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/BuyGoal/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/BuyGoal/index.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect } from 'react'
 import { FormattedMessage } from 'react-intl'
-import { connect, ConnectedProps } from 'react-redux'
-import { find, isEmpty, isNil, propEq, propOr } from 'ramda'
+import { useSelector } from 'react-redux'
 import { InjectedFormProps } from 'redux-form'
 import styled from 'styled-components'
 
 import Currencies from '@core/exchange/currencies'
+import { getIsCoinDataLoaded } from '@core/redux/data/coins/selectors'
 import { Icon, Text } from 'blockchain-info-components'
-import { selectors } from 'data'
 import { BuySellWidgetGoalDataType } from 'data/types'
 
 import { SIGNUP_FORM } from '..'
@@ -56,17 +55,19 @@ const Amount = styled(Text)`
   text-overflow: ellipsis;
 `
 
-const BuyGoal = (props: InjectedFormProps<{}> & SubviewProps & Props) => {
-  const { formActions, goals, isCoinDataLoaded } = props
-  const dataGoal = find(propEq('name', 'buySell'), goals)
-  const goalData: BuySellWidgetGoalDataType = propOr({}, 'data', dataGoal)
+const BuyGoal = (props: InjectedFormProps<{}> & SubviewProps) => {
+  const isCoinDataLoaded = useSelector(getIsCoinDataLoaded)
+  const { formActions, goals } = props
+
+  const dataGoal = goals.find((goal) => goal.name === 'buySell')
+  const goalData = dataGoal?.data ?? ({} as BuySellWidgetGoalDataType)
   const { amount, crypto, email, fiatCurrency } = goalData
-  const showBuyHeader =
-    !isNil(goalData) && !isEmpty(goalData) && !!fiatCurrency && !!crypto && !!amount
+
+  const showBuyHeader = !!fiatCurrency && !!crypto && !!amount
 
   useEffect(() => {
     formActions.change(SIGNUP_FORM, 'email', email)
-  }, [formActions])
+  }, [formActions, email])
   return (
     <>
       <CardsWrapper>
@@ -114,19 +115,11 @@ const BuyGoal = (props: InjectedFormProps<{}> & SubviewProps & Props) => {
             )}
             <SignupForm {...props} />
           </PaddingWrapper>
-          <LoginLink analyticsActions={props.analyticsActions} unified={props.unified} />
+          <LoginLink />
         </BuyCard>
       </CardsWrapper>
     </>
   )
 }
 
-const mapStateToProps = (state) => ({
-  isCoinDataLoaded: selectors.core.data.coins.getIsCoinDataLoaded(state)
-})
-
-const connector = connect(mapStateToProps)
-
-type Props = ConnectedProps<typeof connector>
-
-export default connector(BuyGoal)
+export default BuyGoal

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/index.tsx
@@ -54,7 +54,11 @@ const ProductPickerContainer: React.FC<Props> = (props) => {
   return props.walletLoginData.cata({
     Failure: (error) =>
       error === 4 && isExchangeMobileSignup ? (
-        <ExchangeMobileUserConflict {...props} />
+        <ExchangeMobileUserConflict
+          authActions={props.authActions}
+          email={props.email}
+          showExchangeLoginButton={props.showExchangeLoginButton}
+        />
       ) : (
         <Error error={error} />
       ),
@@ -62,17 +66,17 @@ const ProductPickerContainer: React.FC<Props> = (props) => {
     NotAsked: () => {
       if (isMetadataRecovery) {
         props.routerActions.push('/home')
-        return null
+      } else {
+        props.routerActions.push('/login?product=exchange')
       }
-      props.routerActions.push('/login?product=exchange')
       return null
     },
     Success: () =>
       showExchangeUserConflict ? (
-        <ExchangeUserConflict {...props} walletRedirect={walletRedirect} />
+        <ExchangeUserConflict email={props.email} walletRedirect={walletRedirect} />
       ) : (
         <ProductPicker
-          {...props}
+          isAccountReset={props.isAccountReset}
           walletRedirect={walletRedirect}
           exchangeRedirect={exchangeRedirect}
         />
@@ -80,10 +84,9 @@ const ProductPickerContainer: React.FC<Props> = (props) => {
   })
 }
 const mapStateToProps = (state) => ({
-  appEnv: selectors.core.walletOptions.getAppEnv(state).getOrElse('prod'),
   email: selectors.signup.getRegisterEmail(state) as string,
   exchangeUserConflict: selectors.auth.getExchangeConflictStatus(state) as boolean,
-  isAccountReset: selectors.signup.getAccountReset(state) as boolean,
+  isAccountReset: selectors.signup.getAccountReset(state),
   isMetadataRecoveryR: selectors.signup.getMetadataRestore(state),
   products: selectors.custodial.getProductEligibilityForUser(state).getOrElse({
     notifications: []
@@ -98,7 +101,6 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   authActions: bindActionCreators(actions.auth, dispatch),
   custodialActions: bindActionCreators(actions.custodial, dispatch),
-  miscActions: bindActionCreators(actions.core.data.misc, dispatch),
   profileActions: bindActionCreators(actions.modules.profile, dispatch),
   routerActions: bindActionCreators(actions.router, dispatch),
   runGoals: () => dispatch(actions.goals.runGoals()),

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/template.error.exchangeMobile.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/template.error.exchangeMobile.tsx
@@ -78,6 +78,6 @@ const ExchangeMobileUserConflict = ({ authActions, email, showExchangeLoginButto
 type Props = {
   email: string
   showExchangeLoginButton: boolean
-} & OwnProps
+} & Pick<OwnProps, 'authActions'>
 
 export default ExchangeMobileUserConflict

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/SignupCard/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/SignupCard/index.tsx
@@ -196,11 +196,7 @@ const SignupCard = (props: InjectedFormProps<{}> & SubviewProps) => {
               </Bottom>
             </AppButtons>
           )}
-          {isExchangeMobileSignup ? (
-            <Bottom />
-          ) : (
-            <LoginLink analyticsActions={props.analyticsActions} unified={props.unified} />
-          )}
+          {isExchangeMobileSignup ? <Bottom /> : <LoginLink />}
         </Card>
       </CardWrapper>
     </>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/SignupForm/QRsModal.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/SignupForm/QRsModal.tsx
@@ -45,7 +45,7 @@ type Props = {
 
 const QRsModal: React.FC<Props> = ({ onClose, platform }) => (
   <QRModal doNotHide size='medium'>
-    <Image name='backgorund-modal-gradient' />
+    <Image name='background-modal-gradient' />
     <QRModalHeader onClose={onClose} />
     <QRModalBody>
       <Text color='white' size='1.5rem' weight={600} lineHeight='1.5'>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/index.tsx
@@ -1,9 +1,12 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { FormattedMessage } from 'react-intl'
+import { useDispatch, useSelector } from 'react-redux'
 import { LinkContainer } from 'react-router-bootstrap'
 import styled, { DefaultTheme } from 'styled-components'
 
 import { Text } from 'blockchain-info-components'
+import { trackEvent } from 'data/analytics/slice'
+import { getUnifiedAccountStatus } from 'data/cache/selectors'
 import { Analytics } from 'data/types'
 import { media } from 'services/styles'
 
@@ -145,36 +148,43 @@ align-items: center;
 `}
 `
 
-export const LoginLink = (props: { analyticsActions; unified }) => (
-  <LoginCard>
-    <LinkContainer data-e2e='signupLink' to='/login'>
-      <LoginLinkRow
-        onClick={() =>
-          props.analyticsActions.trackEvent({
-            key: Analytics.LOGIN_CLICKED,
-            properties: {
-              origin: 'SIGN_UP_FLOW',
-              unified: props.unified
-            }
-          })
+export const LoginLink = () => {
+  const dispatch = useDispatch()
+  const unified = useSelector(getUnifiedAccountStatus)
+
+  const trackLoginClicked = useCallback(() => {
+    dispatch(
+      trackEvent({
+        key: Analytics.LOGIN_CLICKED,
+        properties: {
+          origin: 'SIGN_UP_FLOW',
+          unified
         }
-      >
-        <Text
-          size='16px'
-          color='grey600'
-          weight={500}
-          style={{ cursor: 'pointer', marginTop: '16px' }}
-        >
-          <FormattedMessage
-            id='scenes.register.account.link'
-            defaultMessage='Already have a Blockchain.com Account?'
-          />
-        </Text>
-        &nbsp;
-        <LoginLinkText size='16px' color='blue600' weight={600}>
-          <FormattedMessage id='scenes.login.wallet.exchange_login' defaultMessage='Log In ->' />
-        </LoginLinkText>
-      </LoginLinkRow>
-    </LinkContainer>
-  </LoginCard>
-)
+      })
+    )
+  }, [])
+
+  return (
+    <LoginCard>
+      <LinkContainer data-e2e='signupLink' to='/login'>
+        <LoginLinkRow onClick={trackLoginClicked}>
+          <Text
+            size='16px'
+            color='grey600'
+            weight={500}
+            style={{ cursor: 'pointer', marginTop: '16px' }}
+          >
+            <FormattedMessage
+              id='scenes.register.account.link'
+              defaultMessage='Already have a Blockchain.com Account?'
+            />
+          </Text>
+          &nbsp;
+          <LoginLinkText size='16px' color='blue600' weight={600}>
+            <FormattedMessage id='scenes.login.wallet.exchange_login' defaultMessage='Log In ->' />
+          </LoginLinkText>
+        </LoginLinkRow>
+      </LinkContainer>
+    </LoginCard>
+  )
+}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/types.ts
@@ -8,13 +8,7 @@ export type SignupFormInitValuesType = {
   country?: string
   email?: string
 }
-export type GeoLocationType = {
-  countryCode: string
-  headerBlockchainCFIpCountry: string
-  headerBlockchainGoogleIpCountry: string
-  headerBlockchainGoogleIpRegion: string
-  ip: string
-}
+
 export type SignupFormType = {
   country: string
   email: string
@@ -23,7 +17,13 @@ export type SignupFormType = {
   state: string
 }
 export type GoalDataType = Array<{
-  data: never
+  data: {
+    amount: number
+    crypto: string
+    email: string
+    fiatCurrency: string
+    firstLogin: boolean
+  }
   id: string
   name: GoalsType
 }>


### PR DESCRIPTION
#### Images & SignupForm/QRsModal.tsx
 - Fixed typo
#### BuyGoal & SignupForm
 - Replaced `ramda` with js functions
 - Use RTK's `useSelector`
#### ProductPicker/index.jsx
- Pass down only used props to children
- Removed unused elements from `mapStateToProps` and `mapDispatchToProps`
#### ProductPicker/template.error.exchangeMobile.jsx
- Only require required prop
#### LoginLink
- Both props could be acquired by using RTK's elements, so deleted them and refactored accordingly
#### Signup/index.jsx
- Renamed function according to what it does
- Removed `initialValues` as they are used in a child componen (SignupForm) that can calculate it by itself
- Replaced `ramda` with js functions
- Removed unused Redux props (`domains`, `alertActions`)
- Removed Redux props that are later acquired in children components (`isReferralEnabled`, `isValidReferralCode`, `analyticsActions`)
#### Signup/types.ts
- Deleted unused type
- Expanded existing types with data based on usage on code