### PR TITLE
feat(replace-mempool-fees): replace mempool/fees endpoint

### DIFF
--- a/packages/blockchain-wallet-v4/src/network/api/bch/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/bch/index.ts
@@ -71,9 +71,17 @@ export default ({ apiUrl, get, post }) => {
 
   const getBchFees = () =>
     get({
-      endPoint: '/mempool/fees/bch',
+      endPoint: '/currency/btc/fees/btc?network=BCH',
+      ignoreQueryParams: true,
       url: apiUrl
-    })
+    }).then((response) => ({
+      limits: {
+        max: parseInt(response.LIMITS.max, 10),
+        min: parseInt(response.LIMITS.min, 10)
+      },
+      priority: parseInt(response.HIGH, 10),
+      regular: parseInt(response.NORMAL, 10)
+    }))
 
   return {
     fetchBchData,

--- a/packages/blockchain-wallet-v4/src/network/api/btc/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/btc/index.ts
@@ -15,9 +15,17 @@ export default ({ apiUrl, get, post, rootUrl }) => {
 
   const getBtcFees = () =>
     get({
-      endPoint: '/mempool/fees',
+      endPoint: '/currency/btc/fees/btc?network=BTC',
+      ignoreQueryParams: true,
       url: apiUrl
-    })
+    }).then((response) => ({
+      limits: {
+        max: parseInt(response.LIMITS.max, 10),
+        min: parseInt(response.LIMITS.min, 10)
+      },
+      priority: parseInt(response.HIGH, 10),
+      regular: parseInt(response.NORMAL, 10)
+    }))
 
   const pushBtcTx = (txHex) =>
     post({

--- a/packages/blockchain-wallet-v4/src/network/api/eth/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/eth/index.ts
@@ -32,12 +32,21 @@ export default ({ apiUrl, get, openSeaApi, post }) => {
 
   // https://docs.ethers.io/v5/api/providers/provider/#Provider-getGasPrice
   const getEthFees = (contractAddress) => {
-    const baseUrl = '/mempool/fees/eth'
+    const baseUrl = '/currency/evm/fees/ETH'
     return get({
-      endPoint: contractAddress ? `${baseUrl}?contractAddress=${contractAddress}` : baseUrl,
+      endPoint: contractAddress ? `${baseUrl}?identifier=${contractAddress}` : baseUrl,
       ignoreQueryParams: true,
       url: apiUrl
-    })
+    }).then((response) => ({
+      gasLimit: parseInt(response.gasLimit, 10),
+      gasLimitContract: parseInt(response.gasLimitContract, 10),
+      limits: {
+        max: Math.round(parseInt(response.LIMITS.max, 10) / 1e9),
+        min: Math.round(parseInt(response.LIMITS.min, 10) / 1e9)
+      },
+      priority: Math.round(parseInt(response.NORMAL, 10) / 1e9),
+      regular: Math.round(parseInt(response.LOW, 10) / 1e9)
+    }))
   }
 
   // https://docs.ethers.io/v5/api/providers/provider/#Provider-sendTransaction

--- a/packages/blockchain-wallet-v4/src/network/api/xlm/index.ts
+++ b/packages/blockchain-wallet-v4/src/network/api/xlm/index.ts
@@ -16,9 +16,17 @@ export default ({ apiUrl, get, horizonUrl }) => {
 
   const getXlmFees = () =>
     get({
-      endPoint: '/mempool/fees/xlm',
+      endPoint: '/currency/xlm/fees/xlm',
+      ignoreQueryParams: true,
       url: apiUrl
-    })
+    }).then((response) => ({
+      limits: {
+        max: parseInt(response.LIMITS.max, 10),
+        min: parseInt(response.LIMITS.min, 10)
+      },
+      priority: parseInt(response.HIGH, 10),
+      regular: parseInt(response.NORMAL, 10)
+    }))
 
   const pushXlmTx = (tx) => server.submitTransaction(tx)
 


### PR DESCRIPTION
## Description (optional)
Replaced the /mempool/fees endpoint, which will be deprecated, for the coin-apis endpoints

## Testing Steps (optional)
Locally, ensure you can enter the send flows for all the coins. You do not have to to an actual send.

