### PR TITLE
chore(signup): code refactor

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/BuyGoal/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/BuyGoal/index.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect } from 'react'
 import { FormattedMessage } from 'react-intl'
-import { connect, ConnectedProps } from 'react-redux'
-import { find, isEmpty, isNil, propEq, propOr } from 'ramda'
-import { InjectedFormProps } from 'redux-form'
+import { useDispatch, useSelector } from 'react-redux'
+import { change, InjectedFormProps } from 'redux-form'
 import styled from 'styled-components'
 
 import Currencies from '@core/exchange/currencies'
+import { getIsCoinDataLoaded } from '@core/redux/data/coins/selectors'
 import { Icon, Text } from 'blockchain-info-components'
-import { selectors } from 'data'
 import { BuySellWidgetGoalDataType } from 'data/types'
 
 import { SIGNUP_FORM } from '..'
-import { Card, CardHeader, CardsWrapper, LoginLink, PaddingWrapper } from '../components'
+import { Card, CardHeader, CardsWrapper, PaddingWrapper } from '../components'
+import { LoginLink } from '../components/LoginLink'
 import SignupForm from '../components/SignupForm'
 import { SubviewProps } from '../types'
 
@@ -56,17 +56,20 @@ const Amount = styled(Text)`
   text-overflow: ellipsis;
 `
 
-const BuyGoal = (props: InjectedFormProps<{}> & SubviewProps & Props) => {
-  const { formActions, goals, isCoinDataLoaded } = props
-  const dataGoal = find(propEq('name', 'buySell'), goals)
-  const goalData: BuySellWidgetGoalDataType = propOr({}, 'data', dataGoal)
+const BuyGoal = (props: InjectedFormProps<{}> & SubviewProps) => {
+  const isCoinDataLoaded = useSelector(getIsCoinDataLoaded)
+  const dispatch = useDispatch()
+
+  const { goals } = props
+  const dataGoal = goals.find((goal) => goal.name === 'buySell')
+  const goalData = dataGoal?.data ?? ({} as BuySellWidgetGoalDataType)
   const { amount, crypto, email, fiatCurrency } = goalData
-  const showBuyHeader =
-    !isNil(goalData) && !isEmpty(goalData) && !!fiatCurrency && !!crypto && !!amount
+  const showBuyHeader = Object.keys(goalData).length > 0 && !!fiatCurrency && !!crypto && !!amount
 
   useEffect(() => {
-    formActions.change(SIGNUP_FORM, 'email', email)
-  }, [formActions])
+    dispatch(change(SIGNUP_FORM, 'email', email))
+  }, [])
+
   return (
     <>
       <CardsWrapper>
@@ -114,19 +117,11 @@ const BuyGoal = (props: InjectedFormProps<{}> & SubviewProps & Props) => {
             )}
             <SignupForm {...props} />
           </PaddingWrapper>
-          <LoginLink analyticsActions={props.analyticsActions} unified={props.unified} />
+          <LoginLink />
         </BuyCard>
       </CardsWrapper>
     </>
   )
 }
 
