### PR TITLE
feat(settings): allow to delete wire banks

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/slice.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/slice.ts
@@ -10,7 +10,7 @@ import {
 } from '@core/types'
 import { PartialClientErrorProperties } from 'data/analytics/types/errors'
 import { ModalNameType } from 'data/modals/types'
-import { BankTransferAccountType } from 'data/types'
+import { BankTransferAccountType, DeleteBankEndpointTypes } from 'data/types'
 
 import {
   AddBankStepType,
@@ -48,7 +48,13 @@ const brokerageSlice = createSlice({
   name: 'brokerage',
   reducers: {
     createFiatDeposit: () => {},
-    deleteSavedBank: (state, action: PayloadAction<BankTransferAccountType['id']>) => {},
+    deleteSavedBank: (
+      state,
+      action: PayloadAction<{
+        bankId: BankTransferAccountType['id']
+        bankType: DeleteBankEndpointTypes
+      }>
+    ) => {},
     fetchBankLinkCredentials: (state, action: PayloadAction<WalletFiatType>) => {},
     fetchBankLinkCredentialsError: (state, action: PayloadAction<string | Error>) => {
       state.bankCredentials = Remote.Failure(action.payload)
@@ -145,6 +151,9 @@ const brokerageSlice = createSlice({
     setReason: (state, action: PayloadAction<PlaidSettlementErrorReasons | undefined>) => {
       state.reason = action.payload
     },
+    setRedirectBackToStep: (state, action: PayloadAction<boolean>) => {
+      state.redirectBackToStep = action.payload ?? false
+    },
     setupBankTransferProvider: () => {},
     showModal: (
       state,
@@ -176,6 +185,7 @@ export const {
   setBankCredentials,
   setBankDetails,
   setDWStep,
+  setRedirectBackToStep,
   showModal
 } = brokerageSlice.actions
 const { actions } = brokerageSlice

--- a/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/data/components/brokerage/types.ts
@@ -295,3 +295,5 @@ export type DepositTerms = {
   settlementType: SettlementType
   withdrawalLockDays: number
 }
+
+export type DeleteBankEndpointTypes = 'banks' | 'banktransfer'

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/index.tsx
@@ -1,19 +1,16 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
 import { compose } from 'redux'
 
 import Flyout, { duration, FlyoutChild } from 'components/Flyout'
-import { selectors } from 'data'
 import { ModalName } from 'data/types'
 import ModalEnhancer from 'providers/ModalEnhancer'
 
 import { ModalPropsType } from '../../../types'
 import Template from './template'
+import { BankDetailsModalProps } from './types'
 
-const BankDetails = (props: ModalPropsType) => {
+const BankDetails = (props: BankDetailsModalProps & ModalPropsType) => {
   const [show, setShow] = useState(false)
-
-  const account = useSelector(selectors.components.brokerage.getAccount)
 
   const handleClose = () => {
     setShow(false)
@@ -26,12 +23,21 @@ const BankDetails = (props: ModalPropsType) => {
     setShow(true)
   }, [])
 
-  if (!account) return null
+  if (!props.accountId) return null
+
+  const { accountId, accountNumber, accountType, bankName, bankType } = props
 
   return (
     <Flyout {...props} onClose={handleClose} isOpen={show} data-e2e='bankDetailsModal'>
       <FlyoutChild>
-        <Template account={account} handleClose={handleClose} />
+        <Template
+          handleClose={handleClose}
+          accountId={accountId}
+          accountType={accountType}
+          bankType={bankType}
+          accountNumber={accountNumber}
+          bankName={bankName}
+        />
       </FlyoutChild>
     </Flyout>
   )

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/template.tsx
@@ -7,9 +7,12 @@ import styled from 'styled-components'
 import { getCurrency } from '@core/redux/settings/selectors'
 import { Button, HeartbeatLoader, Icon, Image, Text } from 'blockchain-info-components'
 import { FlyoutWrapper } from 'components/Flyout'
+import { modals } from 'data/actions'
 import { brokerage } from 'data/components/actions'
-import { BankTransferAccountType, BrokerageModalOriginType } from 'data/types'
+import { ModalName } from 'data/types'
 import { getBankLogoImageName } from 'services/images'
+
+import { BankDetailsModalProps } from './types'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -51,38 +54,35 @@ export const BankDetails = styled.div`
 `
 
 type Props = {
-  account: BankTransferAccountType
   handleClose: () => void
-}
+} & BankDetailsModalProps
 
 const Template: React.FC<InjectedFormProps<{}, Props> & Props> = ({
-  account,
+  accountId,
+  accountNumber,
+  accountType,
+  bankName,
+  bankType,
   handleClose,
   submitting
 }) => {
   const dispatch = useDispatch()
   const walletCurrency = useSelector(getCurrency).getOrElse('USD')
 
-  const { details } = account
-
-  const bankAccountName = details ? (
-    `${details?.bankName || ''} ${details?.accountNumber || ''}`
-  ) : (
-    <FormattedMessage id='copy.bank_account' defaultMessage='Bank Account' />
-  )
-
   const onClick = () => {
+    dispatch(brokerage.setRedirectBackToStep(true))
+
     dispatch(
-      brokerage.showModal({
-        modalType: 'REMOVE_BANK_MODAL',
-        origin: BrokerageModalOriginType.BANK
-      })
-    )
-    dispatch(
-      brokerage.setBankDetails({
-        account,
-        redirectBackToStep: true
-      })
+      modals.showModal(
+        ModalName.REMOVE_BANK_MODAL,
+        { origin: 'BankDetailsModal' },
+        {
+          accountId,
+          accountNumber,
+          bankName,
+          bankType
+        }
+      )
     )
   }
 
@@ -102,16 +102,16 @@ const Template: React.FC<InjectedFormProps<{}, Props> & Props> = ({
         </CloseContainer>
 
         <BankIconWrapper>
-          {details && <Image name={getBankLogoImageName(details.bankName)} />}
+          <Image name={getBankLogoImageName(bankName)} />
         </BankIconWrapper>
         <BankDetails>
-          <Text size='24px' color='grey900' weight={600}>
-            {bankAccountName}
+          <Text size='24px' color='grey900' weight={600} capitalize>
+            {bankName ?? <FormattedMessage id='copy.bank_account' defaultMessage='Bank Account' />}
           </Text>
-          <Text size='24px' color='grey600' weight={500}>
-            {details.bankAccountType?.toLowerCase() || ''}{' '}
+          <Text size='24px' color='grey600' weight={500} capitalize>
+            {accountType.toLowerCase() || ''}{' '}
             <FormattedMessage id='scenes.settings.general.account' defaultMessage='account' />{' '}
-            {account.details?.accountNumber || ''}
+            {accountNumber || ''}
           </Text>
         </BankDetails>
       </FlyoutWrapper>

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/BankDetails/types.ts
@@ -1,0 +1,9 @@
+import { BSPaymentTypes } from '@core/types'
+
+export type BankDetailsModalProps = {
+  accountId: string
+  accountNumber: string
+  accountType: string
+  bankName: string
+  bankType: BSPaymentTypes.BANK_ACCOUNT | BSPaymentTypes.BANK_TRANSFER
+}

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/RemoveBank/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/RemoveBank/index.tsx
@@ -1,19 +1,16 @@
 import React, { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
 import { compose } from 'redux'
 
 import Flyout, { duration, FlyoutChild } from 'components/Flyout'
-import { selectors } from 'data'
 import { ModalName } from 'data/types'
 import ModalEnhancer from 'providers/ModalEnhancer'
 
 import { ModalPropsType } from '../../../types'
 import Template from './template'
+import { RemoveBankModalProps } from './types'
 
-const RemoveBankFlyout = (props: ModalPropsType) => {
+const RemoveBankFlyout = (props: RemoveBankModalProps & ModalPropsType) => {
   const [show, setShow] = useState(false)
-
-  const account = useSelector(selectors.components.brokerage.getAccount)
 
   const handleClose = () => {
     setShow(false)
@@ -26,12 +23,21 @@ const RemoveBankFlyout = (props: ModalPropsType) => {
     setShow(true)
   }, [])
 
-  if (!account) return null
+  if (!props.accountId) return null
+
+  const { accountId, accountNumber, bankName, bankType } = props
+  const entityType = bankType === 'BANK_ACCOUNT' ? 'banks' : 'banktransfer'
 
   return (
     <Flyout {...props} onClose={handleClose} isOpen={show} data-e2e='bankRemoveModal'>
       <FlyoutChild>
-        <Template account={account} handleClose={handleClose} />
+        <Template
+          handleClose={handleClose}
+          accountId={accountId}
+          accountNumber={accountNumber}
+          bankName={bankName}
+          entityType={entityType}
+        />
       </FlyoutChild>
     </Flyout>
   )

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/RemoveBank/template.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/RemoveBank/template.tsx
@@ -9,7 +9,9 @@ import { FlyoutWrapper } from 'components/Flyout'
 import Form from 'components/Form/Form'
 import { getRedirectBackToStep } from 'data/components/brokerage/selectors'
 import { deleteSavedBank } from 'data/components/brokerage/slice'
-import { BankTransferAccountType } from 'data/types'
+import { DeleteBankEndpointTypes } from 'data/types'
+
+import { RemoveBankModalProps } from './types'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -41,12 +43,15 @@ const LeftTopCol = styled.div`
 `
 
 type Props = {
-  account: BankTransferAccountType
+  entityType: DeleteBankEndpointTypes
   handleClose: () => void
-}
+} & Omit<RemoveBankModalProps, 'bankType'>
 
 const Template: React.FC<InjectedFormProps<{}, Props> & Props> = ({
-  account,
+  accountId,
+  accountNumber,
+  bankName,
+  entityType,
   handleClose,
   submitting
 }) => {
@@ -56,12 +61,8 @@ const Template: React.FC<InjectedFormProps<{}, Props> & Props> = ({
 
   const handleSubmit = (e) => {
     e.preventDefault()
-    dispatch(deleteSavedBank(account.id))
+    dispatch(deleteSavedBank({ bankId: accountId, bankType: entityType }))
   }
-
-  const bankAccountName = account?.details
-    ? `${account.details?.bankName} ${account.details?.accountNumber || ''}`
-    : `bank account`
 
   return (
     <Wrapper>
@@ -113,8 +114,8 @@ const Template: React.FC<InjectedFormProps<{}, Props> & Props> = ({
           >
             <FormattedMessage
               id='modals.brokerage.remove_bank.description'
-              defaultMessage="You're about to remove your {bankAccountName}"
-              values={{ bankAccountName }}
+              defaultMessage="You're about to remove your {bankName} account ending in {accountNumber}"
+              values={{ accountNumber, bankName }}
             />
           </Text>
           <Button

--- a/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/RemoveBank/types.ts
+++ b/packages/blockchain-wallet-v4-frontend/src/modals/Brokerage/Banks/RemoveBank/types.ts
@@ -1,0 +1,8 @@
+import { BSPaymentTypes } from '@core/types'
+
+export type RemoveBankModalProps = {
+  accountId: string
+  accountNumber: string
+  bankName: string
+  bankType: BSPaymentTypes.BANK_ACCOUNT | BSPaymentTypes.BANK_TRANSFER
+}

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/index.tsx
@@ -22,7 +22,7 @@ const LinkedBanks = () => {
 
   if (isLoading || isNotAsked) return <Loading />
   if (hasError || !data) return null
-  return <Success {...data} />
+  return <Success bankAccounts={data.bankAccounts} paymentMethods={data.paymentMethods} />
 }
 
 export default LinkedBanks

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedBanks/template.success.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { useDispatch } from 'react-redux'
 import { IconBank, PaletteColors } from '@blockchain-com/constellation'
-import { InjectedFormProps, reduxForm } from 'redux-form'
 import styled from 'styled-components'
 
 import { fiatToString } from '@core/exchange/utils'
@@ -12,13 +11,14 @@ import { Box, Button, Image, Text } from 'blockchain-info-components'
 import { Expanded, Flex } from 'components/Flex'
 import { StandardRow } from 'components/Rows'
 import { SettingComponent, SettingContainer, SettingSummary } from 'components/Setting'
+import { modals } from 'data/actions'
 import { brokerage } from 'data/components/actions'
 import { convertBaseToStandard } from 'data/components/exchange/services'
-import { BankTransferAccountType, BrokerageModalOriginType } from 'data/types'
+import { BankTransferAccountType, BrokerageModalOriginType, ModalName } from 'data/types'
 import { getBankLogoImageName } from 'services/images'
 import { media } from 'services/styles'
 
-import { CustomSettingHeader, RemoveButton } from '../styles'
+import { CustomSettingHeader } from '../styles'
 
 const CustomSettingComponent = styled(SettingComponent)`
   margin-top: 36px;
@@ -31,11 +31,7 @@ const StyledSettingsContainer = styled(SettingContainer)`
   border-bottom: none;
 `
 
-const Success: React.FC<InjectedFormProps<{}, Props> & Props> = ({
-  bankAccounts,
-  paymentMethods,
-  submitting
-}) => {
+const Success: React.FC<Props> = ({ bankAccounts, paymentMethods }) => {
   const dispatch = useDispatch()
 
   const handleBankClick = () => {
@@ -49,22 +45,20 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = ({
 
   const handleShowBankClick = (account: BankTransferAccountType) => {
     dispatch(
-      brokerage.showModal({
-        modalType: 'BANK_DETAILS_MODAL',
-        origin: BrokerageModalOriginType.BANK
-      })
+      modals.showModal(
+        ModalName.BANK_DETAILS_MODAL,
+        {
+          origin: 'SettingsGeneral'
+        },
+        {
+          accountId: account.id,
+          accountNumber: account.details.accountNumber,
+          accountType: account.details.bankAccountType,
+          bankName: account.details.bankName,
+          bankType: BSPaymentTypes.BANK_TRANSFER
+        }
+      )
     )
-    dispatch(brokerage.setBankDetails({ account }))
-  }
-
-  const handleDeleteBank = (account: BankTransferAccountType) => {
-    dispatch(
-      brokerage.showModal({
-        modalType: 'REMOVE_BANK_MODAL',
-        origin: BrokerageModalOriginType.BANK
-      })
-    )
-    dispatch(brokerage.setBankDetails({ account }))
   }
 
   const bankLimit = paymentMethods?.methods.find(
@@ -161,22 +155,6 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = ({
                       </Flex>
                     </Flex>
                   </Expanded>
-
-                  <Flex alignItems='center'>
-                    <RemoveButton
-                      data-e2e={`removeBankAccount-${account.id}`}
-                      nature='light-red'
-                      disabled={submitting}
-                      style={{ minWidth: 'auto' }}
-                      // @ts-ignore
-                      onClick={(e: SyntheticEvent) => {
-                        e.stopPropagation()
-                        handleDeleteBank(account)
-                      }}
-                    >
-                      <FormattedMessage id='buttons.remove' defaultMessage='Remove' />
-                    </RemoveButton>
-                  </Flex>
                 </Flex>
               </Box>
             )
@@ -199,4 +177,4 @@ type Props = {
   paymentMethods: BSPaymentMethodsType
 }
 
-export default reduxForm<{}, Props>({ form: 'linkedBanks' })(Success)
+export default Success

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedWireBanks/template.success.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/LinkedWireBanks/template.success.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import { useDispatch } from 'react-redux'
 import { InjectedFormProps, reduxForm } from 'redux-form'
 import styled from 'styled-components'
 
 import { fiatToString } from '@core/exchange/utils'
 import {
   BeneficiariesType,
+  BeneficiaryType,
   BSPaymentMethodsType,
   BSPaymentMethodType,
   BSPaymentTypes,
@@ -14,8 +16,9 @@ import {
 } from '@core/types'
 import { Box, Image, Text } from 'blockchain-info-components'
 import { SettingContainer, SettingSummary } from 'components/Setting'
+import { modals } from 'data/actions'
 import { convertBaseToStandard } from 'data/components/exchange/services'
-import { BankTransferAccountType } from 'data/types'
+import { ModalName } from 'data/types'
 import { getBankLogoImageName } from 'services/images'
 import { media } from 'services/styles'
 
@@ -50,9 +53,28 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = ({
   beneficiaries,
   paymentMethods
 }) => {
+  const dispatch = useDispatch()
+
   const walletBeneficiaries = beneficiaries.filter(
     (beneficiary) => beneficiary.currency in WalletFiatEnum
   )
+
+  const onBankClick = (beneficiary: BeneficiaryType) => {
+    dispatch(
+      modals.showModal(
+        ModalName.BANK_DETAILS_MODAL,
+        {
+          origin: 'SettingsGeneral'
+        },
+        {
+          accountId: beneficiary.id,
+          accountNumber: beneficiary.address,
+          accountType: 'Wire',
+          bankType: BSPaymentTypes.BANK_ACCOUNT
+        }
+      )
+    )
+  }
 
   if (!walletBeneficiaries.length) return <SettingContainer />
 
@@ -66,7 +88,12 @@ const Success: React.FC<InjectedFormProps<{}, Props> & Props> = ({
               beneficiary.currency as WalletFiatType
             )
             return (
-              <Box style={{ width: '430px' }} isMobile={media.mobile} key={beneficiary.id}>
+              <Box
+                style={{ width: '430px' }}
+                isMobile={media.mobile}
+                key={beneficiary.id}
+                onClick={() => onBankClick(beneficiary)}
+              >
                 <Child>
                   <BankIconWrapper>
                     <Image name={getBankLogoImageName(beneficiary.agent)} />

--- a/packages/blockchain-wallet-v4/src/network/api/buySell/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/buySell/index.ts
@@ -242,7 +242,7 @@ export default ({ authorizedDelete, authorizedGet, authorizedPost, authorizedPut
   // TODO: move this BROKERAGE component
   const deleteSavedAccount = (
     accountId: BSCardType['id'] | BankTransferAccountType['id'],
-    accountType: 'cards' | 'banktransfer'
+    accountType: 'cards' | 'banktransfer' | 'banks'
   ): BSCardType | BankTransferAccountType =>
     authorizedDelete({
       endPoint: `/payments/${accountType}/${accountId}`,


### PR DESCRIPTION
Passing info directly to each modal. Alternative was to create an almost exact flow just for wire banks.
I will be cleaning up some duplication in the next PR