### PR TITLE
Checking issue with the build path

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "storybook:build-base": "yarn workspace blockchain-info-components storybook:build",
     "storybook:serve-wallet": "start-storybook -p 6006",
     "storybook:serve-base": "yarn workspace blockchain-info-components storybook:serve",
-    "storybook:deploy-wallet": "yarn storybook:build-wallet && yarn deploy-storybook --existing-output-dir=./storybook-static",
+    "storybook:deploy-wallet": "yarn storybook:build-wallet && yarn deploy-storybook --existing-output-dir=../storybook-static/",
     "storybook:deploy-base": "yarn workspace blockchain-info-components storybook:build && yarn workspace blockchain-info-components storybook:deploy",
     "test": "cross-env yarn wsrun --serial test:build && yarn wsrun --serial test",
     "test:components": "yarn workspace blockchain-info-components test",


### PR DESCRIPTION
Hi, while using the project locally, I'm getting an error that the "./storybook-static" doesn't exist. This is a test to check if the full path works instead.

## Description (optional)
Add a concise explanation of the changes.

## Testing Steps (optional)
Detail the steps required for the reviewer(s) to verify and test these changes.