-const mapStateToProps = (state) => ({
-  isCoinDataLoaded: selectors.core.data.coins.getIsCoinDataLoaded(state)
-})
-
-const connector = connect(mapStateToProps)
-
-type Props = ConnectedProps<typeof connector>
-
-export default connector(BuyGoal)
+export default BuyGoal

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/index.tsx
@@ -54,7 +54,11 @@ const ProductPickerContainer: React.FC<Props> = (props) => {
   return props.walletLoginData.cata({
     Failure: (error) =>
       error === 4 && isExchangeMobileSignup ? (
-        <ExchangeMobileUserConflict {...props} />
+        <ExchangeMobileUserConflict
+          email={props.email}
+          showExchangeLoginButton={props.showExchangeLoginButton}
+          authActions={props.authActions}
+        />
       ) : (
         <Error error={error} />
       ),
@@ -62,25 +66,24 @@ const ProductPickerContainer: React.FC<Props> = (props) => {
     NotAsked: () => {
       if (isMetadataRecovery) {
         props.routerActions.push('/home')
-        return null
+      } else {
+        props.routerActions.push('/login?product=exchange')
       }
-      props.routerActions.push('/login?product=exchange')
       return null
     },
     Success: () =>
       showExchangeUserConflict ? (
-        <ExchangeUserConflict {...props} walletRedirect={walletRedirect} />
+        <ExchangeUserConflict email={props.email} walletRedirect={walletRedirect} />
       ) : (
         <ProductPicker
-          {...props}
           walletRedirect={walletRedirect}
           exchangeRedirect={exchangeRedirect}
+          isAccountReset={props.isAccountReset}
         />
       )
   })
 }
 const mapStateToProps = (state) => ({
-  appEnv: selectors.core.walletOptions.getAppEnv(state).getOrElse('prod'),
   email: selectors.signup.getRegisterEmail(state) as string,
   exchangeUserConflict: selectors.auth.getExchangeConflictStatus(state) as boolean,
   isAccountReset: selectors.signup.getAccountReset(state) as boolean,
@@ -98,7 +101,6 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   authActions: bindActionCreators(actions.auth, dispatch),
   custodialActions: bindActionCreators(actions.custodial, dispatch),
-  miscActions: bindActionCreators(actions.core.data.misc, dispatch),
   profileActions: bindActionCreators(actions.modules.profile, dispatch),
   routerActions: bindActionCreators(actions.router, dispatch),
   runGoals: () => dispatch(actions.goals.runGoals()),

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/template.error.exchangeMobile.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/ProductPicker/template.error.exchangeMobile.tsx
@@ -78,6 +78,6 @@ const ExchangeMobileUserConflict = ({ authActions, email, showExchangeLoginButto
 type Props = {
   email: string
   showExchangeLoginButton: boolean
-} & OwnProps
+} & Pick<OwnProps, 'authActions'>
 
 export default ExchangeMobileUserConflict

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/LoginLink/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/LoginLink/index.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import { useDispatch, useSelector } from 'react-redux'
+import { LinkContainer } from 'react-router-bootstrap'
+import styled from 'styled-components'
+
+import { Text } from 'blockchain-info-components'
+import { trackEvent } from 'data/analytics/slice'
+import { getUnifiedAccountStatus } from 'data/cache/selectors'
+import { Analytics } from 'data/types'
+import { media } from 'services/styles'
+
+const LoginCard = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 24px;
+  border-top: 1px solid ${(props) => props.theme.grey000};
+  padding-bottom: 1.5rem;
+  ${media.tabletL`
+    flex-direction: column;
+    align-items: center;
+  `};
+`
+const LoginLinkText = styled(Text)`
+  margin-top: 16px;
+  cursor: pointer;
+  ${media.mobile`
+    margin-top: 0;
+  `};
+  &:hover {
+    font-weight: 600;
+  }
+`
+const LoginLinkRow = styled.div`
+  display: flex;
+  align-items: center;
+  ${media.mobile`
+    flex-direction: column;
+    align-items: center;
+  `}
+`
+
+export const LoginLink = () => {
+  const dispatch = useDispatch()
+
+  const unified = useSelector(getUnifiedAccountStatus)
+
+  return (
+    <LoginCard>
+      <LinkContainer data-e2e='signupLink' to='/login'>
+        <LoginLinkRow
+          onClick={() =>
+            dispatch(
+              trackEvent({
+                key: Analytics.LOGIN_CLICKED,
+                properties: {
+                  origin: 'SIGN_UP_FLOW',
+                  unified
+                }
+              })
+            )
+          }
+        >
+          <Text
+            size='16px'
+            color='grey600'
+            weight={500}
+            style={{ cursor: 'pointer', marginTop: '16px' }}
+          >
+            <FormattedMessage
+              id='scenes.register.account.link'
+              defaultMessage='Already have a Blockchain.com Account?'
+            />
+          </Text>
+          &nbsp;
+          <LoginLinkText size='16px' color='blue600' weight={600}>
+            <FormattedMessage id='scenes.login.wallet.exchange_login' defaultMessage='Log In ->' />
+          </LoginLinkText>
+        </LoginLinkRow>
+      </LinkContainer>
+    </LoginCard>
+  )
+}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/SignupCard/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/SignupCard/index.tsx
@@ -8,16 +8,8 @@ import { PlatformTypes } from 'data/types'
 import { isMobile, media } from 'services/styles'
 
 import { SubviewProps } from '../../types'
-import {
-  Card,
-  CardInfo,
-  CardTitle,
-  CardWrapper,
-  InfoItem,
-  InfoTitle,
-  LoginLink,
-  PaddingWrapper
-} from '..'
+import { Card, CardInfo, CardTitle, CardWrapper, InfoItem, InfoTitle, PaddingWrapper } from '..'
+import { LoginLink } from '../LoginLink'
 import SignupForm from '../SignupForm'
 import QRsModal, { QRModalType } from '../SignupForm/QRsModal'
 
@@ -196,11 +188,7 @@ const SignupCard = (props: InjectedFormProps<{}> & SubviewProps) => {
               </Bottom>
             </AppButtons>
           )}
-          {isExchangeMobileSignup ? (
-            <Bottom />
-          ) : (
-            <LoginLink analyticsActions={props.analyticsActions} unified={props.unified} />
-          )}
+          {isExchangeMobileSignup ? <Bottom /> : <LoginLink />}
         </Card>
       </CardWrapper>
     </>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/components/index.tsx
@@ -1,10 +1,6 @@
-import React from 'react'
-import { FormattedMessage } from 'react-intl'
-import { LinkContainer } from 'react-router-bootstrap'
-import styled, { DefaultTheme } from 'styled-components'
+import styled from 'styled-components'
 
 import { Text } from 'blockchain-info-components'
-import { Analytics } from 'data/types'
 import { media } from 'services/styles'
 
 export const CardWrapper = styled.div<{ hideMargin?: boolean }>`
@@ -47,22 +43,7 @@ export const CardHeader = styled.div`
   align-items: center;
   display: flex;
 `
-export const IconWrapper = styled.div<{ color: keyof DefaultTheme }>`
-  display: flex;
-  background: ${(props) => props.theme[props.color]};
-  height: 3rem;
-  width: 3rem;
-  justify-content: center;
-  align-items: center;
-  border-radius: 50%;
-  margin-right: 1.25rem;
 
-  ${media.tablet`
-    height: 2.5rem;
-    width: 2.5rem;
-    flex-shrink: 0;
-  `}
-`
 export const CardsWrapper = styled.div`
   display: flex;
 
@@ -103,78 +84,3 @@ export const InfoItem = styled.div`
     `}
   }
 `
-export const SubCard = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-top: 1.25rem;
-  margin-bottom: 2.5rem;
-`
-export const SignInText = styled(Text)`
-  &:hover {
-    color: ${(props) => props.theme.white};
-    font-weight: 600;
-  }
-`
-const LoginCard = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-top: 24px;
-  border-top: 1px solid ${(props) => props.theme.grey000};
-  padding-bottom: 1.5rem;
-  ${media.tabletL`
-  flex-direction: column;
-  align-items: center;
-`};
-`
-const LoginLinkText = styled(Text)`
-  margin-top: 16px;
-  cursor: pointer;
-  ${media.mobile`
-  margin-top: 0;
-`};
-  &:hover {
-    font-weight: 600;
-  }
-`
-const LoginLinkRow = styled.div`
-  display: flex;
-  align-items: center;
-  ${media.mobile`
-flex-direction: column;
-align-items: center;
-`}
-`
-
-export const LoginLink = (props: { analyticsActions; unified }) => (
-  <LoginCard>
-    <LinkContainer data-e2e='signupLink' to='/login'>
-      <LoginLinkRow
-        onClick={() =>
-          props.analyticsActions.trackEvent({
-            key: Analytics.LOGIN_CLICKED,
-            properties: {
-              origin: 'SIGN_UP_FLOW',
-              unified: props.unified
-            }
-          })
-        }
-      >
-        <Text
-          size='16px'
-          color='grey600'
-          weight={500}
-          style={{ cursor: 'pointer', marginTop: '16px' }}
-        >
-          <FormattedMessage
-            id='scenes.register.account.link'
-            defaultMessage='Already have a Blockchain.com Account?'
-          />
-        </Text>
-        &nbsp;
-        <LoginLinkText size='16px' color='blue600' weight={600}>
-          <FormattedMessage id='scenes.login.wallet.exchange_login' defaultMessage='Log In ->' />
-        </LoginLinkText>
-      </LoginLinkRow>
-    </LinkContainer>
-  </LoginCard>
-)

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/index.tsx
@@ -6,7 +6,7 @@ import { InjectedFormProps, reduxForm } from 'redux-form'
 import styled from 'styled-components'
 
 import { Remote } from '@core'
-import { RemoteDataType, WalletOptionsType } from '@core/types'
+import { RemoteDataType } from '@core/types'
 import { Image } from 'blockchain-info-components'
 import { actions, selectors } from 'data'
 import { RootState } from 'data/rootReducer'
@@ -155,9 +155,6 @@ class SignupContainer extends React.PureComponent<
 }
 
 const mapStateToProps = (state: RootState): LinkStatePropsType => ({
-  domains: selectors.core.walletOptions.getDomains(state).getOrElse({
-    exchange: 'https://exchange.blockchain.com'
-  } as WalletOptionsType['domains']),
   formValues: selectors.form.getFormValues(SIGNUP_FORM)(state) as SignupFormType,
   goals: selectors.goals.getGoals(state) as GoalDataType,
   isLoadingR: selectors.signup.getRegistering(state) as RemoteDataType<string, undefined>,
@@ -167,13 +164,10 @@ const mapStateToProps = (state: RootState): LinkStatePropsType => ({
   isValidReferralCode: selectors.signup.getIsValidReferralCode(state),
   language: selectors.preferences.getLanguage(state),
   search: selectors.router.getSearch(state) as string,
-  signupMetadata: selectors.signup.getProductSignupMetadata(state) as ProductSignupMetadata,
-  unified: selectors.cache.getUnifiedAccountStatus(state) as boolean
+  signupMetadata: selectors.signup.getProductSignupMetadata(state) as ProductSignupMetadata
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  alertActions: bindActionCreators(actions.alerts, dispatch),
-  analyticsActions: bindActionCreators(actions.analytics, dispatch),
   authActions: bindActionCreators(actions.auth, dispatch),
   formActions: bindActionCreators(actions.form, dispatch),
   signupActions: bindActionCreators(actions.signup, dispatch),
@@ -183,7 +177,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 const connector = connect(mapStateToProps, mapDispatchToProps)
 
 type LinkStatePropsType = {
-  domains: WalletOptionsType['domains']
   formValues: SignupFormType
   goals: GoalDataType
   isLoadingR: RemoteDataType<string, undefined>
@@ -192,7 +185,6 @@ type LinkStatePropsType = {
   language: string
   search: string
   signupMetadata: ProductSignupMetadata
-  unified: boolean
 }
 type StateProps = {
   showForm: boolean

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Signup/types.ts
@@ -8,13 +8,7 @@ export type SignupFormInitValuesType = {
   country?: string
   email?: string
 }
-export type GeoLocationType = {
-  countryCode: string
-  headerBlockchainCFIpCountry: string
-  headerBlockchainGoogleIpCountry: string
-  headerBlockchainGoogleIpRegion: string
-  ip: string
-}
+
 export type SignupFormType = {
   country: string
   email: string

--- a/packages/blockchain-wallet-v4/src/redux/data/coins/selectors.ts
+++ b/packages/blockchain-wallet-v4/src/redux/data/coins/selectors.ts
@@ -60,7 +60,7 @@ export const getAllCoins: () => Array<string> = memoizeWhenCoinsExist(_getAllCoi
 export const getErc20Coins: () => Array<string> = memoizeWhenCoinsExist(_getErc20Coins)
 export const getCoins = _getCoins
 
-export const getIsCoinDataLoaded = (state) => {
+export const getIsCoinDataLoaded = (state: RootState) => {
   return state.dataPath.coins.isCoinDataLoaded
 }
 


### PR DESCRIPTION
There is more work to do, but this is an initial nudge into a cleaner slate
# Changes per file:

#### BuyGoal/index.tsx
- Remove `ramda`
- Use `redux` hooks

#### ProductPicker/index.tsx
- Pass down only necessary props to child components
- Fix return on `NotAsked` cata
- Remove unused `appEnv` and `miscActions` variables

#### ProductPicker/template.error.exchangeMobile.tsx
- Pick only required elements for props

#### components/LoginLink/index.tsx
- Use `redux` hooks to get required state and dispatch, removing the need of props
- Made this a component, as it was being built and exported in the `index.tsx` file

#### components/SignupCard/index.tsx
- Refactor accordingly to new `LoginLink` component

#### components/index.tsx
- Moved `LoginLink` to own file
- Removed exports that were not used

#### index.tsx
- Removed `unified` and `analyticsActions` as they are now imported directly where they are used in `LoginLink`
- Removed `domains`, `signupMetadata`, `alertActions` as they were not used 

#### types.ts
- Removed unused type

#### data/coins/selectors.ts
- Added type so selector can infer return type too



