### PR TITLE
fix/frontend-webpackBuilder: fixed storage of sensitive information in build artifact

### DIFF
--- a/packages/blockchain-wallet-v4-frontend/webpackBuilder.js
+++ b/packages/blockchain-wallet-v4-frontend/webpackBuilder.js
@@ -127,21 +127,11 @@ const buildWebpackConfig = (envConfig, extraPluginsList) => ({
   plugins: concat(
     [
       new webpack.DefinePlugin({
-        'process.env.FIREBASE_API_KEY': JSON.stringify(
-          process.env.FIREBASE_API_KEY || envConfig.FIREBASE_API_KEY
-        ),
-        'process.env.FIREBASE_APP_ID': JSON.stringify(
-          process.env.FIREBASE_APP_ID || envConfig.FIREBASE_APP_ID
-        ),
-        'process.env.FIREBASE_MEASUREMENT_ID': JSON.stringify(
-          process.env.FIREBASE_MEASUREMENT_ID || envConfig.FIREBASE_MEASUREMENT_ID
-        ),
-        'process.env.FIREBASE_MESSAGING_SENDER_ID': JSON.stringify(
-          process.env.FIREBASE_MESSAGING_SENDER_ID || envConfig.FIREBASE_MESSAGING_SENDER_ID
-        ),
-        'process.env.FIREBASE_PROJECT_ID': JSON.stringify(
-          process.env.FIREBASE_PROJECT_ID || envConfig.FIREBASE_PROJECT_ID
-        )
+        'process.env.FIREBASE_API_KEY': JSON.stringify(envConfig.FIREBASE_API_KEY),
+        'process.env.FIREBASE_APP_ID': JSON.stringify(envConfig.FIREBASE_APP_ID),
+        'process.env.FIREBASE_MEASUREMENT_ID': JSON.stringify(envConfig.FIREBASE_MEASUREMENT_ID),
+        'process.env.FIREBASE_MESSAGING_SENDER_ID': JSON.stringify(envConfig.FIREBASE_MESSAGING_SENDER_ID),
+        'process.env.FIREBASE_PROJECT_ID': JSON.stringify(envConfig.FIREBASE_PROJECT_ID)
       }),
       new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({


### PR DESCRIPTION

fix the problem, only inject environment variables into the build artifact that are explicitly intended to be public. Instead of passing all values from `process.env`, use a whitelist approach: define a set of public environment variables (e.g., in a config file or as a constant in the build script) and only inject those. For the Firebase configuration, ensure that only non-sensitive values are exposed, or document clearly which values are safe. The best fix is to replace the direct use of `process.env.FIREBASE_API_KEY` (and similar) with values from a safe, public configuration source, such as `envConfig`, which should be populated only with non-sensitive values intended for client-side use.

**Required changes:**  
- In `packages/blockchain-wallet-v4-frontend/webpackBuilder.js`, update the `webpack.DefinePlugin` configuration to use only values from `envConfig`, not from `process.env`.
- Remove the fallback to `process.env` for each Firebase variable.
- Optionally, document that `envConfig` must only contain public, non-sensitive values.


#### References
[webpack DefinePlugin API](https://webpack.js.org/plugins/define-plugin/)