### PR TITLE
chore(banners): styles only cleanup

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/BSOrderBanner/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/BSOrderBanner/index.tsx
@@ -6,70 +6,16 @@ import { bindActionCreators, Dispatch } from 'redux'
 import styled from 'styled-components'
 
 import { BSOrderType, BSPaymentTypes } from '@core/types'
-import { Button, Icon, Text } from 'blockchain-info-components'
+import { Icon, Text } from 'blockchain-info-components'
 import { actions, selectors } from 'data'
 import { getOrderType } from 'data/components/buySell/model'
 import { RootState } from 'data/rootReducer'
-import { media } from 'services/styles'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 8px;
-  padding: 20px;
+import { BannerButton, Column, Copy, PendingIconWrapper, Wrapper } from '../styles'
 
-  ${media.atLeastLaptop`
-    height: 80px;
-    padding: 0 20px;
-  `}
-  ${media.mobile`
-    padding: 12px;
-    flex-direction: column;
-  `}
-`
 const Row = styled.div`
   display: flex;
   align-items: center;
-`
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  & > div:first-child {
-    margin-bottom: 4px;
-  }
-`
-const PendingIconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px;
-  width: 40px;
-  min-width: 40px;
-  border-radius: 20px;
-  margin-right: 20px;
-  background-color: ${(props) => props.theme.orange000};
-`
-const Copy = styled(Text)`
-  display: flex;
-  align-items: center;
-  ${media.mobile`
-    font-size: 12px;
-  `}
-  ${media.tablet`
-    font-size: 14px;
-  `}
-`
-const BannerButton = styled(Button)`
-  height: 48px;
-  ${media.mobile`
-    font-size: 14px;
-    margin-top: 16px;
-    padding: 10px;
-  `}
 `
 
 class BSOrderBanner extends PureComponent<Props> {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/BuyCrypto/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/BuyCrypto/index.tsx
@@ -8,50 +8,9 @@ import { WalletFiatType } from '@core/types'
 import { Icon, Text } from 'blockchain-info-components'
 import { actions, selectors } from 'data'
 import { RootState } from 'data/rootReducer'
-import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
-import { BannerButton, CloseLink, IconWrapper, Row } from '../styles'
-
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 8px;
-  padding: 20px;
-
-  ${media.atLeastLaptop`
-    height: 80px;
-    padding: 0 20px;
-  `}
-  ${media.mobile`
-    padding: 12px;
-    flex-direction: column;
-  `}
-`
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  & > div:first-child {
-    margin-bottom: 4px;
-  }
-`
-const PendingIconWrapper = styled(IconWrapper)`
-  background-color: ${(props) => props.theme.blue100};
-`
-const Copy = styled(Text)`
-  display: flex;
-  align-items: center;
-  ${media.mobile`
-    font-size: 12px;
-  `}
-  ${media.tablet`
-    font-size: 14px;
-  `}
-`
+import { BannerButton, CloseLink, Column, Copy, Row, SyncIconWrapper, Wrapper } from '../styles'
 
 const BuyCrypto = ({ buySellActions, cacheActions, fiatCurrency }: Props) => {
   const showModal = useCallback(() => {
@@ -66,9 +25,9 @@ const BuyCrypto = ({ buySellActions, cacheActions, fiatCurrency }: Props) => {
   return (
     <Wrapper>
       <Row>
-        <PendingIconWrapper>
+        <SyncIconWrapper>
           <Icon name='plus' color='blue600' size='30px' />
-        </PendingIconWrapper>
+        </SyncIconWrapper>
         <Column>
           <Text size='20px' weight={600} color='grey800'>
             <FormattedMessage

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CoinRename/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CoinRename/index.tsx
@@ -10,24 +10,9 @@ import { actions, selectors } from 'data'
 import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
+import { Wrapper } from '../styles'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  box-sizing: border-box;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 8px;
-  overflow: hidden;
-  padding: 20px;
-
-  ${media.atLeastLaptop`
-    height: 80px;
-    padding: 0 20px;
-  `}
-`
-const NewCoinWrapper = styled.div`
+const CenterWrapper = styled.div`
   display: flex;
   align-items: center;
 `
@@ -48,11 +33,6 @@ const Description = styled(Text)`
   ${media.atLeastMobile`
     display: block;
   `}
