### PR TITLE
feat/remove-legacy-pages-routing: removed routing for legacy pages

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/webpack.config.ci.js
+++ b/packages/blockchain-wallet-v4-frontend/webpack.config.ci.js
@@ -9,11 +9,11 @@ const runBundleAnalyzer = process.env.ANALYZE
 let extraPluginsList = [
   new CopyWebpackPlugin({
     patterns: [
-      {
-        force: true,
-        from: CONFIG_PATH.legacyPages,
-        to: CONFIG_PATH.ciBuild + '/legacy-pages'
-      },
+      // {
+      //   force: true,
+      //   from: CONFIG_PATH.legacyPages,
+      //   to: CONFIG_PATH.ciBuild + '/legacy-pages'
+      // },
       {
         force: true,
         from: CONFIG_PATH.wellKnownConfig,


### PR DESCRIPTION
Will redirect to v5 now.