### PR TITLE
fix(finprom): allow flex banner to adjust itself

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/components/Banner/UkBanner/styles.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/components/Banner/UkBanner/styles.ts
@@ -7,7 +7,6 @@ export const LinkContainer = styled(Link)`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
   padding: 4px 16px;
   background: #ffd9d6;
   color: ${({ theme }) => theme.grey900};


### PR DESCRIPTION
It seems layout is slightly different from Dot Com so the 100% width was messing with it.

![Screen Cast 2023-11-27 at 1 54 06 PM](https://github.com/blockchain/blockchain-wallet-v4-frontend/assets/97296851/1e38720c-b4d2-48e9-b9d6-62a845102762)
