### PR TITLE
chore(settigs): do not rerender if pairing flag does not change

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/PairingCode/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/PairingCode/index.tsx
@@ -27,11 +27,7 @@ const PairingCode = () => {
   const dispatch = useDispatch()
 
   const onShowCode = () => {
-    dispatch(
-      modals.showModal(ModalName.PAIRING_CODE_MODAL, {
-        origin: 'SettingsPage'
-      })
-    )
+    dispatch(modals.showModal(ModalName.PAIRING_CODE_MODAL, { origin: 'SettingsPage' }))
   }
 
   return (

--- a/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/index.tsx
+++ b/packages/blockchain-wallet-v4-frontend/src/scenes/Settings/General/index.tsx
@@ -3,9 +3,9 @@ import { FormattedMessage } from 'react-intl'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
 
+import { getPairingCodeFlag } from '@core/redux/walletOptions/selectors'
 import { Text } from 'blockchain-info-components'
 import MenuHeader from 'components/MenuHeader'
-import { selectors } from 'data'
 
 import About from './About'
 import LinkedBanks from './LinkedBanks'
@@ -22,9 +22,10 @@ const Title = styled(Text)`
 `
 
 const General = () => {
-  const showPairingCode = useSelector(selectors.core.walletOptions.getPairingCodeFlag).getOrElse(
-    false
-  )
+  const showPairingCode = useSelector(
+    getPairingCodeFlag,
+    (prev, next) => prev.data === next.data
+  ).getOrElse(false)
 
   return (
     <section>


### PR DESCRIPTION
The remote check for a feature flag was making the entire sub-tree to re-render, when the result is always `true`. (A boolean, could change to false, but we can check if the value is the same in the hook)

### Before
![Screen Cast 2024-02-06 at 2 25 51 PM](https://github.com/blockchain/blockchain-wallet-v4-frontend/assets/97296851/af6010e2-78d8-46ed-893b-e40b5d756f0b)

![image](https://github.com/blockchain/blockchain-wallet-v4-frontend/assets/97296851/9dc31bf5-97d2-4e5f-b595-271f8226ed37)


### After
![Screen Cast 2024-02-06 at 2 13 50 PM](https://github.com/blockchain/blockchain-wallet-v4-frontend/assets/97296851/2c244652-f3a2-4386-a6e6-da3f4f65df05)

![image](https://github.com/blockchain/blockchain-wallet-v4-frontend/assets/97296851/4d17fac6-a72b-41b4-834e-bfb2f1e21172)

