### PR TITLE
fix(tx-feed): allow for nabu user to be undefined for tx feed

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/selectors.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Transactions/selectors.ts
@@ -111,11 +111,8 @@ const coinSelectorMap = (
 export const getData = (state: RootState, ownProps: OwnProps) => {
   const { computedMatch } = ownProps
   const { coin } = computedMatch.params
-  const {
-    data: {
-      tiers: { current = 0 }
-    }
-  } = selectors.modules.profile.getUserData(state)
+  const userData = selectors.modules.profile.getUserData(state)
+  const current = userData?.data?.tiers?.current || 0
   const isGoldTier = current >= 2
 
   return createSelector(


### PR DESCRIPTION
## Description (optional)
Addresses user issue where wallets without nabu IDs would get an error when trying to view Transaction Feed. Fix allows for user to be undefined. 

https://blockchain.atlassian.net/browse/PO-445

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