-`
-
-const CTAWrapper = styled.div`
-  display: flex;
-  align-items: center;
 `
 
 const CTAButton = styled(Button)`
@@ -78,7 +58,7 @@ const CoinRename = ({ buySellActions, cacheActions, coinRename }: Props) => {
 
   return (
     <Wrapper>
-      <NewCoinWrapper>
+      <CenterWrapper>
         <Icon name={coinRename} size='36px' style={{ marginRight: '16px' }} />
         <div>
           <VerbText>
@@ -92,9 +72,9 @@ const CoinRename = ({ buySellActions, cacheActions, coinRename }: Props) => {
             />
           </Description>
         </div>
-      </NewCoinWrapper>
+      </CenterWrapper>
 
-      <CTAWrapper>
+      <CenterWrapper>
         <CTAButton
           data-e2e='newCoinTradeNowButton'
           nature='primary'
@@ -118,7 +98,7 @@ const CoinRename = ({ buySellActions, cacheActions, coinRename }: Props) => {
         >
           <Icon size='20px' color='grey400' name='close-circle' />
         </CloseLink>
-      </CTAWrapper>
+      </CenterWrapper>
     </Wrapper>
   )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CompleteYourProfile/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CompleteYourProfile/index.tsx
@@ -11,32 +11,13 @@ import { actions, selectors } from 'data'
 import { ModalName } from 'data/modals/types'
 import { RootState } from 'data/rootReducer'
 import { Analytics } from 'data/types'
-import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
-import { BannerButton, CloseLink } from '../styles'
+import { BannerButton, CloseLink, IconWrapper, Wrapper } from '../styles'
 import { getData } from './selectors'
 
 const MAX_STEPS = 3
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 8px;
-  padding: 20px;
-
-  ${media.atLeastLaptop`
-    height: 96px;
-    padding: 0 20px;
-  `}
-  ${media.mobile`
-    padding: 12px;
-    flex-direction: column;
-  `}
-`
 const Row = styled.div`
   display: flex;
   align-items: center;
@@ -49,17 +30,6 @@ const Column = styled.div`
   flex-direction: column;
   align-items: start;
   flex: 1;
-`
-
-const PendingIconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px;
-  width: 40px;
-  min-width: 40px;
-  border-radius: 20px;
-  margin-right: 20px;
 `
 
 const CompleteYourProfile = ({
@@ -94,13 +64,13 @@ const CompleteYourProfile = ({
   return (
     <Wrapper>
       <Row>
-        <PendingIconWrapper>
+        <IconWrapper>
           <CircularProgressBar percentage={percentage} strokeWidth={12}>
             <Text size='16px' color='blue600' weight={600}>
               {`${currentStep}/${MAX_STEPS}`}
             </Text>
           </CircularProgressBar>
-        </PendingIconWrapper>
+        </IconWrapper>
       </Row>
       <CentralRow>
         <Column>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CompleteYourProfile/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/CompleteYourProfile/selectors.ts
@@ -5,6 +5,8 @@ import { model, selectors } from 'data'
 import { RootState } from 'data/rootReducer'
 import { UserDataType } from 'data/types'
 
+const { KYC_STATES } = model.profile
+
 export const getData = (state: RootState): { currentStep: number } => {
   let currentStep = 0
   const isKycStateNone =
@@ -22,7 +24,6 @@ export const getData = (state: RootState): { currentStep: number } => {
     tiers: { current: 0 }
   } as UserDataType)
 
-  const { KYC_STATES } = model.profile
   const isKycVerified = userData.kycState === KYC_STATES.VERIFIED
 
   if (isKycVerified) {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ContinueToGold/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ContinueToGold/index.tsx
@@ -4,69 +4,20 @@ import { connect, ConnectedProps } from 'react-redux'
 import { IconCloseCircleV2, PaletteColors } from '@blockchain-com/constellation'
 import { bindActionCreators } from '@reduxjs/toolkit'
 import { Dispatch } from 'redux'
-import styled from 'styled-components'
 
 import { Image, Text } from 'blockchain-info-components'
 import { actions } from 'data'
-import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
-import { BannerButton, CloseLink, Row } from '../styles'
-
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 8px;
-  padding: 20px;
-
-  ${media.atLeastLaptop`
-    height: 80px;
-    padding: 0 20px;
-  `}
-  ${media.mobile`
-    padding: 12px;
-    flex-direction: column;
-  `}
-`
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  & > div:first-child {
-    margin-bottom: 4px;
-  }
-`
-const PendingIconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px;
-  width: 40px;
-  min-width: 40px;
-  border-radius: 20px;
-  margin-right: 20px;
-`
-const Copy = styled(Text)`
-  display: flex;
-  align-items: center;
-  ${media.mobile`
-    font-size: 12px;
-  `}
-  ${media.tablet`
-    font-size: 14px;
-  `}
-`
+import { BannerButton, CloseLink, Column, Copy, IconWrapper, Row, Wrapper } from '../styles'
 
 const ContinueToGold = ({ cacheActions, verifyIdentity }: Props) => {
   return (
     <Wrapper>
       <Row>
-        <PendingIconWrapper>
+        <IconWrapper>
           <Image name='tier-gold' size='32px' />
-        </PendingIconWrapper>
+        </IconWrapper>
         <Column>
           <Text size='20px' weight={600} color='grey800'>
             <FormattedMessage

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/FinishKyc/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/FinishKyc/index.tsx
@@ -6,60 +6,12 @@ import styled from 'styled-components'
 
 import { Icon, Text } from 'blockchain-info-components'
 import { actions } from 'data'
-import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
-import { BannerButton, CloseLink, Row } from '../styles'
+import { BannerButton, CloseLink, Column, Copy, PendingIconWrapper, Row, Wrapper } from '../styles'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 8px;
-  padding: 20px;
-
-  ${media.atLeastLaptop`
-    height: 80px;
-    padding: 0 20px;
-  `}
-  ${media.mobile`
-    padding: 12px;
-    flex-direction: column;
-  `}
-`
 const StyledRow = styled(Row)`
   margin-right: 12px;
-`
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  & > div:first-child {
-    margin-bottom: 4px;
-  }
-`
-const PendingIconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px;
-  width: 40px;
-  min-width: 40px;
-  border-radius: 20px;
-  margin-right: 20px;
-  background-color: ${(props) => props.theme.orange000};
-`
-const Copy = styled(Text)`
-  display: flex;
-  align-items: center;
-  ${media.mobile`
-    font-size: 12px;
-  `}
-  ${media.tablet`
-    font-size: 14px;
-  `}
 `
 
 const FinishKyc = (props: Props) => {

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/KycResubmit/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/KycResubmit/index.tsx
@@ -25,8 +25,8 @@ const Wrapper = styled.div`
   `}
 `
 
-const Column = styled.div<{ hiddenOnMobile?: boolean }>`
-  display: ${(props) => (props.hiddenOnMobile ? 'none' : 'flex')};
+const Column = styled.div`
+  display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/NewCurrency/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/NewCurrency/index.tsx
@@ -10,27 +10,13 @@ import { actions, selectors } from 'data'
 import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
+import { Wrapper } from '../styles'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  box-sizing: border-box;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 8px;
-  overflow: hidden;
-  padding: 20px;
-
-  ${media.atLeastLaptop`
-    height: 80px;
-    padding: 0 20px;
-  `}
-`
-const NewCoinWrapper = styled.div`
+const CenterWrapper = styled.div`
   display: flex;
   align-items: center;
 `
+
 const VerbText = styled(Text)`
   margin-right: 5px;
   font-weight: 600;
@@ -50,11 +36,6 @@ const Description = styled(Text)`
   `}
 `
 
-const CTAWrapper = styled.div`
-  display: flex;
-  align-items: center;
-`
-
 const CTAButton = styled(Button)`
   margin-right: 12px;
 
@@ -64,6 +45,7 @@ const CTAButton = styled(Button)`
     font-size: 14px;
   }
 `
+
 const CloseLink = styled.div`
   cursor: pointer;
 `
@@ -78,7 +60,7 @@ const NewCurrency = ({ buySellActions, cacheActions, coinListing }: Props) => {
 
   return (
     <Wrapper>
-      <NewCoinWrapper>
+      <CenterWrapper>
         <Icon name={coinListing} size='36px' style={{ marginRight: '16px' }} />
         <div>
           <VerbText>
@@ -93,9 +75,9 @@ const NewCurrency = ({ buySellActions, cacheActions, coinListing }: Props) => {
             />
           </Description>
         </div>
-      </NewCoinWrapper>
+      </CenterWrapper>
 
-      <CTAWrapper>
+      <CenterWrapper>
         <CTAButton
           data-e2e='newCoinTradeNowButton'
           nature='primary'
@@ -119,7 +101,7 @@ const NewCurrency = ({ buySellActions, cacheActions, coinListing }: Props) => {
         >
           <Icon size='20px' color='grey400' name='close-circle' />
         </CloseLink>
-      </CTAWrapper>
+      </CenterWrapper>
     </Wrapper>
   )
 }

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/RecurringBuys/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/RecurringBuys/index.tsx
@@ -12,7 +12,7 @@ import { RecurringBuyOrigins } from 'data/types'
 import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
-import { BannerButton, CloseLink } from '../styles'
+import { BannerButton, CloseLink, Column, Copy, Row, SyncIconWrapper } from '../styles'
 
 const Wrapper = styled.div`
   display: flex;
@@ -34,40 +34,6 @@ const Wrapper = styled.div`
   ${media.mobile`
     padding: 12px;
     flex-direction: column;
-  `}
-`
-const Row = styled.div`
-  display: flex;
-  align-items: center;
-  flex: 1;
-`
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  & > div:first-child {
-    margin-bottom: 4px;
-  }
-`
-const SyncIconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px;
-  width: 40px;
-  min-width: 40px;
-  border-radius: 20px;
-  margin-right: 20px;
-  background-color: ${(props) => props.theme.blue100};
-`
-const Copy = styled(Text)`
-  display: flex;
-  align-items: center;
-  ${media.mobile`
-    font-size: 12px;
-  `}
-  ${media.tablet`
-    font-size: 14px;
   `}
 `
 

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/RewardsBanner/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/RewardsBanner/index.tsx
@@ -5,54 +5,15 @@ import { LinkContainer } from 'react-router-bootstrap'
 import { IconCloseCircleV2, IconPercent, PaletteColors } from '@blockchain-com/constellation'
 import { bindActionCreators } from '@reduxjs/toolkit'
 import { Dispatch } from 'redux'
-import styled from 'styled-components'
 
 import { Text } from 'blockchain-info-components'
 import { actions } from 'data'
 import { Analytics } from 'data/types'
-import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
-import { BannerButton, CloseLink, IconWrapper, Row } from '../styles'
+import { BannerButton, CloseLink, Column, Copy, Row, SyncIconWrapper, Wrapper } from '../styles'
 
 const { BANNER_REWARDS_CLICKED, BANNER_REWARDS_VIEWED } = Analytics
-
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 0.5rem;
-  padding: 1.25rem;
-
-  ${media.atLeastLaptop`
-    height: 5rem;
-    padding: 0 1.25rem;
-  `}
-  ${media.mobile`
-    padding: 0,75rem;
-    flex-direction: column;
-  `}
-`
-
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  & > div:first-child {
-    margin-bottom: 0.25rem;
-  }
-`
-const PendingIconWrapper = styled(IconWrapper)`
-  background-color: ${(props) => props.theme.blue100};
-`
-const Copy = styled(Text)`
-  display: flex;
-  align-items: center;
-  margin-right: 1.25rem;
-  font-size: 0.75rem;
-`
 
 const StartEarningRewards: React.FC<Props> = (props) => {
   const {
@@ -82,9 +43,9 @@ const StartEarningRewards: React.FC<Props> = (props) => {
   return (
     <Wrapper>
       <Row>
-        <PendingIconWrapper>
+        <SyncIconWrapper>
           <IconPercent label='percentage' color={PaletteColors['blue-600']} size='medium' />
-        </PendingIconWrapper>
+        </SyncIconWrapper>
         <Column>
           <Text size='20px' weight={600} color='grey800'>
             <FormattedMessage

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/Sanctions/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/Sanctions/index.tsx
@@ -6,27 +6,9 @@ import styled from 'styled-components'
 
 import { Link, Text } from 'blockchain-info-components'
 import { selectors } from 'data'
-import { media } from 'services/styles'
 
-import { BannerButton } from '../styles'
+import { BannerButton, IconWrapper, Wrapper } from '../styles'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  border: 1px solid ${(props) => props.theme.orange900};
-  border-radius: 8px;
-  padding: 20px;
-  ${media.atLeastLaptop`
-    height: 96px;
-    padding: 0 20px;
-  `}
-  ${media.mobile`
-    padding: 12px;
-    flex-direction: column;
-  `}
-`
 const Row = styled.div`
   display: flex;
   align-items: center;
@@ -41,17 +23,6 @@ const Column = styled.div`
   flex: 1;
 `
 
-const PendingIconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px;
-  width: 40px;
-  min-width: 40px;
-  border-radius: 20px;
-  margin-right: 20px;
-`
-
 const Sanctions = () => {
   const products = useSelector(selectors.custodial.getProductEligibilityForUser).data
   const message = products?.notifications?.length ? products?.notifications[0].message : null
@@ -59,9 +30,9 @@ const Sanctions = () => {
   return (
     <Wrapper>
       <Row>
-        <PendingIconWrapper>
+        <IconWrapper>
           <IconWarningTriangle color={PaletteColors['orange-400']} label='alert' size='large' />
-        </PendingIconWrapper>
+        </IconWrapper>
       </Row>
       <CentralRow>
         <Column>

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ServicePriceUnavailable/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/ServicePriceUnavailable/index.tsx
@@ -10,24 +10,8 @@ import { actions } from 'data'
 import { media } from 'services/styles'
 
 import ANNOUNCEMENTS from '../constants'
-import { CloseLink } from '../styles'
+import { CloseLink, Wrapper } from '../styles'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  box-sizing: border-box;
-  border: 1px solid ${(props) => props.theme.grey000};
-  border-radius: 8px;
-  overflow: hidden;
-  padding: 20px;
-
-  ${media.atLeastLaptop`
-    height: 80px;
-    padding: 0 20px;
-  `}
-`
 const MessageWrapper = styled.div`
   display: flex;
   align-items: center;

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/styles.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Home/Banners/styles.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { Button, Text } from 'blockchain-info-components'
 import { media } from 'services/styles'
@@ -8,63 +8,29 @@ export const Wrapper = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  border: 1px solid ${(props) => props.theme.grey000};
+  border-radius: 8px;
+  padding: 20px;
   box-sizing: border-box;
   overflow: hidden;
-  padding: 20px;
-  border-radius: 8px;
-  border: 1px solid ${(props) => props.theme.grey000};
 
   ${media.atLeastLaptop`
-  height: 56px;
-  padding: 0 20px;
-  align-items: flex-start;
-`}
+    height: 80px;
+    padding: 0 20px;
+  `}
 
   ${media.mobile`
-  flex-direction: column
-`}
+    padding: 12px;
+    flex-direction: column;
+  `}
 `
 
-export const ColumnWrapper = styled.div<{ showSpacing?: boolean }>`
+export const Column = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  height: 100%;
-  ${media.mobile`
-  width: 100%;
-  margin-top: ${(props) => (props.showSpacing ? '24px' : '0')};
-`}
-`
-export const Column = styled.div<{ hideRow?: boolean }>`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: flex-start;
 
-  ${(props) =>
-    !props.hideRow &&
-    css`
-      flex-direction: column;
-    `}
-
-  ${media.mobile`
-  flex-direction: column
-`}
-`
-export const Title = styled(Text)`
-  color: ${(props) => props.theme.grey800};
-  margin-top: 4px;
-  margin-right: 8px;
-`
-export const SubTitle = styled(Text)`
-  margin-top: 6px;
-`
-
-export const CartridgeContainer = styled.div`
-  width: auto;
-  margin-right: 14px;
-  > span {
-    text-transform: uppercase;
+  & > div:first-child {
+    margin-bottom: 0.25rem;
   }
 `
 
@@ -94,6 +60,14 @@ export const IconWrapper = styled.div`
   min-width: 40px;
   border-radius: 20px;
   margin-right: 20px;
+`
+
+export const PendingIconWrapper = styled(IconWrapper)`
+  background-color: ${(props) => props.theme.orange000};
+`
+
+export const SyncIconWrapper = styled(IconWrapper)`
+  background-color: ${(props) => props.theme.blue100};
 `
 
 export const BannerButton = styled(Button)`


### PR DESCRIPTION
A lot of styles were extracted and not reused in the banners. I went through most files and extracted the most used ones - several banners have a `Banner` or `Column` with some different css so those were left untouched.